### PR TITLE
Add sync-awareness to pow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8173,6 +8173,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
+ "sp-consensus",
  "sp-consensus-qpow",
  "sp-core",
  "sp-genesis-builder",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -78,6 +78,7 @@ sp-block-builder.workspace = true
 sp-blockchain.default-features = true
 sp-blockchain.workspace = true
 sp-consensus-qpow.workspace = true
+sp-consensus.workspace = true
 sp-core.default-features = true
 sp-core.workspace = true
 sp-genesis-builder.default-features = true


### PR DESCRIPTION
This is an attempt to address the issue of miners forking themselves off randomly.

We could add more conditions, like need at least 1 peer to mine?

