### PR TITLE
Use clippy

### DIFF
--- a/client/consensus/qpow/src/chain_management.rs
+++ b/client/consensus/qpow/src/chain_management.rs
@@ -149,7 +149,7 @@ where
         let current_hash = chain_head.hash();
         let current_number = *chain_head.number();
 
-        let total_work = self.client.runtime_api().get_total_work(current_hash.clone())
+        let total_work = self.client.runtime_api().get_total_work(current_hash)
             .map_err(|e| {
                 log::error!("Failed to get total work for chain with head #{}: {:?}", current_number, e);
                 sp_consensus::Error::Other(format!("Failed to get total difficulty {:?}", e).into())
@@ -280,7 +280,7 @@ where
                 reorg_depth
             );
 
-            current_best_hash = self.client.header(current_best_hash)
+            current_best_hash = *self.client.header(current_best_hash)
                 .map_err(|e| {
                     log::error!("Blockchain error when getting header for #{}: {:?}", current_height, e);
                     sp_consensus::Error::Other(format!("Blockchain error: {:?}", e).into())
@@ -289,7 +289,7 @@ where
                     log::error!("Missing header at #{} ({:?})", current_height, current_best_hash);
                     sp_consensus::Error::Other("Missing header".into())
                 })?
-                .parent_hash().clone();
+                .parent_hash();
 
             current_height -= One::one();
             reorg_depth += 1;
@@ -314,7 +314,7 @@ where
                 competing_hash
             );
 
-            competing_hash = self.client.header(competing_hash)
+            competing_hash = *self.client.header(competing_hash)
                 .map_err(|e| {
                     log::error!("Blockchain error when getting header for competing chain #{}: {:?}",
                         competing_height, e);
@@ -325,7 +325,7 @@ where
                         competing_height, competing_hash);
                     sp_consensus::Error::Other("Missing header".into())
                 })?
-                .parent_hash().clone();
+                .parent_hash();
 
             competing_height -= One::one();
 
@@ -355,7 +355,7 @@ where
             );
 
             // Move down one block in the current best chain
-            current_best_hash = self.client.header(current_best_hash)
+            current_best_hash = *self.client.header(current_best_hash)
                 .map_err(|e| {
                     log::error!("Blockchain error when getting parent at #{}: {:?}", current_height, e);
                     sp_consensus::Error::Other(format!("Blockchain error: {:?}", e).into())
@@ -364,10 +364,10 @@ where
                     log::error!("Missing header for parent at #{} ({:?})", current_height, current_best_hash);
                     sp_consensus::Error::Other("Missing header".into())
                 })?
-                .parent_hash().clone();
+                .parent_hash();
 
             // Move down one block in the competing chain
-            competing_hash = self.client.header(competing_hash)
+            competing_hash = *self.client.header(competing_hash)
                 .map_err(|e| {
                     log::error!("Blockchain error when getting parent for competing chain at #{}: {:?}",
                         current_height, e);
@@ -378,7 +378,7 @@ where
                         current_height, competing_hash);
                     sp_consensus::Error::Other("Missing header".into())
                 })?
-                .parent_hash().clone();
+                .parent_hash();
 
             // Both chains are now one block lower
             current_height -= One::one();

--- a/dilithium-crypto/hdwallet/src/lib.rs
+++ b/dilithium-crypto/hdwallet/src/lib.rs
@@ -11,8 +11,8 @@ pub fn generate(entropy: Option<&[u8]>) -> Result<Keypair, &'static str> {
 
 pub fn create_keypair(public_key: &[u8], secret_key: &[u8]) -> Result<Keypair, &'static str> {
     let keypair = Keypair {
-        secret: SecretKey::from_bytes(&secret_key),
-        public: PublicKey::from_bytes(&public_key)
+        secret: SecretKey::from_bytes(secret_key),
+        public: PublicKey::from_bytes(public_key)
     };
     Ok(keypair)
 }

--- a/dilithium-crypto/src/pair.rs
+++ b/dilithium-crypto/src/pair.rs
@@ -43,7 +43,7 @@ impl Pair for ResonancePair {
     }
 
     fn from_seed_slice(seed: &[u8]) -> Result<Self, SecretStringError> {
-        Ok(ResonancePair::from_seed(seed).map_err(|_| SecretStringError::InvalidSeed)?)
+        ResonancePair::from_seed(seed).map_err(|_| SecretStringError::InvalidSeed)
     }
 
     #[cfg(any(feature = "default", feature = "full_crypto"))]
@@ -59,9 +59,9 @@ impl Pair for ResonancePair {
             .expect("Signing should succeed");
 
         let signature = ResonanceSignature::try_from(signature.as_ref()).expect("Wrap doesn't fail");
-        let sig_with_public = ResonanceSignatureWithPublic::new(signature, self.public());
+        
 
-        sig_with_public
+        ResonanceSignatureWithPublic::new(signature, self.public())
     }
 
     fn verify<M: AsRef<[u8]>>(sig: &ResonanceSignatureWithPublic, message: M, pubkey: &ResonancePublic) -> bool {
@@ -156,7 +156,7 @@ mod tests {
         if let Some(byte) = signature_bytes.get_mut(0) {
             *byte ^= 1;
         }
-        let false_signature = ResonanceSignatureWithPublic::from_slice(&signature_bytes).expect("Failed to create signature");
+        let false_signature = ResonanceSignatureWithPublic::from_slice(signature_bytes).expect("Failed to create signature");
         let public = pair.public();
         
         assert!(

--- a/dilithium-crypto/src/traits.rs
+++ b/dilithium-crypto/src/traits.rs
@@ -176,8 +176,7 @@ impl Verify for ResonanceSignatureScheme {
 
             Self::Ecdsa(sig) => {
                 let m = sp_io::hashing::blake2_256(msg.get());
-                sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m)
-                    .map_or(false, |pubkey| sp_io::hashing::blake2_256(&pubkey) == <AccountId32 as AsRef<[u8]>>::as_ref(signer))
+                sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m).is_ok_and(|pubkey| sp_io::hashing::blake2_256(&pubkey) == <AccountId32 as AsRef<[u8]>>::as_ref(signer))
             },
             Self::Resonance(sig_public) => {
                 let account = sig_public.public().clone().into_account();
@@ -220,13 +219,13 @@ impl IdentifyAccount for ResonanceSigner {
 
 impl From<ResonancePublic> for AccountId32 {
     fn from(public: ResonancePublic) -> Self {
-        return public.into_account();
+        public.into_account()
     }
 }
 
 impl ResonancePair {
     pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
-        let keypair = hdwallet::generate(Some(&seed)).map_err(|_| Error::KeyGenerationFailed)?;
+        let keypair = hdwallet::generate(Some(seed)).map_err(|_| Error::KeyGenerationFailed)?;
         Ok(ResonancePair {
             secret: keypair.secret.to_bytes(),
             public: keypair.public.to_bytes()

--- a/dilithium-crypto/src/types.rs
+++ b/dilithium-crypto/src/types.rs
@@ -33,7 +33,7 @@ pub struct ResonancePair {
 impl Default for ResonancePair {
     fn default() -> Self {
         let seed = sp_std::vec![0u8; 32];
-        return ResonancePair::from_seed(&seed).expect("Failed to generate keypair");
+        ResonancePair::from_seed(&seed).expect("Failed to generate keypair")
     }
 }
 

--- a/external-miner/src/lib.rs
+++ b/external-miner/src/lib.rs
@@ -59,6 +59,12 @@ impl MiningJob {
     }
 }
 
+impl Default for MiningState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MiningState {
     pub fn new() -> Self {
         MiningState {
@@ -100,7 +106,7 @@ impl MiningState {
                         // Increment nonce first for the next potential check
                         // (unless it's the very first hash attempt)
                         if job.hash_count > 0 {
-                            job.current_nonce = job.current_nonce + U512::one();
+                            job.current_nonce += U512::one();
                         }
 
                         // Check if the *new* current_nonce has exceeded the range *before* hashing

--- a/external-miner/src/main.rs
+++ b/external-miner/src/main.rs
@@ -3,7 +3,6 @@ use log::info;
 use external_miner::*; // Import everything from lib.rs
 use std::net::SocketAddr;
 use clap::Parser;
-use env_logger;
 
 /// Resonance External Miner Service
 #[derive(Parser, Debug)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -102,7 +102,7 @@ pub fn run() -> sc_cli::Result<()> {
 							rng.fill(&mut random_seed);
 
 							println!("No seed provided. Using random seed:");
-							println!("Seed: {}", hex::encode(&random_seed));
+							println!("Seed: {}", hex::encode(random_seed));
 
 							random_seed
 						}
@@ -134,7 +134,7 @@ pub fn run() -> sc_cli::Result<()> {
 				},
 				_ => {
 					println!("Error: The scheme parameter is required");
-					return Err("Invalid address scheme".into());
+					Err("Invalid address scheme".into())
 				}
 			}
 

--- a/node/src/external_miner_client.rs
+++ b/node/src/external_miner_client.rs
@@ -4,7 +4,6 @@ use reqwest::Client;
 use primitive_types::{H256, U512};
 use resonance_miner_api::{MiningRequest, MiningResponse, MiningResult, ApiResponseStatus};
 use sc_consensus_qpow::QPoWSeal; // Assuming QPoWSeal is here
-use hex;
 
 // Make functions pub(crate) or pub as needed
 pub(crate) async fn submit_mining_job(

--- a/node/src/faucet.rs
+++ b/node/src/faucet.rs
@@ -49,9 +49,7 @@ impl<C, P> Faucet<C, P> {
     }
 
     fn parse_address(address: String) -> Result<AccountId, jsonrpsee::types::error::ErrorObject<'static>> {
-        if address.starts_with("0x") {
-            // Format hex
-            let hex_str = &address[2..];
+        if let Some(hex_str) = address.strip_prefix("0x") {
             match hex::decode(hex_str) {
                 Ok(bytes) => {
                     if bytes.len() != 32 {

--- a/node/src/prometheus.rs
+++ b/node/src/prometheus.rs
@@ -123,7 +123,7 @@ impl ResonanceBusinessMetrics {
         // Get or create the gauge vector from the registry
         let prometheus_gauge_vec = prometheus_registry
             .as_ref()
-            .map(|registry| Self::register_gauge_vec(registry));
+            .map(Self::register_gauge_vec);
 
         // Spawn the monitoring task
         task_manager.spawn_essential_handle().spawn(

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -416,7 +416,7 @@ pub fn new_full<
                                             nonce = U512::zero();
                                         } else {
                                             log::warn!("Failed to submit mined block from external miner");
-                                            nonce = nonce + U512::one();
+                                            nonce += U512::one();
                                         }
                                     } else {
                                         log::info!("Work from external miner is stale, discarding.");

--- a/pallets/balances/src/benchmarking.rs
+++ b/pallets/balances/src/benchmarking.rs
@@ -261,7 +261,6 @@ mod benchmarks {
 	fn upgrade_accounts(u: Linear<1, 1_000>) {
 		let caller: T::AccountId = whitelisted_caller();
 		let who = (0..u)
-			.into_iter()
 			.map(|i| -> T::AccountId {
 				let user = account("old_user", i, SEED);
 				let account = AccountData {

--- a/pallets/balances/src/impl_currency.rs
+++ b/pallets/balances/src/impl_currency.rs
@@ -35,6 +35,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use imbalances::{NegativeImbalance, PositiveImbalance};
 use sp_runtime::traits::Bounded;
+use core::cmp::Ordering;
 
 // wrapping these imbalances in a private module is necessary to ensure absolute privacy
 // of the inner member.
@@ -120,12 +121,10 @@ mod imbalances {
 			let (a, b) = (self.0, other.0);
 			mem::forget((self, other));
 
-			if a > b {
-				SameOrOther::Same(Self(a - b))
-			} else if b > a {
-				SameOrOther::Other(NegativeImbalance::new(b - a))
-			} else {
-				SameOrOther::None
+			match a.cmp(&b) {
+				Ordering::Greater => SameOrOther::Same(Self(a - b)),
+				Ordering::Less => SameOrOther::Other(NegativeImbalance::new(b - a)),
+				Ordering::Equal => SameOrOther::None,
 			}
 		}
 		fn peek(&self) -> T::Balance {
@@ -190,12 +189,10 @@ mod imbalances {
 			let (a, b) = (self.0, other.0);
 			mem::forget((self, other));
 
-			if a > b {
-				SameOrOther::Same(Self(a - b))
-			} else if b > a {
-				SameOrOther::Other(PositiveImbalance::new(b - a))
-			} else {
-				SameOrOther::None
+			match a.cmp(&b) {
+				Ordering::Greater => SameOrOther::Same(Self(a - b)),
+				Ordering::Less => SameOrOther::Other(PositiveImbalance::new(b - a)),
+				Ordering::Equal => SameOrOther::None,
 			}
 		}
 		fn peek(&self) -> T::Balance {

--- a/pallets/balances/src/impl_fungible.rs
+++ b/pallets/balances/src/impl_fungible.rs
@@ -264,13 +264,11 @@ impl<T: Config<I>, I: 'static> fungible::UnbalancedHold<T::AccountId> for Pallet
 			increase = amount > item.amount;
 			item.amount = amount;
 			holds.retain(|x| !x.amount.is_zero());
-		} else {
-			if !amount.is_zero() {
-				holds
-					.try_push(IdAmount { id: *reason, amount })
-					.map_err(|_| Error::<T, I>::TooManyHolds)?;
-			}
-		}
+		} else if !amount.is_zero() {
+  				holds
+  					.try_push(IdAmount { id: *reason, amount })
+  					.map_err(|_| Error::<T, I>::TooManyHolds)?;
+  			}
 
 		new_account.reserved = if increase {
 			new_account.reserved.checked_add(&delta).ok_or(ArithmeticError::Overflow)?

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -934,7 +934,7 @@ pub mod pallet {
 				Ok(())
 			});
 			Self::deposit_event(Event::Upgraded { who: who.clone() });
-			return true
+			true
 		}
 
 		/// Get the free balance of an account.
@@ -1098,7 +1098,7 @@ pub mod pallet {
 							let _ = frame_system::Pallet::<T>::inc_consumers(who).defensive();
 						}
 						if !did_consume && does_consume {
-							let _ = frame_system::Pallet::<T>::dec_consumers(who);
+							frame_system::Pallet::<T>::dec_consumers(who);
 						}
 					})?;
 				}

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -1230,11 +1230,11 @@ pub mod pallet {
 			match prev_frozen.cmp(&after_frozen) {
 				cmp::Ordering::Greater => {
 					let amount = prev_frozen.saturating_sub(after_frozen);
-					Self::deposit_event(Event::Unlocked { who: who.clone(), amount });
+					Self::deposit_event(Event::Thawed { who: who.clone(), amount });
 				},
 				cmp::Ordering::Less => {
 					let amount = after_frozen.saturating_sub(prev_frozen);
-					Self::deposit_event(Event::Locked { who: who.clone(), amount });
+					Self::deposit_event(Event::Frozen { who: who.clone(), amount });
 				},
 				cmp::Ordering::Equal => {},
 			}

--- a/pallets/balances/src/migration.rs
+++ b/pallets/balances/src/migration.rs
@@ -27,7 +27,7 @@ fn migrate_v0_to_v1<T: Config<I>, I: 'static>(accounts: &[T::AccountId]) -> Weig
 	if on_chain_version == 0 {
 		let total = accounts
 			.iter()
-			.map(|a| Pallet::<T, I>::total_balance(a))
+			.map(Pallet::<T, I>::total_balance)
 			.fold(T::Balance::zero(), |a, e| a.saturating_add(e));
 		Pallet::<T, I>::deactivate(total);
 

--- a/pallets/balances/src/tests/dispatchable_tests.rs
+++ b/pallets/balances/src/tests/dispatchable_tests.rs
@@ -50,14 +50,14 @@ fn dust_account_removal_should_work() {
 		.existential_deposit(100)
 		.monied(true)
 		.build_and_execute_with(|| {
-			System::inc_account_nonce(&2);
-			assert_eq!(System::account_nonce(&2), 1);
+			System::inc_account_nonce(2);
+			assert_eq!(System::account_nonce(2), 1);
 			assert_eq!(Balances::total_balance(&2), 2000);
 			// index 1 (account 2) becomes zombie
 			assert_ok!(Balances::transfer_allow_death(Some(2).into(), 5, 1901));
 			assert_eq!(Balances::total_balance(&2), 0);
 			assert_eq!(Balances::total_balance(&5), 1901);
-			assert_eq!(System::account_nonce(&2), 0);
+			assert_eq!(System::account_nonce(2), 0);
 		});
 }
 
@@ -191,7 +191,7 @@ fn set_balance_handles_total_issuance() {
 		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), 1337, 69));
 		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), old_total_issuance + 69);
 		assert_eq!(Balances::total_balance(&1337), 69);
-		assert_eq!(Balances::free_balance(&1337), 69);
+		assert_eq!(Balances::free_balance(1337), 69);
 	});
 }
 

--- a/pallets/balances/src/tests/fungible_tests.rs
+++ b/pallets/balances/src/tests/fungible_tests.rs
@@ -421,7 +421,7 @@ fn sufficients_work_properly_with_reference_counting() {
 				System::inc_sufficients(&1);
 				// Spend the same balance multiple times
 				assert_ok!(<Balances as fungible::Mutate<_>>::transfer(&1, &1337, 100, Expendable));
-				assert_eq!(Balances::free_balance(&1), 0);
+				assert_eq!(Balances::free_balance(1), 0);
 				assert_noop!(
 					<Balances as fungible::Mutate<_>>::transfer(&1, &1337, 100, Expendable),
 					TokenError::FundsUnavailable
@@ -537,13 +537,13 @@ fn freeze_consideration_works() {
 
 			let ticket = ticket.update(&who, Footprint::from_parts(0, 0)).unwrap();
 			assert!(ticket.is_none());
-			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), 0 + extend_freeze);
+			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), extend_freeze);
 
 			let ticket = Consideration::new(&who, Footprint::from_parts(10, 1)).unwrap();
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), 10 + extend_freeze);
 
-			let _ = ticket.drop(&who).unwrap();
-			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), 0 + extend_freeze);
+			ticket.drop(&who).unwrap();
+			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), extend_freeze);
 		});
 }
 
@@ -583,13 +583,13 @@ fn hold_consideration_works() {
 
 			let ticket = ticket.update(&who, Footprint::from_parts(0, 0)).unwrap();
 			assert!(ticket.is_none());
-			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), 0 + extend_hold);
+			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), extend_hold);
 
 			let ticket = Consideration::new(&who, Footprint::from_parts(10, 1)).unwrap();
 			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), 10 + extend_hold);
 
-			let _ = ticket.drop(&who).unwrap();
-			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), 0 + extend_hold);
+			ticket.drop(&who).unwrap();
+			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), extend_hold);
 		});
 }
 
@@ -626,7 +626,7 @@ fn lone_freeze_consideration_works() {
 			let ticket = Consideration::new(&who, Footprint::from_parts(10, 1)).unwrap();
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), 10);
 
-			let _ = ticket.drop(&who).unwrap();
+			ticket.drop(&who).unwrap();
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &who), 0);
 		});
 }
@@ -664,7 +664,7 @@ fn lone_hold_consideration_works() {
 			let ticket = Consideration::new(&who, Footprint::from_parts(10, 1)).unwrap();
 			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), 10);
 
-			let _ = ticket.drop(&who).unwrap();
+			ticket.drop(&who).unwrap();
 			assert_eq!(Balances::balance_on_hold(&TestId::Foo, &who), 0);
 		});
 }

--- a/pallets/balances/src/tests/general_tests.rs
+++ b/pallets/balances/src/tests/general_tests.rs
@@ -50,7 +50,7 @@ fn regression_historic_acc_does_not_evaporate_reserve() {
 		System::dec_consumers(&alice);
 
 		assert_eq!(
-			System::account(&alice),
+			System::account(alice),
 			AccountInfo {
 				data: AccountData {
 					free: 90,

--- a/pallets/balances/src/tests/mod.rs
+++ b/pallets/balances/src/tests/mod.rs
@@ -35,7 +35,6 @@ use frame_system::{self as system, RawOrigin};
 use pallet_transaction_payment::{ChargeTransactionPayment, FungibleAdapter, Multiplier};
 use scale_info::TypeInfo;
 use sp_core::hexdisplay::HexDisplay;
-use sp_io;
 use sp_runtime::{
 	traits::{BadOrigin, Zero},
 	ArithmeticError, BuildStorage, DispatchError, DispatchResult, FixedPointNumber, RuntimeDebug,
@@ -180,9 +179,9 @@ impl ExtBuilder {
 	pub fn build_and_execute_with(self, f: impl Fn()) {
 		let other = self.clone();
 		UseSystem::set(false);
-		other.build().execute_with(|| f());
+		other.build().execute_with(&f);
 		UseSystem::set(true);
-		self.build().execute_with(|| f());
+		self.build().execute_with(f);
 	}
 }
 

--- a/pallets/balances/src/tests/reentrancy_tests.rs
+++ b/pallets/balances/src/tests/reentrancy_tests.rs
@@ -41,15 +41,15 @@ fn transfer_dust_removal_tst1_should_work() {
 			assert_ok!(Balances::transfer_allow_death(RawOrigin::Signed(2).into(), 3, 450));
 
 			// As expected dust balance is removed.
-			assert_eq!(Balances::free_balance(&2), 0);
+			assert_eq!(Balances::free_balance(2), 0);
 
 			// As expected beneficiary account 3
 			// received the transferred fund.
-			assert_eq!(Balances::free_balance(&3), 450);
+			assert_eq!(Balances::free_balance(3), 450);
 
 			// Dust balance is deposited to account 1
 			// during the process of dust removal.
-			assert_eq!(Balances::free_balance(&1), 1050);
+			assert_eq!(Balances::free_balance(1), 1050);
 
 			// Verify the events
 			assert_eq!(System::events().len(), 14);
@@ -86,11 +86,11 @@ fn transfer_dust_removal_tst2_should_work() {
 			assert_ok!(Balances::transfer_allow_death(RawOrigin::Signed(2).into(), 1, 450));
 
 			// As expected dust balance is removed.
-			assert_eq!(Balances::free_balance(&2), 0);
+			assert_eq!(Balances::free_balance(2), 0);
 
 			// Dust balance is deposited to account 1
 			// during the process of dust removal.
-			assert_eq!(Balances::free_balance(&1), 1500);
+			assert_eq!(Balances::free_balance(1), 1500);
 
 			// Verify the events
 			assert_eq!(System::events().len(), 12);

--- a/pallets/balances/src/types.rs
+++ b/pallets/balances/src/types.rs
@@ -113,7 +113,7 @@ impl ExtraFlags {
 		Self(0)
 	}
 	pub fn set_new_logic(&mut self) {
-		self.0 = self.0 | IS_NEW_LOGIC
+		self.0 |= IS_NEW_LOGIC
 	}
 	pub fn is_new_logic(&self) -> bool {
 		(self.0 & IS_NEW_LOGIC) == IS_NEW_LOGIC

--- a/pallets/qpow/src/lib.rs
+++ b/pallets/qpow/src/lib.rs
@@ -353,7 +353,7 @@ pub mod pallet {
 					// Propagate new Event
 					Self::deposit_event(Event::DistanceThresholdAdjusted {
 						old_distance_threshold: current_distance_threshold,
-						new_distance_threshold: new_distance_threshold,
+						new_distance_threshold,
 						observed_block_time,
 					});
 

--- a/pallets/qpow/src/mock.rs
+++ b/pallets/qpow/src/mock.rs
@@ -7,7 +7,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 use sp_core::{H256};
-use frame_system;
 use primitive_types::U512;
 use crate::DefaultWeightInfo;
 use sp_runtime::BuildStorage;

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -248,7 +248,7 @@ fn test_total_distance_threshold_initialization() {
     new_test_ext().execute_with(|| {
         // Initially, total distance_threshold should be as genesis distance_threshold
         let initial_work = U512::one();
-        assert_eq!(QPow::get_total_work(), initial_work.into(),
+        assert_eq!(QPow::get_total_work(), initial_work,
                    "Initial TotalWork should be 0");
 
         // After the first btest_total_distance_threshold_increases_with_each_blocklock, TotalWork should equal block 1's distance_threshold
@@ -484,7 +484,7 @@ fn test_get_random_rsa() {
         let (m, n) = get_random_rsa(&header);
 
         // Check that n > m
-        assert!(U512::from(m) < n);
+        assert!(m < n);
 
         // Check that numbers are coprime
         assert!(is_coprime(&m, &n));
@@ -802,7 +802,7 @@ fn test_median_block_time_single_value() {
 fn test_median_block_time_odd_count() {
     new_test_ext().execute_with(|| {
         // Add odd number of entries
-        let block_times = vec![1000, 3000, 2000, 5000, 4000];
+        let block_times = [1000, 3000, 2000, 5000, 4000];
         let history_size = block_times.len() as u32;
 
         <HistorySize<Test>>::put(history_size);
@@ -823,7 +823,7 @@ fn test_median_block_time_odd_count() {
 fn test_median_block_time_even_count() {
     new_test_ext().execute_with(|| {
         // Add even number of entries
-        let block_times = vec![1000, 3000, 2000, 4000];
+        let block_times = [1000, 3000, 2000, 4000];
         let history_size = block_times.len() as u32;
 
         <HistorySize<Test>>::put(history_size);
@@ -844,7 +844,7 @@ fn test_median_block_time_even_count() {
 fn test_median_block_time_with_duplicates() {
     new_test_ext().execute_with(|| {
         // Add entries with duplicates
-        let block_times = vec![1000, 2000, 2000, 2000, 3000];
+        let block_times = [1000, 2000, 2000, 2000, 3000];
         let history_size = block_times.len() as u32;
 
         <HistorySize<Test>>::put(history_size);
@@ -868,7 +868,7 @@ fn test_median_block_time_ring_buffer() {
         // Assuming <Test as Config>::BlockTimeHistorySize::get() = 5
 
         // Add more entries than the maximum history size
-        let initial_times = vec![1000, 2000, 3000, 4000, 5000];
+        let initial_times = [1000, 2000, 3000, 4000, 5000];
 
         // Set initial history
         <HistoryIndex<Test>>::put(0);

--- a/pallets/reversible-transfers/src/tests.rs
+++ b/pallets/reversible-transfers/src/tests.rs
@@ -405,7 +405,7 @@ fn full_flow_execute_works() {
         // Event should be emitted by execute_transfer called by scheduler
         let expected_event = Event::TransactionExecuted {
             tx_id,
-            result: Ok(().into()).into(),
+            result: Ok(().into()),
         };
         assert!(
             System::events()

--- a/pallets/vesting/src/lib.rs
+++ b/pallets/vesting/src/lib.rs
@@ -136,14 +136,14 @@ pub mod pallet {
             schedule_id: u64
         ) -> DispatchResult {
 
-            let mut schedule = VestingSchedules::<T>::get(&schedule_id)
+            let mut schedule = VestingSchedules::<T>::get(schedule_id)
                 .ok_or(Error::<T>::NoVestingSchedule)?;
             let vested = Self::vested_amount(&schedule)?;
             let claimable = vested.saturating_sub(schedule.claimed);
 
             if claimable > T::Balance::zero() {
                 schedule.claimed += claimable;
-                VestingSchedules::<T>::insert(&schedule_id, &schedule);
+                VestingSchedules::<T>::insert(schedule_id, &schedule);
 
                 // Transfer claimable tokens
                 pallet_balances::Pallet::<T>::transfer(&Self::account_id(), &schedule.beneficiary, claimable, AllowDeath)?;
@@ -165,7 +165,7 @@ pub mod pallet {
             // Claim for beneficiary whatever they are currently owed
             Self::claim(origin, schedule_id)?;
 
-            let schedule = VestingSchedules::<T>::get(&schedule_id)
+            let schedule = VestingSchedules::<T>::get(schedule_id)
                 .ok_or(Error::<T>::ScheduleNotFound)?;
             ensure!(schedule.creator == who, Error::<T>::NotCreator);
 
@@ -180,7 +180,7 @@ pub mod pallet {
                 )?;
             }
 
-            VestingSchedules::<T>::remove(&schedule_id);
+            VestingSchedules::<T>::remove(schedule_id);
 
             // Emit event
             Self::deposit_event(Event::VestingScheduleCancelled(who, schedule_id));

--- a/pallets/vesting/src/tests.rs
+++ b/pallets/vesting/src/tests.rs
@@ -12,7 +12,7 @@ fn create_vesting_schedule<Moment: From<u64>>(start: u64, end: u64, amount: Bala
         beneficiary: 2,
         start: start.into(),
         end: end.into(),
-        amount: amount.into(),
+        amount,
         claimed: 0,
         id: 1
     }
@@ -407,12 +407,12 @@ fn vesting_near_max_timestamp() {
 
         run_to_block(2, max - 250); // Halfway
         assert_ok!(Vesting::claim(RuntimeOrigin::signed(2), 1));
-        let schedule = VestingSchedules::<Test>::get(&1).expect("Schedule should exist");
+        let schedule = VestingSchedules::<Test>::get(1).expect("Schedule should exist");
         assert_eq!(schedule.claimed, 250); // 50% vested
 
         run_to_block(3, max);
         assert_ok!(Vesting::claim(RuntimeOrigin::signed(2), 1));
-        let schedule = VestingSchedules::<Test>::get(&1).expect("Schedule should exist");
+        let schedule = VestingSchedules::<Test>::get(1).expect("Schedule should exist");
         assert_eq!(schedule.claimed, 500);
     });
 }
@@ -445,7 +445,7 @@ fn creator_insufficient_funds_fails() {
         );
 
         // Ensure no schedule was created
-        let schedule = VestingSchedules::<Test>::get(&1);
+        let schedule = VestingSchedules::<Test>::get(1);
         assert_eq!(schedule, None);
 
         // Check balances
@@ -507,7 +507,7 @@ fn non_creator_cannot_cancel() {
         );
 
         // Schedule still exists
-        let schedule = VestingSchedules::<Test>::get(&1).expect("Schedule should exist");
+        let schedule = VestingSchedules::<Test>::get(1).expect("Schedule should exist");
         let num_schedules = ScheduleCounter::<Test>::get();
         assert_eq!(num_schedules, 1);
         assert_eq!(schedule.creator, 1);

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -171,7 +171,7 @@ pub mod pallet {
 
 
             // Verify nullifier hasn't been used
-            ensure!(!UsedNullifiers::<T>::contains_key(&public_inputs.nullifier), Error::<T>::NullifierAlreadyUsed);
+            ensure!(!UsedNullifiers::<T>::contains_key(public_inputs.nullifier), Error::<T>::NullifierAlreadyUsed);
 
             VERIFIER_DATA.verify(proof)
                 .map_err(|_e| {
@@ -180,7 +180,7 @@ pub mod pallet {
                 })?;
 
             // Mark nullifier as used
-            UsedNullifiers::<T>::insert(&public_inputs.nullifier, true);
+            UsedNullifiers::<T>::insert(public_inputs.nullifier, true);
 
             // let exit_balance: <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance
             let exit_balance: <T as BalancesConfig>::Balance

--- a/qpow-math/src/lib.rs
+++ b/qpow-math/src/lib.rs
@@ -38,8 +38,8 @@ pub fn get_nonce_distance(
 
     // Compare PoW results
     let nonce_element = hash_to_group_bigint_sha(&header_int, &m, &n, &nonce_int);
-    let distance = target.bitxor(nonce_element);
-    distance
+    
+    target.bitxor(nonce_element)
 }
 
 /// Generates a pair of RSA-style numbers (m,n) deterministically from input header
@@ -55,7 +55,7 @@ pub fn get_random_rsa(header: &[u8; 32]) -> (U512, U512) {
     let mut n = U512::from_big_endian(sha3.finalize().as_slice());
 
     // Keep hashing until we find composite coprime n > m
-    while n.clone() % 2u32 == U512::zero() || n <= m || !is_coprime(&m, &n) || is_prime(&n) {
+    while n % 2u32 == U512::zero() || n <= m || !is_coprime(&m, &n) || is_prime(&n) {
         n = sha3_512(n);
     }
 
@@ -89,9 +89,9 @@ pub fn hash_to_group_bigint(h: &U512, m: &U512, n: &U512, solution: &U512) -> U5
     //log::info!("ComputePoW: h={:?}, m={:?}, n={:?}, solution={:?}, sum={:?}", h, m, n, solution, sum);
 
     // Compute m^sum mod n using modular exponentiation
-    let result = mod_pow(&m, &sum, n);
+    
 
-    result
+    mod_pow(m, &sum, n)
 }
 
 /// Modular exponentiation using Substrate's BigUint
@@ -136,7 +136,7 @@ pub fn is_prime(n: &U512) -> bool {
     let mut d = *n - U512::one();
     let mut r = 0u32;
     while d % U512::from(2u32) == U512::zero() {
-        d = d / U512::from(2u32);
+        d /= U512::from(2u32);
         r += 1;
     }
 
@@ -157,7 +157,7 @@ pub fn is_prime(n: &U512) -> bool {
         bytes[..64].copy_from_slice(&n_bytes);
         bytes[64..128].copy_from_slice(&counter_bytes);
 
-        sha3.update(&bytes);
+        sha3.update(bytes);
 
         // Use the hash to generate a base between 2 and n-2
         let hash = U512::from_big_endian(sha3.finalize_reset().as_slice());
@@ -165,11 +165,11 @@ pub fn is_prime(n: &U512) -> bool {
         bases[base_count] = base;
         base_count += 1;
 
-        counter = counter + U512::one();
+        counter += U512::one();
     }
 
     'witness: for base in bases {
-        let mut x = mod_pow(&U512::from(base), &d, n);
+        let mut x = mod_pow(&base, &d, n);
 
         if x == U512::one() || x == *n - U512::one() {
             continue 'witness;
@@ -195,7 +195,7 @@ pub fn is_prime(n: &U512) -> bool {
 pub fn sha3_512(input: U512) -> U512 {
     let mut sha3 = Sha3_512::new();
     let bytes = input.to_big_endian();
-    sha3.update(&bytes);
+    sha3.update(bytes);
     let output = U512::from_big_endian(sha3.finalize().as_slice());
     output
 }

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -73,8 +73,8 @@ impl_runtime_apis! {
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
 		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			let result = Executive::apply_extrinsic(extrinsic);
-			result
+			
+			Executive::apply_extrinsic(extrinsic)
 		}
 
 		fn finalize_block() -> <Block as BlockT>::Header {
@@ -130,7 +130,7 @@ impl_runtime_apis! {
 
 		fn verify_historical_block(header: [u8; 32], nonce: [u8; 64], block_number: u32) -> bool {
 			// Convert u32 to the appropriate BlockNumber type used by your runtime
-			let block_number_param = block_number.into();
+			let block_number_param = block_number;
 			pallet_qpow::Pallet::<Self>::verify_historical_block(header, nonce, block_number_param)
 		}
 
@@ -152,7 +152,7 @@ impl_runtime_apis! {
 
 		fn get_distance_threshold_at_block(block_number: u32) -> U512 {
 			// Convert u32 to the appropriate BlockNumber type used by your runtime
-			let block_number_param = block_number.into();
+			let block_number_param = block_number;
 			pallet_qpow::Pallet::<Self>::get_distance_threshold_at_block(block_number_param)
 		}
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -171,7 +171,7 @@ parameter_types! {
     pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
     pub const MaxVotes: u32 = 512;
     pub const MaxTurnout: Balance = 60 * UNIT;
-    pub const MinimumDeposit: Balance = 1 * UNIT;
+    pub const MinimumDeposit: Balance = UNIT;
 }
 
 impl pallet_conviction_voting::Config for Runtime {
@@ -185,8 +185,8 @@ impl pallet_conviction_voting::Config for Runtime {
 }
 
 parameter_types! {
-    pub const PreimageBaseDeposit: Balance = 1 * UNIT;
-    pub const PreimageByteDeposit: Balance = 1 * MICRO_UNIT;
+    pub const PreimageBaseDeposit: Balance = UNIT;
+    pub const PreimageByteDeposit: Balance = MICRO_UNIT;
 }
 
 impl pallet_preimage::Config for Runtime {

--- a/runtime/src/governance.rs
+++ b/runtime/src/governance.rs
@@ -84,10 +84,10 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
                     name: "root",
                     max_deciding: 1,                // Only 1 referendum can be in deciding phase at a time
                     decision_deposit: 10 * UNIT,    // Highest deposit requirement to prevent spam
-                    prepare_period: 1 * DAYS,       // 1 day preparation before voting begins
+                    prepare_period: DAYS,       // 1 day preparation before voting begins
                     decision_period: 14 * DAYS,     // 2 weeks for community to vote
-                    confirm_period: 1 * DAYS,       // 1 day confirmation period once passing
-                    min_enactment_period: 1 * DAYS, // At least 1 day between approval and execution
+                    confirm_period: DAYS,       // 1 day confirmation period once passing
+                    min_enactment_period: DAYS, // At least 1 day between approval and execution
                     min_approval: pallet_referenda::Curve::LinearDecreasing {
                         length: Perbill::from_percent(100),
                         floor: Perbill::from_percent(50),    // Minimum 50% approval at end
@@ -134,7 +134,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
                 pallet_referenda::TrackInfo {
                     name: "signaling",
                     max_deciding: 20,               // High throughput for community proposals
-                    decision_deposit: 1 * UNIT,     // Low deposit requirement
+                    decision_deposit: UNIT,     // Low deposit requirement
                     prepare_period: 6 * HOURS,      // Short preparation time
                     decision_period: 5 * DAYS,      // Standard voting period
                     confirm_period: 3 * HOURS,      // Minimal confirmation period
@@ -175,7 +175,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 
         // Check for other custom origins
         // This syntax depends on exactly how your custom origins are implemented
-        if let Some(_) = id.as_signed() {
+        if id.as_signed().is_some() {
             return Ok(1);
         }
 

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -1,7 +1,7 @@
 //! Custom signed extensions for the runtime.
 use crate::*;
 use codec::{Decode, Encode};
-use core::{marker::PhantomData, u8};
+use core::{marker::PhantomData};
 use frame_support::pallet_prelude::{InvalidTransaction, ValidTransaction};
 use frame_support::traits::fungible::Inspect;
 use frame_support::traits::tokens::Preservation;

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -127,7 +127,7 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 
                     // Schedule the transfer
 
-                    let _ = ReversibleTransfers::do_schedule_transfer(
+                    ReversibleTransfers::do_schedule_transfer(
                         origin.clone(),
                         dest.clone(),
                         *amount,
@@ -228,11 +228,11 @@ mod tests {
             let origin = RuntimeOrigin::signed(alice());
 
             // Test the prepare method
-            let pre = ext
+            ext
                 .clone()
                 .prepare((), &origin, &call, &Default::default(), 0)
                 .unwrap();
-            assert_eq!(pre, ());
+            assert_eq!((), ());
 
             // Test the validate method
             let result = ext.validate(
@@ -270,12 +270,12 @@ mod tests {
             let origin = RuntimeOrigin::signed(charlie());
 
             // Test the prepare method
-            let pre = ext
+            ext
                 .clone()
                 .prepare((), &origin, &call, &Default::default(), 0)
                 .unwrap();
 
-            assert_eq!(pre, ());
+            assert_eq!((), ());
 
             // Test the validate method
             let result = ext.validate(

--- a/runtime/tests/governance_engine.rs
+++ b/runtime/tests/governance_engine.rs
@@ -299,7 +299,7 @@ mod tests {
             };
 
             // Activation moment
-            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32.into());
+            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32);
 
             // Submit referendum - remember balance before this operation
             let balance_before_referendum = Balances::free_balance(&proposer);
@@ -366,7 +366,7 @@ mod tests {
             };
 
             // Activation moment
-            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32.into());
+            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32);
 
             // Submit referendum
             assert_ok!(Referenda::submit(
@@ -445,7 +445,7 @@ mod tests {
             };
 
             // Activation moment
-            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32.into());
+            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32);
 
             // Submit referendum
             assert_ok!(Referenda::submit(
@@ -562,7 +562,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             let referendum_index = 0;
@@ -735,7 +735,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call2,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             let referendum_index2 = 1;

--- a/runtime/tests/governance_logic.rs
+++ b/runtime/tests/governance_logic.rs
@@ -46,7 +46,7 @@ mod tests {
             };
 
             // Activation moment
-            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32.into());
+            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32);
 
             // Submit referendum
             assert_ok!(Referenda::submit(
@@ -171,7 +171,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             let referendum_index = 0;
@@ -264,7 +264,7 @@ mod tests {
             };
 
             // Activation moment
-            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32.into());
+            let enactment_moment = frame_support::traits::schedule::DispatchTime::After(0u32);
 
             // Submit referendum
             assert_ok!(Referenda::submit(
@@ -345,7 +345,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             let referendum_index = 0;
@@ -398,7 +398,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             let referendum_index = 0;
@@ -510,7 +510,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             // Check referendum is using track 0
@@ -542,9 +542,9 @@ mod tests {
         ));
 
             // Progress through phases
-            let prepare_period = 1 * DAYS;
+            let prepare_period = DAYS;
             let decision_period = 14 * DAYS;
-            let confirm_period = 1 * DAYS;
+            let confirm_period = DAYS;
 
             // Advance to deciding phase
             run_to_block(prepare_period + 1);
@@ -603,7 +603,7 @@ mod tests {
             RuntimeOrigin::signed(proposer.clone()),
             Box::new(OriginCaller::system(frame_system::RawOrigin::None)),
             bounded_call,
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             // Check referendum is using track 2
@@ -734,7 +734,7 @@ mod tests {
                 hash: root_hash,
                 len: root_encoded.len() as u32
             },
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             // Signed track (1)
@@ -745,7 +745,7 @@ mod tests {
                 hash: signed_hash,
                 len: signed_encoded.len() as u32
             },
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             // Signaling track (2)
@@ -756,7 +756,7 @@ mod tests {
                 hash: signal_hash,
                 len: signal_encoded.len() as u32
             },
-            frame_support::traits::schedule::DispatchTime::After(0u32.into())
+            frame_support::traits::schedule::DispatchTime::After(0u32)
         ));
 
             // Check each referendum is on the correct track
@@ -843,7 +843,7 @@ mod tests {
         ));
 
             // Get the prepare periods for each track
-            let root_prepare = 1 * DAYS;
+            let root_prepare = DAYS;
             let signed_prepare = 12 * HOURS;
             let signal_prepare = 6 * HOURS;
 
@@ -893,7 +893,7 @@ mod tests {
             }
 
             // Advance through all decision periods to confirm all pass
-            let longest_process = root_prepare + 14 * DAYS + 1 * DAYS + 5; // Root track has longest periods
+            let longest_process = root_prepare + 14 * DAYS + DAYS + 5; // Root track has longest periods
             run_to_block(longest_process);
 
             // Verify all referenda passed
@@ -947,7 +947,7 @@ mod tests {
                 RuntimeOrigin::signed(proposer.clone()),
                 Box::new(OriginCaller::system(frame_system::RawOrigin::None)),
                 bounded_call,
-                frame_support::traits::schedule::DispatchTime::After(0u32.into())
+                frame_support::traits::schedule::DispatchTime::After(0u32)
             ));
 
                 // Place decision deposit

--- a/runtime/tests/integration.rs
+++ b/runtime/tests/integration.rs
@@ -2,7 +2,6 @@ use codec::{Decode, Encode};
 use dilithium_crypto::{
     ResonanceSignatureWithPublic, ResonanceSignatureScheme, PUB_KEY_BYTES,
 };
-use hdwallet;
 use sp_core::ByteArray;
 use sp_runtime::{
     generic::UncheckedExtrinsic,generic::Preamble,
@@ -51,7 +50,7 @@ mod tests {
         // Generate a keypair
         let entropy = [0u8; 32]; // Fixed entropy of all zeros
         let keypair = hdwallet::generate(Some(&entropy)).expect("Failed to generate keypair");
-        let pk_bytes: [u8; PUB_KEY_BYTES as usize] = keypair.public.to_bytes();
+        let pk_bytes: [u8; PUB_KEY_BYTES] = keypair.public.to_bytes();
 
         println!("Gen Public Key (hex): {:?}", format_hex_truncated(&pk_bytes));
 
@@ -66,7 +65,7 @@ mod tests {
             ResonanceSignature::from_slice(&sig_bytes).expect("Signature length mismatch");
 
         let bytes: &[u8] = signature.as_ref(); // or signature.as_slice()
-        println!("Gen Signature bytes: {:?}", format_hex_truncated(&bytes));
+        println!("Gen Signature bytes: {:?}", format_hex_truncated(bytes));
         println!("Gen Signature length: {:?}", bytes.len());
 
         // Step 3: Derive AccountId and create extrinsic
@@ -121,7 +120,7 @@ mod tests {
                         let sig = sig_public.signature();
                         let sig_bytes = sig.as_slice();
                         println!("Decoded Signature: {:?}", format_hex_truncated(sig_bytes));
-                        println!("Decoded Public Key: {:?}", format_hex_truncated(&sig_public.public().as_ref()));
+                        println!("Decoded Public Key: {:?}", format_hex_truncated(sig_public.public().as_ref()));
                     }
                     _ => println!("Decoded Signature: --"),
                 }
@@ -270,7 +269,7 @@ mod tests {
         // Generate a keypair
         let entropy = [0u8; 32]; // Fixed entropy of all zeros
         let keypair = hdwallet::generate(Some(&entropy)).expect("Failed to generate keypair");
-        let pk_bytes: [u8; PUB_KEY_BYTES as usize] = keypair.public.to_bytes();
+        let pk_bytes: [u8; PUB_KEY_BYTES] = keypair.public.to_bytes();
 
         // Create and sign a payload
         let payload: RuntimeCall = 42;
@@ -381,7 +380,7 @@ mod tests {
                 match decoded_signature {
                     ResonanceSignatureScheme::Sr25519(ref sig) => {
                         let sig_bytes = sig.as_slice();
-                        println!("Decoded Signature: {:?}", format_hex_truncated(&sig_bytes));
+                        println!("Decoded Signature: {:?}", format_hex_truncated(sig_bytes));
                     }
                     _ => println!("Decoded Signature: --"),
                 }


### PR DESCRIPTION
I used:
- `cargo clippy --fix` to autofix
- Fixed `cargo clippy -- -A clippy::all -W clippy::comparison_chain`
- Fixed `cargo clippy -- -A clippy::all -W clippy::doc_lazy_continuation`
- Fixed `clippy::manual_strip`
- Fixed `clippy::legacy_numeric_constants`

I tried to get the statistics of what else we have:
- `clippy::large_enum_variant` - 3
- `clippy::await_holding_lock` - 1
- `clippy::type_complexity` - 2
- `clippy::too_many_arguments` - 1
- `clippy::result_unit_err` - 1

We can add maybe a config to ignore it for now, but maybe we can put some priority if we want to fix them all.