### PR TITLE
Automate release for v0.0.12-resonance-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.0.11-summer-romance"
+version = "0.0.12-resonance-alpha"
 dependencies = [
  "async-trait",
  "circuit-builder",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.0.11-summer-romance"
+version = "0.0.12-resonance-alpha"
 dependencies = [
  "dilithium-crypto",
  "env_logger 0.11.8",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.0.11-summer-romance"
+version = "0.0.12-resonance-alpha"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-runtime"
 description = "Quantus Runtime - Proof of Vibes"
-version = "0.0.11-summer-romance"
+version = "0.0.12-resonance-alpha"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 103,
+    spec_version: 104,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Automated version bump for release v0.0.12-resonance-alpha.

https://github.com/Quantus-Network/chain/actions/runs/16215079366

Triggered by workflow run: patch

Type: 