### PR TITLE
Shortened difficulty adjustment period to reduce wobble

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -142,7 +142,7 @@ impl pallet_qpow::Config for Runtime {
     type TargetBlockTime = TargetBlockTime;
     type AdjustmentPeriod = ConstU32<1>;
     // This is how many blocks to include for the difficulty adjustment
-    type BlockTimeHistorySize = ConstU32<25>;
+    type BlockTimeHistorySize = ConstU32<10>;
     type MaxReorgDepth = ConstU32<180>;
     type FixedU128Scale = ConstU128<1_000_000_000_000_000_000>;
     type MaxDistanceMultiplier = ConstU32<2>;


### PR DESCRIPTION
<img width="1220" height="540" alt="Screenshot 2025-07-19 at 5 22 44 PM" src="https://github.com/user-attachments/assets/8a689aba-76d2-402c-a2c5-69a00925cb27" />

This wobble in the difficulty is directly downstream of this parameter. It's not a huge problem, but smaller wobbles would make mining more predictable. Right now we sometimes get a 5x change in difficulty in one wobble.