### PR TITLE
Format toml files: fix indendation, order dependencies, make workspace dependency declaration consistent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,49 +28,86 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-resonance-runtime = { path = "./runtime", default-features = false }
-rusty-crystals-dilithium = { git = "https://gitlab.com/resonance-network/rusty-crystals.git", package = "rusty-crystals-dilithium", default-features = false, features = [
-    "no_std",
-] }
-plonky2 = { git = "https://github.com/Quantus-Network/plonky2", default-features = false, features = [
-    "no_random",
-] }
-poseidon-resonance = { git = "https://github.com/Quantus-Network/poseidon-resonance", default-features = false }
-futures-timer = { version = "3.0.2" }
-docify = { version = "0.2.9", default-features = false }
-paste = { version = "1.0.15", default-features = false }
+# Miscellaneous
 async-trait = { version = "0.1.85", default-features = false }
-pallet-faucet = { path = "./pallets/faucet", default-features = false }
-pallet-qpow = { path = "./pallets/qpow", default-features = false }
-pallet-mining-rewards = { path = "./pallets/mining-rewards", default-features = false }
-pallet-wormhole = { path = "./pallets/wormhole", default-features = false }
-pallet-balances = { path = "./pallets/balances", default-features = false }
-pallet-reversible-transfers = { path = "./pallets/reversible-transfers", default-features = false }
-pallet-conviction-voting = { version = "39.1.0", default-features = false }
-pallet-ranked-collective = { version = "39.0.0", default-features = false }
-pallet-preimage = { version = "39.0.0", default-features = false }
-pallet-referenda = { version = "39.1.0", default-features = false }
-pallet-treasury = { version = "38.1.0", default-features = false}
-pallet-recovery = { version = "39.1.0", default-features = false }
-pallet-scheduler = { path = "./pallets/scheduler", default-features = false }
-pallet-utility = { version = "39.1.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-pallet-vesting = { version = "39.1.0", default-features = false }
+binary-merkle-tree = { version = "16.0.0", default-features = false }
 clap = { version = "4.5.13" }
-frame-benchmarking-cli = { version = "46.1.0", default-features = false }
-frame-metadata-hash-extension = { version = "0.7.0", default-features = false }
-frame-system = { version = "39.1.0", default-features = false }
+codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
+docify = { version = "0.2.9", default-features = false }
+env_logger = "0.11.5"
 futures = { version = "0.3.31" }
+futures-timer = { version = "3.0.2" }
+hex = { version = "0.4.3", default-features = false }
 jsonrpsee = { version = "0.24.3" }
+lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
+log = { version = "0.4.22", default-features = false }
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+parking_lot = { version = "0.12.1", default-features = false }
+paste = { version = "1.0.15", default-features = false }
+primitive-types = { version = "0.13.1", default-features = false }
+prometheus = { version = "0.13.4", default-features = false }
+rand = { version = "0.8.5", default-features = false }
+reqwest = { version = "0.11.24", default-features = false, features = ["json"] }
+scale-info = { version = "2.11.1", default-features = false }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = { version = "1.0.132", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+thiserror = { version = "1.0.64" }
+uuid = { version = "1.7.0", features = ["v4", "serde"] }
+
+# Own dependencies
+dilithium-crypto = { path = "./dilithium-crypto", default-features = false }
+hdwallet = { path = "./dilithium-crypto/hdwallet", default-features = true }
+pallet-balances = { path = "./pallets/balances", default-features = false }
+pallet-faucet = { path = "./pallets/faucet", default-features = false }
+pallet-merkle-airdrop = { path = "./pallets/merkle-airdrop", default-features = false }
+pallet-mining-rewards = { path = "./pallets/mining-rewards", default-features = false }
+pallet-qpow = { path = "./pallets/qpow", default-features = false }
+pallet-reversible-transfers = { path = "./pallets/reversible-transfers", default-features = false }
+pallet-scheduler = { path = "./pallets/scheduler", default-features = false }
+pallet-wormhole = { path = "./pallets/wormhole", default-features = false }
+qp-scheduler = { path = "./primitives/scheduler", default-features = false }
+qpow-math = { path = "./qpow-math", default-features = false }
+resonance-runtime = { path = "./runtime", default-features = false }
+sc-consensus-pow = { path = "./client/consensus/pow", default-features = false }
+sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
+sp-consensus-pow = { path = "./primitives/consensus/pow", default-features = false }
+sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = false }
+sp-faucet = { path = "./primitives/faucet", default-features = false }
+
+# Quantus network dependencies
+rusty-crystals-dilithium = { git = "https://gitlab.com/resonance-network/rusty-crystals.git", default-features = false, features = ["no_std"] }
+rusty-crystals-hdwallet = { git = "https://github.com/Quantus-Network/rusty-crystals.git", package = "rusty-crystals-hdwallet" }
+plonky2 = { git = "https://github.com/Quantus-Network/plonky2", default-features = false, features = ["no_random"] }
+poseidon-resonance = { git = "https://github.com/Quantus-Network/poseidon-resonance", default-features = false }
+
+# polkadot-sdk dependencies
+frame-benchmarking = { version = "39.0.0", default-features = false }
+frame-benchmarking-cli = { version = "46.1.0", default-features = false }
+frame-executive = { version = "39.1.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.7.0", default-features = false }
+frame-support = { version = "39.1.0", default-features = false }
+frame-system = { version = "39.1.0", default-features = false }
+frame-system-benchmarking = { version = "39.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "35.0.0", default-features = false }
+frame-try-runtime = { version = "0.45.0", default-features = false }
+pallet-conviction-voting = { version = "39.1.0", default-features = false }
+pallet-preimage = { version = "39.0.0", default-features = false }
+pallet-ranked-collective = { version = "39.0.0", default-features = false }
+pallet-recovery = { version = "39.1.0", default-features = false }
+pallet-referenda = { version = "39.1.0", default-features = false }
+pallet-sudo = { version = "39.0.0", default-features = false }
+pallet-timestamp = { version = "38.0.0", default-features = false }
 pallet-transaction-payment = { version = "39.1.0", default-features = false }
 pallet-transaction-payment-rpc = { version = "42.0.0", default-features = false }
-reqwest = { version = "0.11.24", default-features = false, features = ["json"] }
+pallet-transaction-payment-rpc-runtime-api = { version = "39.0.0", default-features = false }
+pallet-treasury = { version = "38.1.0", default-features = false}
+pallet-utility = { version = "39.1.0", default-features = false }
+pallet-vesting = { version = "39.1.0", default-features = false }
 sc-basic-authorship = { version = "0.48.0", default-features = false }
 sc-cli = { version = "0.50.1", default-features = false }
 sc-client-api = { version = "38.0.0", default-features = false }
 sc-consensus = { version = "0.47.0", default-features = false }
-sc-consensus-pow = { path = "./client/consensus/pow", default-features = false }
-sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
 sc-executor = { version = "0.41.0", default-features = false }
 sc-network = { version = "0.48.3", default-features = false }
 sc-offchain = { version = "43.0.0", default-features = false }
@@ -78,52 +115,28 @@ sc-service = { version = "0.49.0", default-features = false }
 sc-telemetry = { version = "28.0.0", default-features = false }
 sc-transaction-pool = { version = "38.1.0", default-features = false }
 sc-transaction-pool-api = { version = "38.1.0", default-features = false }
-serde_json = { version = "1.0.132", default-features = false }
 sp-api = { version = "35.0.0", default-features = false }
 sp-arithmetic = { version = "26.0.0", default-features = false }
 sp-block-builder = { version = "35.0.0", default-features = false }
 sp-blockchain = { version = "38.0.0", default-features = false }
 sp-consensus = { version = "0.41.0", default-features = false }
-sp-consensus-pow = { path = "./primitives/consensus/pow", default-features = false }
-sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = false }
-qp-scheduler = { path = "./primitives/scheduler", default-features = false }
-sp-faucet = { path = "./primitives/faucet", default-features = false }
 sp-core = { version = "35.0.0", default-features = false }
 sp-genesis-builder = { version = "0.16.0", default-features = false }
 sp-inherents = { version = "35.0.0", default-features = false }
 sp-io = { version = "39.0.0", default-features = false }
-sp-std = { version = "14.0.0", default-features = false }
 sp-keyring = { version = "40.0.0", default-features = false }
+sp-offchain = { version = "35.0.0", default-features = false }
 sp-runtime = { version = "40.1.0", default-features = false }
 sp-runtime-interface = { version = "29.0.0", default-features = false }
-sp-timestamp = { version = "35.0.0", default-features = false }
-sp-weights = { version = "31.0.0", default-features = false }
-substrate-frame-rpc-system = { version = "42.0.0", default-features = false }
-substrate-build-script-utils = { version = "11.0.0", default-features = false }
-substrate-prometheus-endpoint = { version = "0.17.1", default-features = false }
-thiserror = { version = "1.0.64" }
-codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
-frame-benchmarking = { version = "39.0.0", default-features = false }
-frame-executive = { version = "39.1.0", default-features = false }
-frame-support = { version = "39.1.0", default-features = false }
-frame-system-benchmarking = { version = "39.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "35.0.0", default-features = false }
-frame-try-runtime = { version = "0.45.0", default-features = false }
-pallet-sudo = { version = "39.0.0", default-features = false }
-pallet-timestamp = { version = "38.0.0", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { version = "39.0.0", default-features = false }
-scale-info = { version = "2.11.1", default-features = false }
-sp-offchain = { version = "35.0.0", default-features = false }
 sp-session = { version = "37.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
 sp-storage = { version = "22.0.0", default-features = false }
+sp-timestamp = { version = "35.0.0", default-features = false }
 sp-transaction-pool = { version = "35.0.0", default-features = false }
 sp-version = { version = "38.0.0", default-features = false }
-substrate-wasm-builder = { version = "25.0.0", default-features = false }
-pallet-merkle-airdrop = { version = "0.1.0", path = "./pallets/merkle-airdrop", default-features = false }
-
-log = { version = "0.4.22", default-features = false }
-hex = { version = "0.4.3", default-features = false }
-primitive-types = { version = "0.13.1", default-features = false }
-rand = { version = "0.8.5", default-features = false }
-
+sp-weights = { version = "31.0.0", default-features = false }
+substrate-build-script-utils = { version = "11.0.0", default-features = false }
+substrate-frame-rpc-system = { version = "42.0.0", default-features = false }
+substrate-prometheus-endpoint = { version = "0.17.1", default-features = false }
 substrate-test-utils = { version = "3.0.0", default-features = false }
+substrate-wasm-builder = { version = "25.0.0", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,89 +16,87 @@ build = "build.rs"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-rusty-crystals-hdwallet = { git = "https://github.com/Quantus-Network/rusty-crystals.git", package = "rusty-crystals-hdwallet" }
-sc-consensus-pow = { workspace = true, default-features = false }
-sc-consensus-qpow = { workspace = true, default-features = false }
-sp-consensus-qpow = { workspace = true, default-features = false }
-log = { workspace = true }
-codec = { workspace = true }
-dilithium-crypto = { path = "../dilithium-crypto", default-features = false }
-async-trait = { workspace = true }
+async-trait.workspace = true
 clap = { features = ["derive"], workspace = true }
-futures = { features = ["thread-pool"], workspace = true }
-jsonrpsee = { features = ["server"], workspace = true }
-sc-cli.workspace = true
-sc-cli.default-features = true
-sp-core.workspace = true
-sp-core.default-features = true
-sc-executor.workspace = true
-sc-executor.default-features = true
-sc-network.workspace = true
-sc-network.default-features = true
-sc-service.workspace = true
-sc-service.default-features = true
-sc-telemetry.workspace = true
-sc-telemetry.default-features = true
-sc-transaction-pool.workspace = true
-sc-transaction-pool.default-features = true
-sc-transaction-pool-api.workspace = true
-sc-transaction-pool-api.default-features = true
-sc-offchain.workspace = true
-sc-offchain.default-features = true
-sc-consensus.workspace = true
-sc-consensus.default-features = true
-sp-genesis-builder.workspace = true
-sp-genesis-builder.default-features = true
-sc-client-api.workspace = true
-sc-client-api.default-features = true
-sc-basic-authorship.workspace = true
-sc-basic-authorship.default-features = true
-sp-runtime.workspace = true
-sp-runtime.default-features = true
-sp-io.workspace = true
-sp-io.default-features = true
-sp-timestamp.workspace = true
-sp-timestamp.default-features = true
-sp-inherents.workspace = true
-sp-inherents.default-features = true
-sp-keyring.workspace = true
-sp-keyring.default-features = true
-sp-api.workspace = true
-sp-api.default-features = true
-sp-blockchain.workspace = true
-sp-blockchain.default-features = true
-sp-block-builder.workspace = true
-sp-block-builder.default-features = true
-frame-system.workspace = true
-frame-system.default-features = true
-frame-metadata-hash-extension.workspace = true
-frame-metadata-hash-extension.default-features = true
-pallet-transaction-payment.workspace = true
-pallet-transaction-payment.default-features = true
-pallet-transaction-payment-rpc.workspace = true
-pallet-transaction-payment-rpc.default-features = true
-pallet-faucet.workspace = true
-pallet-faucet.default-features = false
-substrate-frame-rpc-system.workspace = true
-substrate-frame-rpc-system.default-features = true
-frame-benchmarking-cli.workspace = true
+codec.workspace = true
+dilithium-crypto.workspace = true
 frame-benchmarking-cli.default-features = true
-resonance-runtime.workspace = true
-
-sp-faucet = { workspace = true, default-features = false }
+frame-benchmarking-cli.workspace = true
+frame-metadata-hash-extension.default-features = true
+frame-metadata-hash-extension.workspace = true
+frame-system.default-features = true
+frame-system.workspace = true
+futures = { features = ["thread-pool"], workspace = true }
 hex = { workspace = true, default-features = false }
+jsonrpsee = { features = ["server"], workspace = true }
+log.workspace = true
+pallet-faucet.default-features = false
+pallet-faucet.workspace = true
+pallet-transaction-payment-rpc.default-features = true
+pallet-transaction-payment-rpc.workspace = true
+pallet-transaction-payment.default-features = true
+pallet-transaction-payment.workspace = true
+primitive-types = { workspace = true, default-features = false }
+prometheus.workspace = true
 rand = { workspace = true, default-features = false, features = [
 	"alloc",
 	"getrandom",
 ] }
 reqwest = { workspace = true, default-features = false, features = ["json"] }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["alloc"] }
-uuid = { version = "1.7.0", features = ["v4", "serde"] }
-primitive-types = { version = "0.13.1", default-features = false }
-
-prometheus = { version = "0.13.4", default-features = false }
 resonance-miner-api = { path = "../resonance-miner-api", default-features = false }
+resonance-runtime.workspace = true
+rusty-crystals-hdwallet.workspace = true
+sc-basic-authorship.default-features = true
+sc-basic-authorship.workspace = true
+sc-cli.default-features = true
+sc-cli.workspace = true
+sc-client-api.default-features = true
+sc-client-api.workspace = true
+sc-consensus-pow.workspace = true
+sc-consensus-qpow.workspace = true
+sc-consensus.default-features = true
+sc-consensus.workspace = true
+sc-executor.default-features = true
+sc-executor.workspace = true
+sc-network.default-features = true
+sc-network.workspace = true
+sc-offchain.default-features = true
+sc-offchain.workspace = true
+sc-service.default-features = true
+sc-service.workspace = true
+sc-telemetry.default-features = true
+sc-telemetry.workspace = true
+sc-transaction-pool-api.default-features = true
+sc-transaction-pool-api.workspace = true
+sc-transaction-pool.default-features = true
+sc-transaction-pool.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["alloc"] }
+sp-api.default-features = true
+sp-api.workspace = true
+sp-block-builder.default-features = true
+sp-block-builder.workspace = true
+sp-blockchain.default-features = true
+sp-blockchain.workspace = true
+sp-consensus-qpow.workspace = true
+sp-core.default-features = true
+sp-core.workspace = true
+sp-faucet = { workspace = true, default-features = false }
+sp-genesis-builder.default-features = true
+sp-genesis-builder.workspace = true
+sp-inherents.default-features = true
+sp-inherents.workspace = true
+sp-io.default-features = true
+sp-io.workspace = true
+sp-keyring.default-features = true
+sp-keyring.workspace = true
+sp-runtime.default-features = true
+sp-runtime.workspace = true
+sp-timestamp.default-features = true
+sp-timestamp.workspace = true
+substrate-frame-rpc-system.default-features = true
+substrate-frame-rpc-system.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 substrate-build-script-utils.workspace = true
@@ -107,9 +105,9 @@ substrate-build-script-utils.default-features = true
 [features]
 default = ["std"]
 std = [
-	"resonance-runtime/std",
 	"dilithium-crypto/std",
 	"rand/std",
+	"resonance-runtime/std",
 ]
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [

--- a/pallets/balances/Cargo.toml
+++ b/pallets/balances/Cargo.toml
@@ -14,21 +14,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
-log = { workspace = true }
-scale-info = { features = ["derive"], workspace = true }
+docify = { workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
-sp-runtime.workspace = true
-docify = { workspace = true }
+log.workspace = true
 poseidon-resonance = { workspace = true, features = ["serde"] }
+scale-info = { features = ["derive"], workspace = true }
+sp-runtime.workspace = true
 
 [dev-dependencies]
-pallet-transaction-payment = { workspace = true, default-features = true }
+pallet-transaction-payment.workspace = true
 frame-support = { workspace = true, features = ["experimental"], default-features = true }
-sp-core = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
-paste = { workspace = true, default-features = true }
+sp-core.workspace = true
+sp-io.workspace = true
+paste.workspace = true
 
 [features]
 default = ["std"]

--- a/pallets/merkle-airdrop/Cargo.toml
+++ b/pallets/merkle-airdrop/Cargo.toml
@@ -22,16 +22,16 @@ pallet-balances.workspace = true
 sp-runtime.workspace = true
 sp-core.workspace = true
 sp-io.workspace = true
-log = { version = "0.4.22", default-features = false }
-sha2 = { version = "0.10", default-features = false }
-binary-merkle-tree = { version = "16.0.0", default-features = false }
-poseidon-resonance = { workspace = true, default-features = false }
+log.workspace = true
+sha2.workspace = true
+binary-merkle-tree.workspace = true
+poseidon-resonance.workspace = true
 
 [dev-dependencies]
-pallet-vesting = { default-features = true, workspace = true }
-sp-core = { default-features = true, workspace = true }
-sp-io = { default-features = true, workspace = true }
-sp-runtime = { default-features = true, workspace = true }
+pallet-vesting.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
 
 [features]
 default = ["std"]
@@ -57,4 +57,4 @@ runtime-benchmarks = [
 try-runtime = [
     "frame-support/try-runtime",
     "frame-system/try-runtime",
-] 
+]

--- a/pallets/mining-rewards/Cargo.toml
+++ b/pallets/mining-rewards/Cargo.toml
@@ -14,21 +14,20 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "wasm32-unknown-u
 
 [dependencies]
 codec = { workspace = true, default-features = false, features = ["derive"] }
-scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { optional = true, workspace = true, default-features = false }
-frame-support = { workspace = true, default-features = false }
-frame-system = { workspace = true, default-features = false }
-sp-consensus-pow = { workspace = true, default-features = false }
-sp-runtime = { workspace = true, default-features = false }
-sp-std = { workspace = true, default-features = false }
-
-log = { workspace = true, default-features = false }
-pallet-balances = { workspace = true, default-features = false }
-pallet-treasury = { workspace = true, default-features = false }
+frame-support.workspace = true
+frame-system.workspace = true
+log.workspace = true
+pallet-balances.workspace = true
+pallet-treasury.workspace = true
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
+sp-consensus-pow.workspace = true
+sp-runtime.workspace = true
+sp-std.workspace = true
 
 [dev-dependencies]
-sp-io = { workspace = true, default-features = false }
-sp-core = { workspace = true, default-features = false }
+sp-core.workspace = true
+sp-io.workspace = true
 
 [features]
 default = ["std"]

--- a/pallets/qpow/Cargo.toml
+++ b/pallets/qpow/Cargo.toml
@@ -15,24 +15,22 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "wasm32-unknown-u
 #package = "parity-scale-codec",
 [dependencies]
 codec = { workspace=true, default-features = false, features = ["derive"] }
-scale-info = { workspace=true, default-features = false, features = ["derive"] }
 frame-benchmarking = { optional = true, default-features = false, workspace = true }
-frame-support = { default-features = false, workspace = true }
-frame-system = { default-features = false, workspace = true }
-sp-runtime = { workspace=true, default-features = false }
-sp-core = { workspace=true, default-features = false }
-sp-io = { workspace=true, default-features = false }
-sp-std = {workspace = true, default-features = false}
-qpow-math = { path = "../../qpow-math", default-features = false }
-sp-arithmetic = {workspace = true,default-features = false}
-
-pallet-timestamp = {workspace = true, default-features = false}
-
-num-traits = { version = "0.2", default-features = false, features = ["libm"]}
-log = { version = "0.4.22", default-features = false }
+frame-support.workspace = true
+frame-system.workspace = true
+log.workspace = true
+num-traits.workspace = true
+pallet-timestamp.workspace = true
+qpow-math.workspace = true
+scale-info = { workspace=true, default-features = false, features = ["derive"] }
+sp-arithmetic.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+sp-std.workspace = true
 
 [dev-dependencies]
-primitive-types = { version = "0.13.1", default-features = false }
+primitive-types.workspace = true
 
 [features]
 default = ["std"]

--- a/pallets/reversible-transfers/Cargo.toml
+++ b/pallets/reversible-transfers/Cargo.toml
@@ -13,24 +13,24 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
-log = { workspace = true }
-scale-info = { features = ["derive"], workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
+log.workspace = true
+pallet-balances.workspace = true
+qp-scheduler.workspace = true
+scale-info = { features = ["derive"], workspace = true }
 sp-runtime.workspace = true
-pallet-balances = { workspace = true }
-qp-scheduler = { workspace = true, default-features = false }
 
 [dev-dependencies]
 frame-support = { workspace = true, features = ["experimental"], default-features = true }
-sp-core = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
-pallet-scheduler = { workspace = true, default-features = false }
-pallet-timestamp = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, features = ["std"] }
-pallet-preimage = { workspace = true, default-features = false }
-qp-scheduler = { workspace = true, default-features = false }
+pallet-preimage.workspace = true
+pallet-scheduler.workspace = true
+pallet-timestamp.workspace = true
+qp-scheduler.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
 
 [features]
 default = ["std"]
@@ -40,11 +40,11 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
+	"pallet-balances/std",
+	"pallet-scheduler/std",
+	"qp-scheduler/std",
 	"scale-info/std",
 	"sp-runtime/std",
-	"pallet-balances/std",
-	"qp-scheduler/std",
-	"pallet-scheduler/std",
 ]
 # Enable support for setting the existential deposit to zero.
 insecure_zero_ed = []

--- a/pallets/scheduler/Cargo.toml
+++ b/pallets/scheduler/Cargo.toml
@@ -11,22 +11,21 @@ readme = "README.md"
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
-log = { workspace = true }
-scale-info = { features = ["derive"], workspace = true }
+docify.workspace = true
 frame-benchmarking = { optional = true, workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
+log.workspace = true
+qp-scheduler.workspace = true
+scale-info = { features = ["derive"], workspace = true }
 sp-io.workspace = true
 sp-runtime.workspace = true
 sp-weights.workspace = true
-docify = { workspace = true }
-qp-scheduler = { workspace = true, default-features = false }
-
 
 [dev-dependencies]
-pallet-preimage = { default-features = true, workspace = true }
-sp-core = { workspace = true, default-features = false }
-substrate-test-utils = { workspace = true, default-features = false }
+pallet-preimage.workspace = true
+sp-core.workspace = true
+substrate-test-utils.workspace = true
 
 [features]
 default = ["std"]

--- a/pallets/wormhole/Cargo.toml
+++ b/pallets/wormhole/Cargo.toml
@@ -9,36 +9,31 @@ edition.workspace = true
 
 [dependencies]
 codec = { workspace=true, default-features = false, features = ["derive"] }
+frame-support.workspace = true
+frame-system.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+pallet-balances.workspace = true
+plonky2.workspace = true
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
-frame-support = { workspace = true, default-features = false }
-frame-system = { workspace = true, default-features = false }
-
-sp-runtime = { workspace = true, default-features = false }
-sp-core = { workspace = true, default-features = false }
-sp-io = { workspace = true, default-features = false }
-
-plonky2 = { workspace = true }
-sp-std = { workspace = true, default-features = false }
-
-#light-poseidon = { workspace = true, default-features = false }
-
-log = { version = "0.4.22", default-features = false }
-lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
-pallet-balances = { workspace = true, default-features = false }
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+sp-std.workspace = true
 
 [features]
 default = ["std"]
 std = [
+    "codec/std",
     "frame-support/std",
     "frame-system/std",
+    "lazy_static/spin_no_std",
+    "pallet-balances/std",
+    "scale-info/std",
     "sp-core/std",
-    "sp-std/std",
     "sp-io/std",
     "sp-runtime/std",
-    "codec/std",
-    "scale-info/std",
-    "pallet-balances/std",
-    "lazy_static/spin_no_std",
+    "sp-std/std",
 ]
 runtime-benchmarks = [
     "frame-system/runtime-benchmarks",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,76 +14,75 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
+dilithium-crypto.workspace = true
+frame-benchmarking.workspace = true
+frame-executive.workspace = true
+frame-metadata-hash-extension.workspace = true
+frame-support = { features = ["experimental"], workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api.workspace = true
+frame-system.workspace = true
+frame-try-runtime = { optional = true, workspace = true }
+log.workspace = true
+pallet-balances.workspace = true
+pallet-conviction-voting.workspace = true
+pallet-faucet.workspace = true
+pallet-merkle-airdrop.workspace = true
+pallet-mining-rewards.workspace = true
+pallet-preimage.workspace = true
+pallet-qpow.workspace = true
+pallet-ranked-collective.workspace = true
+pallet-recovery.workspace = true
+pallet-referenda.workspace = true
+pallet-reversible-transfers.workspace = true
+pallet-scheduler.workspace = true
+pallet-sudo.workspace = true
+pallet-timestamp.workspace = true
+pallet-transaction-payment-rpc-runtime-api.workspace = true
+pallet-transaction-payment.workspace = true
+pallet-treasury.workspace = true
+pallet-utility.workspace = true
+pallet-vesting.workspace = true
+pallet-wormhole.workspace = true
+poseidon-resonance = { workspace = true, features = ["serde"] }
+primitive-types.workspace = true
+qp-scheduler.workspace = true
 scale-info = { features = ["derive", "serde"], workspace = true }
 serde_json = { workspace = true, default-features = false, features = [
 	"alloc",
 ] }
-frame-support = { features = ["experimental"], workspace = true }
-frame-system.workspace = true
-frame-try-runtime = { optional = true, workspace = true }
-frame-executive.workspace = true
-frame-metadata-hash-extension.workspace = true
-pallet-balances.workspace = true
-pallet-conviction-voting = { workspace = true, default-features = false }
-pallet-ranked-collective = { workspace = true, default-features = false }
-pallet-preimage = { workspace = true, default-features = false }
-pallet-referenda = { workspace = true, default-features = false }
-pallet-scheduler = { workspace = true, default-features = false }
-pallet-treasury = { workspace = true, default-features = false }
-pallet-utility = { workspace = true, default-features = false }
-pallet-sudo.workspace = true
-pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
-pallet-recovery = { workspace = true, default-features = false }
 sp-api.workspace = true
 sp-block-builder.workspace = true
-sp-keyring.workspace = true
+sp-consensus-qpow.workspace = true
 sp-core = { features = ["serde"], workspace = true }
+sp-faucet.workspace = true
+sp-genesis-builder.workspace = true
 sp-inherents.workspace = true
+sp-keyring.workspace = true
 sp-offchain.workspace = true
 sp-runtime = { features = ["serde"], workspace = true }
+sp-runtime-interface.workspace = true
 sp-session.workspace = true
+sp-std.workspace = true
 sp-storage.workspace = true
 sp-transaction-pool.workspace = true
 sp-version = { features = ["serde"], workspace = true }
-sp-genesis-builder.workspace = true
-frame-system-rpc-runtime-api.workspace = true
-pallet-transaction-payment-rpc-runtime-api.workspace = true
-frame-benchmarking = { version = "39.0.0", default-features = false }
-frame-system-benchmarking = { optional = true, workspace = true }
-pallet-faucet = { workspace = true, default-features = false }
-pallet-mining-rewards = { workspace = true, default-features = false }
-pallet-qpow = { workspace = true, default-features = false }
-pallet-wormhole = { workspace = true, default-features = false }
-pallet-reversible-transfers = { workspace = true, default-features = false }
-pallet-vesting = { workspace = true, default-features = false }
-qp-scheduler = { workspace = true, default-features = false }
-sp-consensus-qpow = { workspace = true, default-features = false}
-sp-faucet = {workspace = true, default-features = false}
-log = { workspace = true }
-pallet-merkle-airdrop = { workspace = true, default-features = false }
-
-dilithium-crypto = { path = "../dilithium-crypto", default-features = false }
-primitive-types = { default-features = false, workspace = true }
-sp-runtime-interface = { workspace = true, default-features = false }
-sp-std = { workspace = true, default-features = false }
-
-poseidon-resonance = { workspace = true, features = ["serde"] }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }
 
 [dev-dependencies]
-sp-std = { version = "14.0.0", default-features = true }
-hdwallet = { path = "../dilithium-crypto/hdwallet", default-features = true }
-env_logger = "0.11.5"
+env_logger.workspace = true
+hdwallet.workspace = true
+sp-io.workspace = true
 sp-keyring = { workspace = true, features = ["std"] }
-sp-io = { workspace = true, default-features = true }
+sp-std.workspace = true
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
+	"dilithium-crypto/full_crypto",
 	"frame-benchmarking/std",
 	"frame-executive/std",
 	"frame-metadata-hash-extension/std",
@@ -93,47 +92,46 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime?/std",
 	"pallet-balances/std",
-	"pallet-faucet/std",
-	"pallet-mining-rewards/std",
 	"pallet-conviction-voting/std",
-	"pallet-ranked-collective/std",
+	"pallet-faucet/std",
+	"pallet-merkle-airdrop/std",
+	"pallet-mining-rewards/std",
 	"pallet-preimage/std",
+	"pallet-qpow/std",
+	"pallet-ranked-collective/std",
+	"pallet-recovery/std",
 	"pallet-referenda/std",
+	"pallet-reversible-transfers/std",
 	"pallet-scheduler/std",
 	"pallet-sudo/std",
-	"pallet-treasury/std",
-	"pallet-utility/std",
-	"pallet-qpow/std",
-	"pallet-wormhole/std",
 	"pallet-timestamp/std",
-	"pallet-vesting/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
-	"pallet-merkle-airdrop/std",
-	"pallet-recovery/std",
+	"pallet-treasury/std",
+	"pallet-utility/std",
+	"pallet-vesting/std",
+	"pallet-wormhole/std",
+	"poseidon-resonance/std",
+	"qp-scheduler/std",
+	"scale-info/std",
 	"scale-info/std",
 	"serde_json/std",
 	"sp-api/std",
 	"sp-block-builder/std",
-	"sp-faucet/std",
 	"sp-consensus-qpow/std",
 	"sp-core/std",
+	"sp-faucet/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
 	"sp-offchain/std",
+	"sp-runtime-interface/std",
 	"sp-runtime/std",
 	"sp-session/std",
+	"sp-std/std",
 	"sp-storage/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
-	"sp-std/std",
-	"sp-runtime-interface/std",
-	"scale-info/std",
-	"dilithium-crypto/full_crypto",
-	"poseidon-resonance/std",
-	"pallet-reversible-transfers/std",
-	"qp-scheduler/std",
 ]
 
 runtime-benchmarks = [
@@ -143,20 +141,20 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-conviction-voting/runtime-benchmarks",
-	"pallet-ranked-collective/runtime-benchmarks",
-	"pallet-preimage/runtime-benchmarks",
-	"pallet-referenda/runtime-benchmarks",
-	"pallet-sudo/runtime-benchmarks",
-	"pallet-treasury/runtime-benchmarks",
-	"pallet-timestamp/runtime-benchmarks",
-	"pallet-transaction-payment/runtime-benchmarks",
-	"pallet-recovery/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"pallet-vesting/runtime-benchmarks",
-	"pallet-wormhole/runtime-benchmarks",
 	"pallet-merkle-airdrop/runtime-benchmarks",
 	"pallet-mining-rewards/runtime-benchmarks",
+	"pallet-preimage/runtime-benchmarks",
+	"pallet-ranked-collective/runtime-benchmarks",
+	"pallet-recovery/runtime-benchmarks",
+	"pallet-referenda/runtime-benchmarks",
 	"pallet-reversible-transfers/runtime-benchmarks",
+	"pallet-sudo/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-transaction-payment/runtime-benchmarks",
+	"pallet-treasury/runtime-benchmarks",
+	"pallet-vesting/runtime-benchmarks",
+	"pallet-wormhole/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -167,13 +165,13 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-mining-rewards/try-runtime",
 	"pallet-qpow/try-runtime",
-	"pallet-timestamp/try-runtime",
-	"pallet-vesting/try-runtime",
 	"pallet-ranked-collective/try-runtime",
+	"pallet-recovery/try-runtime",
 	"pallet-sudo/try-runtime",
+	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-treasury/try-runtime",
-	"pallet-recovery/try-runtime",
+	"pallet-vesting/try-runtime",
 	"sp-runtime/try-runtime",
 ]
 


### PR DESCRIPTION
- make workspace toml file a single source of truth for dependency versions
- order dependencies alphabetically (ascending)
- sort dependencies by domain - this helps when bumping `polkadot-sdk` deps
- consistent workspace dependency usage, i.e `crateA.workspace = true` instead of `crateA = { workspace = true }`