### PR TITLE
release now creates a PR for updating version number

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -142,53 +142,52 @@ jobs:
 
   update_cargo_toml:
     needs: calculate_next_version
-    runs-on: ubuntu-latest # Runs on Linux, can use sed easily
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 
-          token: ${{ secrets.ADMIN_PAT }}
+          fetch-depth: 0
 
-      - name: Update Cargo.toml version
-        env:
-          NEW_VERSION_WITH_V: ${{ needs.calculate_next_version.outputs.new_version }}
-        run: |
-          # Strip \'v\' prefix for Cargo.toml
-          new_cargo_version=${NEW_VERSION_WITH_V#v}
-          echo "Updating node/Cargo.toml to version: $new_cargo_version"
-          
-          # Use sed to update the version. This assumes the version line looks like:
-          # version = "x.y.z"
-          # It will replace the string between the quotes.
-          # The regex handles potential whitespace around the equals sign.
-          sed -i -E "s/^version\\s*=\\s*\"[0-9a-zA-Z.-]+\"/version = \"$new_cargo_version\"/" node/Cargo.toml
-          
-          echo "Contents of node/Cargo.toml after update:"
-          cat node/Cargo.toml
-
-      - name: Commit and push Cargo.toml changes
+      - name: Update Cargo.toml version locally and create PR
         env:
           NEW_VERSION_WITH_V: ${{ needs.calculate_next_version.outputs.new_version }}
           BRANCH_NAME: ${{ needs.calculate_next_version.outputs.branch_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # gh cli needs this
         run: |
+          set -ex
+          new_cargo_version=${NEW_VERSION_WITH_V#v}
+          echo "Updating node/Cargo.toml to version: $new_cargo_version locally for PR"
+          sed -i -E "s/^version\s*=\s*\"[0-9a-zA-Z.-]+\"/version = \"$new_cargo_version\"/" node/Cargo.toml
+          
+          echo "Contents of node/Cargo.toml after local update:"
+          cat node/Cargo.toml
+
+          bump_branch_name="version-bump-${NEW_VERSION_WITH_V}"
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
+          
+          git checkout -b "$bump_branch_name"
           git add node/Cargo.toml
-          # Check if there are changes to commit
-          if git diff --staged --quiet; then
-            echo "No changes to commit in Cargo.toml. Version might be the same."
-          else
-            git commit -m "Bump version to $NEW_VERSION_WITH_V in Cargo.toml
+          git commit -m "Bump version to $NEW_VERSION_WITH_V in Cargo.toml
 
-            [skip ci]" # Add [skip ci] to prevent this commit from triggering another workflow run
-            # Use the PAT in the push command
-            git push https://${{ github.actor }}:${{ secrets.ADMIN_PAT }}@github.com/${{ github.repository }}.git HEAD:${BRANCH_NAME}
-            echo "Pushed Cargo.toml changes to ${BRANCH_NAME}"
-          fi
+          [skip ci]"
+          # Try to delete the remote branch first, ignore error if it doesn't exist
+          git push origin --delete "$bump_branch_name" || true 
+          git push origin "$bump_branch_name"
+          
+          echo "Creating Pull Request for version bump..."
+          gh pr create \
+            --title "Bump version to $NEW_VERSION_WITH_V" \
+            --body "This PR bumps the version in node/Cargo.toml to $NEW_VERSION_WITH_V for the release. Triggered by workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --base "${BRANCH_NAME}" \
+            --head "$bump_branch_name"
 
   build_and_package:
-    needs: [calculate_next_version, update_cargo_toml] # Add update_cargo_toml dependency
+    needs: [calculate_next_version, update_cargo_toml] 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -204,6 +203,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        # This will checkout the original commit the workflow ran on, or tip of BRANCH_NAME
+
+      - name: Apply version bump to local Cargo.toml for build
+        env:
+          NEW_VERSION_WITH_V: ${{ needs.calculate_next_version.outputs.new_version }}
+        shell: bash
+        run: |
+          new_cargo_version=${NEW_VERSION_WITH_V#v}
+          echo "Applying version $new_cargo_version to node/Cargo.toml for build purposes..."
+          if [ -f node/Cargo.toml ]; then
+            sed -i -E "s/^version\s*=\s*\"[0-9a-zA-Z.-]+\"/version = \"$new_cargo_version\"/" node/Cargo.toml
+            echo "node/Cargo.toml updated locally for build:"
+            cat node/Cargo.toml
+          else
+            echo "Error: node/Cargo.toml not found at expected location for build-time update."
+            exit 1
+          fi
 
       - name: Install protoc (protobuf-compiler) for Linux
         if: runner.os == 'Linux'
@@ -273,7 +289,7 @@ jobs:
 
       - name: Build quantus-node binary
         if: github.event.inputs.fast_test_create_release_job == 'false'
-        run: cargo build --locked --release --package quantus-node --target ${{ matrix.target }}
+        run: cargo build --release --package quantus-node --target ${{ matrix.target }}
 
       - name: Create dummy quantus-node binary (fast test mode)
         if: github.event.inputs.fast_test_create_release_job == 'true' && (runner.os == 'Linux' || runner.os == 'macOS')


### PR DESCRIPTION
I had to turn off --locked because updating the version number also changes the lock file. 

So it would always fail with locked. 

this now creates a PR for updating the version number to comply with branch protection rules. 