### PR TITLE
Make wormhole addresses ss58 check compatible

### DIFF
--- a/dilithium-crypto/src/traits.rs
+++ b/dilithium-crypto/src/traits.rs
@@ -9,7 +9,7 @@ use sp_core::{
     crypto::{Derive, Public, PublicBytes, Signature, SignatureBytes},
     ByteArray,
 };
-use sp_core::{ecdsa, ed25519, sr25519};
+use sp_core::{ecdsa, ed25519, sr25519, H256};
 use sp_runtime::traits::Hash;
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},
@@ -84,6 +84,16 @@ impl IdentifyAccount for ResonancePublic {
     type AccountId = AccountId32;
     fn into_account(self) -> Self::AccountId {
         AccountId32::new(PoseidonHasher::hash(self.0.as_slice()).0)
+    }
+}
+
+pub struct WormholeAddress(pub H256);
+
+// AccountID32 for a wormhole address is the same as the address itself
+impl IdentifyAccount for WormholeAddress {
+    type AccountId = AccountId32;
+    fn into_account(self) -> Self::AccountId {
+        AccountId32::new(self.0.as_bytes().try_into().unwrap())
     }
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{Cli, Subcommand},
     service,
 };
-use dilithium_crypto::ResonancePair;
+use dilithium_crypto::{traits::WormholeAddress, ResonancePair};
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
 use resonance_runtime::{Block, EXISTENTIAL_DEPOSIT};
 use rusty_crystals_hdwallet::wormhole::WormholePair;
@@ -15,10 +15,12 @@ use sc_service::{BlocksPruning, PartialComponents, PruningMode};
 use sp_core::crypto::AccountId32;
 use sp_core::crypto::Ss58Codec;
 use sp_keyring::Sr25519Keyring;
+use sp_runtime::traits::IdentifyAccount;
 
 #[derive(Debug, PartialEq)]
 pub struct QuantusKeyDetails {
     pub address: String,
+    pub raw_address: String,
     pub public_key_hex: String, // Full public key, hex encoded with "0x" prefix
     pub secret_key_hex: String, // Secret key, hex encoded with "0x" prefix
     pub seed_hex: String,       // Derived seed, hex encoded with "0x" prefix
@@ -85,6 +87,7 @@ pub fn generate_quantus_key(
 
             Ok(QuantusKeyDetails {
                 address: account_id.to_ss58check(),
+                raw_address: format!("0x{}", hex::encode(account_id)),
                 public_key_hex: format!("0x{}", hex::encode(resonance_pair.public())),
                 secret_key_hex: format!("0x{}", hex::encode(resonance_pair.secret)),
                 seed_hex: format!("0x{}", hex::encode(&actual_seed_for_pair)),
@@ -97,11 +100,14 @@ pub fn generate_quantus_key(
                 sc_cli::Error::Input(format!("Wormhole generation error: {:?}", e).into())
             })?;
 
-            // Wormhole addresses are H256, not directly SS58. We'll show its hex representation.
-            // For consistency with the struct, we use the `address` field.
+            // Convert wormhole address to account ID using WormholeAddress type
+            let wormhole_address = WormholeAddress(wormhole_pair.address);
+            let account_id = wormhole_address.into_account();
+
             Ok(QuantusKeyDetails {
-                address: format!("0x{}", hex::encode(wormhole_pair.address)),
-                public_key_hex: "N/A (Wormhole)".to_string(),
+                address: account_id.to_ss58check(),
+                raw_address: format!("0x{}", hex::encode(account_id)),
+                public_key_hex: format!("0x{}", hex::encode(wormhole_pair.address)),
                 secret_key_hex: format!("0x{}", hex::encode(wormhole_pair.secret)),
                 seed_hex: "N/A (Wormhole)".to_string(),
                 secret_phrase: None,
@@ -159,7 +165,6 @@ impl SubstrateCli for Cli {
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
     let cli = Cli::from_args();
-
     match &cli.subcommand {
         Some(Subcommand::Key(cmd)) => {
             match cmd {
@@ -179,7 +184,9 @@ pub fn run() -> sc_cli::Result<()> {
                                     } else if words.is_some() {
                                         println!("Using provided words phrase...");
                                     } else {
-                                        println!("No seed or words provided. Generating a new 24-word phrase...");
+                                        println!(
+                                            "No seed or words provided. Generating a new 24-word phrase..."
+                                        );
                                     }
 
                                     println!(
@@ -189,18 +196,27 @@ pub fn run() -> sc_cli::Result<()> {
                                         println!("Secret phrase: {}", phrase);
                                     }
                                     println!("Address: {}", details.address);
+                                    log::debug!("Raw Hex Address: {}", details.raw_address);
                                     println!("Seed: {}", details.seed_hex);
                                     println!("Pub key: {}", details.public_key_hex);
                                     println!("Secret key: {}", details.secret_key_hex);
-                                    println!("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+                                    println!(
+                                        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+                                    );
                                 }
                                 QuantusAddressType::Wormhole => {
                                     println!("Generating wormhole address...");
-                                    println!("XXXXXXXXXXXXXXX Quantus Wormhole Details XXXXXXXXXXXXXXXXX");
-                                    println!("Address: {}", details.address); // This is 0x prefixed H256 hex
+                                    println!(
+                                        "XXXXXXXXXXXXXXX Quantus Wormhole Details XXXXXXXXXXXXXXXXX"
+                                    );
+                                    println!("Address: {}", details.address);
+                                    log::debug!("Raw Hex Address: {}", details.raw_address);
+                                    println!("Wormhole Address: {}", details.public_key_hex);
                                     println!("Secret: {}", details.secret_key_hex);
                                     // Pub key and Seed are N/A for wormhole as per QuantusKeyDetails
-                                    println!("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+                                    println!(
+                                        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+                                    );
                                 }
                             }
                             Ok(())


### PR DESCRIPTION
Added trait to make wormhole address first class citizens and have ss58 addresses. 

We need this to show them in the wallet, send them around over internet. 

```sh
~/play/quantus-network/chain wormhole-address 38s
❯ ./target/release/quantus-node key quantus --scheme wormhole
Generating wormhole address...
XXXXXXXXXXXXXXX Quantus Wormhole Details XXXXXXXXXXXXXXXXX
Address: 5HCSAF4iDom9et5rEds5JeFaHNw2SK7CwKgN7ufcS6maJAiD
Wormhole Address: 0xe3124a2b0ae70d34c676872aef0a3a8599babc7b21cce8a13ad3adcab580b136
Secret: 0x20cd7043e63810859f440402ba9ef9cbac21a43d0abc4a765dd518a4724da6ff
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

~/play/quantus-network/chain wormhole-address
❯ ./target/release/quantus-node key quantus                  
Generating Quantus Standard address...
No seed or words provided. Generating a new 24-word phrase...
XXXXXXXXXXXXXXX Quantus Account Details XXXXXXXXXXXXXXXXX
Secret phrase: wrong liar mixed truth fog dentist mass dignity click enjoy letter wrong month struggle skill eyebrow enemy valley country ski upon stone steak rain
Address: 5DRivawnrbkVB41ZNEBeDVhF6RPt261YebzDqehvzpy14L7e
Seed: 0x8ebcafe794a8a0e5689c607c7548de1b6474bbd1b1f10902fc7afb396a394173548ad3d750b3ef72451f1a9d53c92150d90b67c314d73edf78e3e1a2c8b03c23
```