### PR TITLE
Bump version to v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7984,7 +7984,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Resonance Runtime - Echo Chamber"
-version = "0.0.3"
+version = "0.0.4"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
This PR bumps the version in node/Cargo.toml and updates Cargo.lock to v0.0.4 for the release. Triggered by workflow run: https://github.com/Quantus-Network/chain/actions/runs/15298970836