### PR TITLE
chore: dilithium node keys

### DIFF
--- a/node/src/chain-specs/live-resonance.json
+++ b/node/src/chain-specs/live-resonance.json
@@ -3,9 +3,9 @@
   "id": "resonance",
   "chainType": "Live",
   "bootNodes": [
-    "/dns/a1.t.res.fm/tcp/30201/p2p/12D3KooWGmDZ95J13cggsv56mSepAj3WiVPR3foqqh728umZrhPr",
-    "/dns/a2.t.res.fm/tcp/30203/p2p/12D3KooWPPv8nrVEN5mjcMruDnAEdcpfppSfSbij2A7FXWNGt8JL",
-    "/dns/a3.t.res.fm/tcp/30202/p2p/12D3KooWMpmEQmCB31Dz84YdnxL48aiSFQydEiq5MZv6VtZouXRd"
+    "/dns/a1.t.res.fm/tcp/30201/p2p/QmYpbayBgKbhfHGn2kNWWhh3DHwBnPaLDMYvaGmT78oAP7",
+    "/dns/a2.t.res.fm/tcp/30203/p2p/QmeN9H9CBdBESd6wib9xetPiYsCLYPTAJn8sxajWi2Bjkb",
+    "/dns/a3.t.res.fm/tcp/30202/p2p/QmQLf3wj7KqqtTjtrq7iQZY5JokQ3k7HHLGe5hNvHSxnFr"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
following on from https://github.com/Quantus-Network/chain/pull/91, nodes now use dilithium keys. this chainspec update reflects the new dilithium bootnode node keys.