### PR TITLE
don't cache on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         name: pin
         run: rustup override set ${RUSTUP_TOOLCHAIN}
       -
+        if: contains(matrix.os, 'macos')
         name: cache
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
prevents out of disk space errors

the cache is 6GB and linux build runs out of space

not sure this is the best solution as it slows down the build even more