### PR TITLE
Added blocknumber to TransferProof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
  "hdwallet",
  "log",
  "parity-scale-codec",
- "poseidon-resonance",
+ "poseidon-resonance 0.7.0",
  "rusty-crystals-dilithium",
  "scale-info",
  "sp-core",
@@ -6612,7 +6612,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
- "poseidon-resonance",
+ "poseidon-resonance 0.7.0",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -6681,7 +6681,7 @@ dependencies = [
  "pallet-balances 40.0.1",
  "pallet-vesting",
  "parity-scale-codec",
- "poseidon-resonance",
+ "poseidon-resonance 0.7.0",
  "scale-info",
  "sha2 0.10.9",
  "sp-core",
@@ -7738,6 +7738,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "poseidon-resonance"
+version = "0.7.0"
+source = "git+https://github.com/Quantus-Network/poseidon-resonance?branch=bigger-transfer-proof#1c7eeb02e26530da2e32379f41f15d6b511815c2"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "plonky2",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-storage",
+ "sp-trie",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8250,7 +8266,7 @@ dependencies = [
  "pallet-vesting",
  "pallet-wormhole",
  "parity-scale-codec",
- "poseidon-resonance",
+ "poseidon-resonance 0.7.0",
  "primitive-types 0.13.1",
  "qp-scheduler",
  "scale-info",
@@ -9178,7 +9194,7 @@ dependencies = [
  "bip39",
  "hex-literal",
  "hmac 0.12.1",
- "poseidon-resonance",
+ "poseidon-resonance 0.6.0",
  "rand 0.8.5",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ sp-faucet = { path = "./primitives/faucet", default-features = false }
 
 # Quantus network dependencies
 plonky2 = { git = "https://github.com/Quantus-Network/plonky2", default-features = false, features = ["no_random"] }
-poseidon-resonance = { git = "https://github.com/Quantus-Network/poseidon-resonance", default-features = false }
+poseidon-resonance = { git = "https://github.com/Quantus-Network/poseidon-resonance", default-features = false, branch = "bigger-transfer-proof" }
 rusty-crystals-dilithium = { git = "https://github.com/Quantus-Network/rusty-crystals", package = "rusty-crystals-dilithium", default-features = false, features = ["no_std"] }
 rusty-crystals-hdwallet = { git = "https://github.com/Quantus-Network/rusty-crystals", package = "rusty-crystals-hdwallet" }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -434,7 +434,7 @@ mod tests {
     fn inspect_node_key() {
         let path = tempfile::tempdir()
             .unwrap()
-            .into_path()
+            .keep()
             .join("node-id")
             .into_os_string();
         let path = path.to_str().unwrap();

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -582,7 +582,7 @@ pub mod pallet {
             T::AccountId,
             T::AccountId,
             T::Balance,
-        ), // (tx_count, from, to, amount)
+        ), // (block_number, tx_count, from, to, amount)
         (),
         OptionQuery, // Returns None if not present
     >;

--- a/pallets/balances/src/tests/mod.rs
+++ b/pallets/balances/src/tests/mod.rs
@@ -49,7 +49,7 @@ mod fungible_tests;
 mod general_tests;
 mod reentrancy_tests;
 
-type Block = frame_system::mocking::MockBlock<Test>;
+type Block = frame_system::mocking::MockBlockU32<Test>;
 
 #[derive(
     Encode,
@@ -81,7 +81,6 @@ frame_support::construct_runtime!(
         TransactionPayment: pallet_transaction_payment,
     }
 );
-
 type Balance = u128;
 
 parameter_types! {

--- a/pallets/reversible-transfers/src/mock.rs
+++ b/pallets/reversible-transfers/src/mock.rs
@@ -11,7 +11,7 @@ use qp_scheduler::BlockNumberOrTimestamp;
 use sp_core::{ConstU128, ConstU32};
 use sp_runtime::{BuildStorage, Perbill, Weight};
 
-type Block = frame_system::mocking::MockBlock<Test>;
+type Block = frame_system::mocking::MockBlockU32<Test>;
 pub type Balance = u128;
 pub type AccountId = u64;
 
@@ -108,8 +108,8 @@ impl<T> Time for MockTimestamp<T> {
 
 parameter_types! {
     pub const ReversibleTransfersPalletIdValue: PalletId = PalletId(*b"rtpallet");
-    pub const DefaultDelay: BlockNumberOrTimestamp<u64, u64> = BlockNumberOrTimestamp::BlockNumber(10);
-    pub const MinDelayPeriodBlocks: u64 = 2;
+    pub const DefaultDelay: BlockNumberOrTimestamp<u32, u64> = BlockNumberOrTimestamp::BlockNumber(10);
+    pub const MinDelayPeriodBlocks: u32 = 2;
     pub const MinDelayPeriodMoment: u64 = 2000;
     pub const MaxReversibleTransfers: u32 = 100;
 }

--- a/pallets/reversible-transfers/src/tests.rs
+++ b/pallets/reversible-transfers/src/tests.rs
@@ -24,7 +24,7 @@ fn calculate_tx_id(who: AccountId, call: &RuntimeCall) -> H256 {
 }
 
 // Helper to run to the next block
-fn run_to_block(n: u64) {
+fn run_to_block(n: u32) {
     while System::block_number() < n {
         // Finalize previous block
         Scheduler::on_finalize(System::block_number());

--- a/pallets/scheduler/src/mock.rs
+++ b/pallets/scheduler/src/mock.rs
@@ -111,7 +111,7 @@ pub mod logger {
     }
 }
 
-type Block = frame_system::mocking::MockBlock<Test>;
+type Block = frame_system::mocking::MockBlockU32<Test>;
 
 frame_support::construct_runtime!(
     pub enum Test
@@ -280,7 +280,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     t.into()
 }
 
-pub fn run_to_block(n: u64) {
+pub fn run_to_block(n: u32) {
     while System::block_number() < n {
         Scheduler::on_finalize(System::block_number());
         System::set_block_number(System::block_number() + 1);

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -13,7 +13,7 @@
 // use pallet_balances;
 // use pallet_balances::AccountData;
 
-// type Block = MockBlockU32<Test>;
+// type Block = MockBlock<Test>;
 // type Balance = u64;
 
 // parameter_types! {

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -13,7 +13,7 @@
 // use pallet_balances;
 // use pallet_balances::AccountData;
 
-// type Block = MockBlock<Test>;
+// type Block = MockBlockU32<Test>;
 // type Balance = u64;
 
 // parameter_types! {


### PR DESCRIPTION
Pretty straightforward change, but this will ensure no collisions in the nullifier or storage key in the case that a user deletes their account and uses it again, which resets the nonce back to zero.