### PR TITLE
Global Transfer Counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,7 +2493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4295,7 +4295,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7000,8 +7000,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -7725,8 +7725,8 @@ dependencies = [
 
 [[package]]
 name = "poseidon-resonance"
-version = "0.6.0"
-source = "git+https://github.com/Quantus-Network/poseidon-resonance#fce507b40c166d9acae1a8885898eea83d0d3780"
+version = "0.7.0"
+source = "git+https://github.com/Quantus-Network/poseidon-resonance#5869b62c0644791e42d15a10c228905cfdb93d32"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8413,7 +8413,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8976,7 +8976,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8989,7 +8989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12235,7 +12235,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12888,7 +12888,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -13633,7 +13633,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13807,15 +13807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.2",
 ]
 
 [[package]]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -17,7 +17,6 @@ use sp_core::crypto::AccountId32;
 use sp_core::crypto::Ss58Codec;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::traits::IdentifyAccount;
-use std::path::PathBuf;
 #[derive(Debug, PartialEq)]
 pub struct QuantusKeyDetails {
     pub address: String,

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -576,10 +576,14 @@ pub mod pallet {
     pub type TransferProof<T: Config<I>, I: 'static = ()> = StorageMap<
         _,
         PoseidonStorageHasher<T::AccountId>,
-        (T::Nonce, T::AccountId, T::AccountId, T::Balance), // (tx_count, from, to, amount)
+        (u64, T::AccountId, T::AccountId, T::Balance), // (tx_count, from, to, amount)
         (),
         OptionQuery, // Returns None if not present
     >;
+
+    #[pallet::storage]
+    #[pallet::getter(fn transfer_count)]
+    pub type TransferCount<T: Config<I>, I: 'static = ()> = StorageValue<_, u64, ValueQuery>;
 
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config<I>, I: 'static = ()> {
@@ -933,18 +937,20 @@ pub mod pallet {
     impl<T: Config<I>, I: 'static> Pallet<T, I> {
         fn store_transfer_proof(from: &T::AccountId, to: &T::AccountId, value: T::Balance) {
             if from != to {
-                let nonce = <frame_system::Pallet<T>>::account_nonce(from);
-                TransferProof::<T, I>::insert((nonce, from.clone(), to.clone(), value), ());
+                let current_count = Self::transfer_count();
+                <TransferCount<T, I>>::put(current_count.saturating_add(1));
+
+                TransferProof::<T, I>::insert((current_count, from.clone(), to.clone(), value), ());
             }
         }
 
         pub fn transfer_proof_storage_key(
-            nonce: T::Nonce,
+            transfer_count: u64,
             from: T::AccountId,
             to: T::AccountId,
             amount: T::Balance,
         ) -> Vec<u8> {
-            let key = (nonce, from, to, amount);
+            let key = (transfer_count, from, to, amount);
             TransferProof::<T, I>::hashed_key_for(&key)
         }
     }

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -935,7 +935,7 @@ pub mod pallet {
     }
 
     impl<T: Config<I>, I: 'static> Pallet<T, I> {
-        fn store_transfer_proof(from: &T::AccountId, to: &T::AccountId, value: T::Balance) {
+        pub fn store_transfer_proof(from: &T::AccountId, to: &T::AccountId, value: T::Balance) {
             if from != to {
                 let current_count = Self::transfer_count();
                 <TransferCount<T, I>>::put(current_count.saturating_add(1));

--- a/pallets/balances/src/tests/mod.rs
+++ b/pallets/balances/src/tests/mod.rs
@@ -48,7 +48,7 @@ mod fungible_conformance_tests;
 mod fungible_tests;
 mod general_tests;
 mod reentrancy_tests;
-
+mod transfer_counter_tests;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 #[derive(

--- a/pallets/balances/src/tests/transfer_counter_tests.rs
+++ b/pallets/balances/src/tests/transfer_counter_tests.rs
@@ -1,0 +1,349 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the global transfer counter functionality.
+
+use sp_runtime::ArithmeticError::Underflow;
+use sp_runtime::DispatchError::Arithmetic;
+use super::*;
+use crate::{TransferCount, TransferProof};
+
+/// Alice account ID for more readable tests.
+const ALICE: u64 = 1;
+/// Bob account ID for more readable tests.
+const BOB: u64 = 2;
+/// Charlie account ID for more readable tests.
+const CHARLIE: u64 = 3;
+
+#[test]
+fn transfer_counter_starts_at_zero() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Transfer counter should start at 0
+            assert_eq!(Balances::transfer_count(), 0);
+        });
+}
+
+#[test]
+fn transfer_allow_death_increments_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Perform a transfer
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 5));
+
+            // Counter should increment to 1
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // Perform another transfer
+            assert_ok!(Balances::transfer_allow_death(Some(BOB).into(), CHARLIE, 3));
+
+            // Counter should increment to 2
+            assert_eq!(Balances::transfer_count(), 2);
+        });
+}
+
+#[test]
+fn transfer_keep_alive_increments_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Perform a transfer_keep_alive
+            assert_ok!(Balances::transfer_keep_alive(Some(ALICE).into(), BOB, 5));
+
+            // Counter should increment to 1
+            assert_eq!(Balances::transfer_count(), 1);
+        });
+}
+
+#[test]
+fn force_transfer_increments_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Perform a force_transfer (requires root)
+            assert_ok!(Balances::force_transfer(
+                RuntimeOrigin::root(),
+                ALICE,
+                BOB,
+                5
+            ));
+
+            // Counter should increment to 1
+            assert_eq!(Balances::transfer_count(), 1);
+        });
+}
+
+#[test]
+fn transfer_all_increments_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Perform a transfer_all
+            assert_ok!(Balances::transfer_all(Some(ALICE).into(), BOB, false));
+
+            // Counter should increment to 1
+            assert_eq!(Balances::transfer_count(), 1);
+        });
+}
+
+#[test]
+fn self_transfer_does_not_increment_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Attempt self-transfer (this should succeed but not increment counter)
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), ALICE, 5));
+
+            // Counter should remain 0 since it's a self-transfer
+            assert_eq!(Balances::transfer_count(), 0);
+        });
+}
+
+#[test]
+fn transfer_proof_storage_is_created() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            let transfer_amount = 5;
+
+            // Perform a transfer
+            assert_ok!(Balances::transfer_allow_death(
+                Some(ALICE).into(),
+                BOB,
+                transfer_amount
+            ));
+
+            // Check that transfer proof was stored with correct key
+            let key = (0u64, ALICE, BOB, transfer_amount);
+            assert!(TransferProof::<Test>::contains_key(&key));
+        });
+}
+
+#[test]
+fn multiple_transfers_create_sequential_proofs() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // First transfer
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 5));
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // Check first proof exists
+            let key1 = (0u64, ALICE, BOB, 5u128);
+            assert!(TransferProof::<Test>::contains_key(&key1));
+
+            // Second transfer
+            assert_ok!(Balances::transfer_allow_death(Some(BOB).into(), CHARLIE, 3));
+            assert_eq!(Balances::transfer_count(), 2);
+
+            // Check second proof exists
+            let key2 = (1u64, BOB, CHARLIE, 3u128);
+            assert!(TransferProof::<Test>::contains_key(&key2));
+
+            // Third transfer with different amount
+            assert_ok!(Balances::transfer_allow_death(
+                Some(ALICE).into(),
+                CHARLIE,
+                1
+            ));
+            assert_eq!(Balances::transfer_count(), 3);
+
+            // Check third proof exists
+            let key3 = (2u64, ALICE, CHARLIE, 1u128);
+            assert!(TransferProof::<Test>::contains_key(&key3));
+        });
+}
+
+#[test]
+fn failed_transfers_do_not_increment_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Attempt transfer with insufficient funds
+            assert_noop!(
+                Balances::transfer_allow_death(Some(ALICE).into(), BOB, 1000),
+                Arithmetic(Underflow)
+            );
+
+            // Counter should remain 0 since transfer failed
+            assert_eq!(Balances::transfer_count(), 0);
+        });
+}
+
+#[test]
+fn transfer_proof_storage_key_generation() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            let transfer_count = 5u64;
+            let from = ALICE;
+            let to = BOB;
+            let amount = 100u128;
+
+            // Generate storage key
+            let key = Balances::transfer_proof_storage_key(transfer_count, from, to, amount);
+
+            // Key should not be empty
+            assert!(!key.is_empty());
+
+            // The same parameters should generate the same key
+            let key2 = Balances::transfer_proof_storage_key(transfer_count, from, to, amount);
+            assert_eq!(key, key2);
+
+            // Different parameters should generate different keys
+            let key3 = Balances::transfer_proof_storage_key(transfer_count + 1, from, to, amount);
+            assert_ne!(key, key3);
+        });
+}
+
+#[test]
+fn counter_saturates_at_max_value() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Set counter to near maximum value (u64::MAX - 1)
+            let near_max = u64::MAX - 1;
+            TransferCount::<Test>::put(near_max);
+
+            assert_eq!(Balances::transfer_count(), near_max);
+
+            // Perform a transfer - should increment to u64::MAX
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 5));
+            assert_eq!(Balances::transfer_count(), u64::MAX);
+
+            // Perform another transfer - should saturate at u64::MAX
+            assert_ok!(Balances::transfer_allow_death(
+                Some(ALICE).into(),
+                CHARLIE,
+                3
+            ));
+            assert_eq!(Balances::transfer_count(), u64::MAX);
+        });
+}
+
+#[test]
+fn transfer_counter_persists_across_blocks() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Perform transfers in block 1
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 5));
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // Move to next block
+            System::set_block_number(2);
+
+            // Counter should persist
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // Perform another transfer
+            assert_ok!(Balances::transfer_allow_death(Some(BOB).into(), CHARLIE, 3));
+            assert_eq!(Balances::transfer_count(), 2);
+        });
+}
+
+#[test]
+fn zero_value_transfers_increment_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // Perform zero-value transfer (should succeed and increment counter)
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 0));
+
+            // Counter should increment even for zero-value transfers
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // Transfer proof should be created
+            let key = (0u64, ALICE, BOB, 0u128);
+            assert!(TransferProof::<Test>::contains_key(&key));
+        });
+}
+
+#[test]
+fn different_transfer_types_all_increment_counter() {
+    ExtBuilder::default()
+        .existential_deposit(1)
+        .monied(true)
+        .build_and_execute_with(|| {
+            // Initial counter should be 0
+            assert_eq!(Balances::transfer_count(), 0);
+
+            // transfer_allow_death
+            assert_ok!(Balances::transfer_allow_death(Some(ALICE).into(), BOB, 1));
+            assert_eq!(Balances::transfer_count(), 1);
+
+            // transfer_keep_alive
+            assert_ok!(Balances::transfer_keep_alive(
+                Some(ALICE).into(),
+                CHARLIE,
+                1
+            ));
+            assert_eq!(Balances::transfer_count(), 2);
+
+            // force_transfer
+            assert_ok!(Balances::force_transfer(
+                RuntimeOrigin::root(),
+                BOB,
+                CHARLIE,
+                1
+            ));
+            assert_eq!(Balances::transfer_count(), 3);
+
+            // transfer_all (transfer remaining balance)
+            let remaining = Balances::free_balance(ALICE);
+            if remaining > 1 {
+                assert_ok!(Balances::transfer_all(Some(ALICE).into(), BOB, false));
+                assert_eq!(Balances::transfer_count(), 4);
+            }
+        });
+}

--- a/pallets/balances/src/tests/transfer_counter_tests.rs
+++ b/pallets/balances/src/tests/transfer_counter_tests.rs
@@ -17,10 +17,10 @@
 
 //! Tests for the global transfer counter functionality.
 
-use sp_runtime::ArithmeticError::Underflow;
-use sp_runtime::DispatchError::Arithmetic;
 use super::*;
 use crate::{TransferCount, TransferProof};
+use sp_runtime::ArithmeticError::Underflow;
+use sp_runtime::DispatchError::Arithmetic;
 
 /// Alice account ID for more readable tests.
 const ALICE: u64 = 1;

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -37,6 +37,10 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         type WeightInfo: WeightInfo;
+
+        /// Account ID used as the "from" account when creating transfer proofs for minted tokens
+        #[pallet::constant]
+        type MintingAccount: Get<Self::AccountId>;
     }
 
     pub trait WeightInfo {
@@ -207,6 +211,14 @@ pub mod pallet {
             // Mint new tokens to the exit account
             let _ =
                 BalancesPallet::<T>::deposit_creating(&public_inputs.exit_account, exit_balance);
+
+            // Create a transfer proof for the minted tokens
+            let mint_account = T::MintingAccount::get();
+            BalancesPallet::<T>::store_transfer_proof(
+                &mint_account,
+                &public_inputs.exit_account,
+                exit_balance,
+            );
 
             // // Emit event
             Self::deposit_event(Event::ProofVerified {

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -153,9 +153,14 @@ impl pallet_qpow::Config for Runtime {
     type MaxReorgDepth = ConstU32<10>;
 }
 
+parameter_types! {
+     pub const WormholeMintingAccount: AccountId = AccountId::new([1u8; 32]);
+}
+
 impl pallet_wormhole::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
+    type MintingAccount = WormholeMintingAccount;
 }
 
 type Moment = u64;


### PR DESCRIPTION
This addresses some issues around TransferProofs
- now wormhole exits generate TransferProofs
- TransferProof hashes depend on a global TransferCount that increments on all transfers 

This removes the dependency on account nonce, as this has some corner cases like minting or recurring payments or account deletion that would make the nullifier inputs (blocknum, nonce, from) collide. Now all transfers have a globally unique id.