### PR TITLE
Add difficulty and distance_achieved to chain_getBlock

### DIFF
--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -14,8 +14,10 @@ use sp_runtime::generic::BlockId;
 use std::{marker::PhantomData, sync::Arc};
 
 #[derive(Clone, Debug, Encode, Decode, PartialEq)]
-pub struct QPoWSeal {
+pub struct QPoWResult {
 	pub nonce: [u8; 64],
+	pub difficulty: [u8; 64],
+	pub distance_achieved: [u8; 64]
 }
 
 pub struct QPowAlgorithm<B, C>
@@ -61,29 +63,8 @@ where
 		_pre_digest: Option<&[u8]>,
 		seal: &RawSeal,
 		_difficulty: Self::Difficulty,
-	) -> Result<bool, Error<B>> {
-		//Executed for mined and imported blocks
-
-		/*
-
-		For now, we will turn this off temporally.
-		In this way, node can mine/import blocks without rewarding anyone.
-
-		// Block miner should exist
-
-		let mut extracted_author: Option<AccountId32> = None;
-		if let Some(pre_digest_bytes) = pre_digest {
-			if let Ok(account) = <AccountId32 as Decode>::decode(&mut &pre_digest_bytes[..]) {
-				extracted_author = Some(account);
-			}
-		}
-
-		let _author = match extracted_author {
-			Some(acc) => acc,
-			None => return Err(Error::Runtime("Failed to extract AccountId32 from pre_digest".into())),
-		};
-
-		*/
+	) -> Result<(bool, U512, U512), Error<B>> {
+		// Executed for mined and imported blocks
 
 		// Convert seal to nonce [u8; 64]
 		let nonce: [u8; 64] = match seal.as_slice().try_into() {
@@ -92,22 +73,28 @@ where
 		};
 		let parent_hash = match extract_block_hash(parent) {
 			Ok(hash) => hash,
-			Err(_) => return Ok(false),
+			Err(_) => return Ok((false, U512::zero(), U512::zero())),
 		};
 
 		let pre_hash = pre_hash.as_ref().try_into().unwrap_or([0u8; 32]);
-
-		// Verify the nonce using QPoW
-		if !self
+		let (verified, difficulty, distance_achieved) = self
 			.client
 			.runtime_api()
-			.verify_for_import(parent_hash, pre_hash, nonce)
-			.map_err(|e| Error::Runtime(format!("API error in verify_nonce: {:?}", e)))?
+			.verify_current_block(parent_hash, pre_hash, nonce, false)
+			.map_err(|e| Error::Runtime(format!("API error in verify_nonce: {:?}", e)))?;
+
+		// Verify the nonce using QPoW
+		if !verified
 		{
-			return Ok(false);
+			return Ok((false, U512::zero(), U512::zero()));
 		}
 
-		Ok(true)
+		// Verify the difficulty using QPoW
+		if difficulty != _difficulty {
+			return Ok((false, U512::zero(), U512::zero()));
+		}
+
+		Ok((true, difficulty, distance_achieved))
 	}
 }
 

--- a/client/consensus/qpow/src/miner.rs
+++ b/client/consensus/qpow/src/miner.rs
@@ -1,4 +1,4 @@
-use crate::QPoWSeal;
+use crate::QPoWResult;
 use primitive_types::H256;
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -30,15 +30,18 @@ where
 		parent_hash: BA::Hash,
 		pre_hash: BA::Hash,
 		nonce: [u8; 64],
-	) -> Result<QPoWSeal, ()> {
+	) -> Result<QPoWResult, ()> {
 		// Convert pre_hash to [u8; 32] for verification
-		// TODO normalize all the different ways we do calculations
 		let block_hash = pre_hash.as_ref().try_into().unwrap_or([0u8; 32]);
 
 		// Verify the nonce using runtime api
-		match self.client.runtime_api().submit_nonce(parent_hash, block_hash, nonce) {
-			Ok(true) => Ok(QPoWSeal { nonce }),
-			Ok(false) => Err(()),
+		match self.client.runtime_api().verify_current_block(parent_hash, block_hash, nonce, true) {
+			Ok((true, difficulty, distance_achieved)) => Ok(QPoWResult {
+				nonce,
+				difficulty: difficulty.to_big_endian(),
+				distance_achieved: distance_achieved.to_big_endian()
+			}),
+			Ok((false, _, _)) => Err(()),
 			Err(e) => {
 				log::error!("API error in verify_nonce: {:?}", e);
 				Err(())

--- a/node/src/external_miner_client.rs
+++ b/node/src/external_miner_client.rs
@@ -2,7 +2,6 @@ use primitive_types::{H256, U512};
 /// Functions to interact with the external miner service
 use reqwest::Client;
 use resonance_miner_api::{ApiResponseStatus, MiningRequest, MiningResponse, MiningResult};
-use sc_consensus_qpow::QPoWSeal; // Assuming QPoWSeal is here
 
 // Make functions pub(crate) or pub as needed
 pub(crate) async fn submit_mining_job(
@@ -45,7 +44,7 @@ pub(crate) async fn check_mining_result(
 	client: &Client,
 	miner_url: &str,
 	job_id: &str,
-) -> Result<Option<QPoWSeal>, String> {
+) -> Result<Option<[u8; 64]>, String> {
 	let response = client
 		.get(format!("{}/result/{}", miner_url, job_id))
 		.send()
@@ -65,7 +64,7 @@ pub(crate) async fn check_mining_result(
 				if nonce_bytes.len() == 64 {
 					let mut nonce = [0u8; 64];
 					nonce.copy_from_slice(&nonce_bytes);
-					Ok(Some(QPoWSeal { nonce }))
+					Ok(Some(nonce))
 				} else {
 					Err(format!(
 						"Invalid decoded work length: {} bytes (expected 64)",

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -3,7 +3,7 @@
 use futures::{FutureExt, StreamExt};
 use quantus_runtime::{self, apis::RuntimeApi, opaque::Block};
 use sc_client_api::Backend;
-use sc_consensus_qpow::{ChainManagement, QPoWMiner, QPoWSeal, QPowAlgorithm};
+use sc_consensus_qpow::{ChainManagement, QPoWMiner, QPoWResult, QPowAlgorithm};
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::{InPoolTransaction, OffchainTransactionPoolFactory, TransactionPool};
@@ -366,7 +366,7 @@ pub fn new_full<
 
 		task_manager.spawn_essential_handle().spawn("qpow-mining", None, async move {
 			log::info!("⛏️ QPoW Mining task spawned");
-			let mut nonce: U512 = U512::zero();
+			let mut nonce: U512 = U512::one();
 			let http_client = Client::new();
 			let mut current_job_id: Option<String> = None;
 
@@ -486,7 +486,7 @@ pub fn new_full<
 										worker_handle.submit(seal.encode()),
 									) {
 										log::info!("🥇Successfully mined and submitted a new block via external miner");
-										nonce = U512::zero();
+										nonce = U512::one();
 									} else {
 										log::warn!(
 											"⛏️Failed to submit mined block from external miner"
@@ -521,7 +521,7 @@ pub fn new_full<
 				} else {
 					// Local mining
 					let miner = QPoWMiner::new(client.clone());
-					let seal: QPoWSeal = match miner.try_nonce::<Block>(
+					let seal: QPoWResult = match miner.try_nonce::<Block>(
 						metadata.best_hash,
 						metadata.pre_hash,
 						nonce.to_big_endian(),
@@ -538,9 +538,9 @@ pub fn new_full<
 
 					let current_version = worker_handle.version();
 					if current_version == version {
-						if futures::executor::block_on(worker_handle.submit(seal.encode())) {
+						if futures::executor::block_on(worker_handle.submit(seal.nonce.encode())) {
 							log::info!("🥇Successfully mined and submitted a new block");
-							nonce = U512::zero();
+							nonce = U512::one();
 						} else {
 							log::warn!("⛏️Failed to submit mined block");
 							nonce += U512::one();

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -53,7 +53,7 @@ fn test_submit_valid_proof() {
 
 		// Submit an invalid proof
 		assert!(
-			!QPow::submit_nonce(header, invalid_nonce),
+			!QPow::verify_current_block(header, invalid_nonce, false),
 			"Nonce should be invalid with distance {} > threshold {}",
 			QPow::get_nonce_distance(header, invalid_nonce),
 			max_distance - distance_threshold
@@ -61,7 +61,7 @@ fn test_submit_valid_proof() {
 
 		// Submit a valid proof
 		assert!(
-			QPow::submit_nonce(header, valid_nonce),
+			QPow::verify_current_block(header, valid_nonce, false),
 			"Nonce should be valid with distance {} <= threshold {}",
 			QPow::get_nonce_distance(header, valid_nonce),
 			max_distance - distance_threshold
@@ -85,7 +85,7 @@ fn test_submit_valid_proof() {
 
 		if found_second {
 			// Submit the second valid proof
-			assert!(QPow::submit_nonce(header, second_valid));
+			assert!(QPow::verify_current_block(header, second_valid, false));
 			assert_eq!(QPow::latest_nonce(), Some(second_valid));
 		} else {
 			println!("Could not find second valid nonce, skipping that part of test");
@@ -96,7 +96,7 @@ fn test_submit_valid_proof() {
 }
 
 #[test]
-fn test_verify_for_import() {
+fn test_verify_current_block() {
 	new_test_ext().execute_with(|| {
 		// Set up test data
 		let header = [1u8; 32];
@@ -127,7 +127,7 @@ fn test_verify_for_import() {
 		assert!(found_valid, "Could not find valid nonce for testing. Adjust test parameters.");
 
 		// Now verify using the dynamically found valid nonce
-		assert!(QPow::verify_for_import(header, valid_nonce));
+		assert!(QPow::verify_current_block(header, valid_nonce, false));
 
 		// Check that the latest proof was stored
 		assert_eq!(QPow::latest_nonce(), Some(valid_nonce));
@@ -414,12 +414,9 @@ fn test_integrated_verification_flow() {
 		}
 
 		// 1. First, simulate mining by submitting a nonce
-		assert!(QPow::submit_nonce(header, nonce));
+		assert!(QPow::verify_current_block(header, nonce, false));
 
-		// 2. Then simulate block import verification
-		assert!(QPow::verify_for_import(header, nonce));
-
-		// 3. Finally verify historical block
+		// 2. Finally verify historical block
 		let current_block = System::block_number();
 		assert!(QPow::verify_historical_block(header, nonce, current_block));
 	});

--- a/primitives/consensus/qpow/src/lib.rs
+++ b/primitives/consensus/qpow/src/lib.rs
@@ -10,12 +10,6 @@ pub const QPOW_ENGINE_ID: [u8; 4] = *b"QPoW";
 
 sp_api::decl_runtime_apis! {
 	pub trait QPoWApi {
-		/// Verify a nonce for a block being imported from the network
-		fn verify_for_import(
-			header: [u8; 32],
-			nonce: [u8; 64],
-		) -> bool;
-
 		/// Verify a nonce for a historical block that's already in the chain
 		fn verify_historical_block(
 			header: [u8; 32],
@@ -23,11 +17,12 @@ sp_api::decl_runtime_apis! {
 			block_number: u32,
 		) -> bool;
 
-		/// Submit a locally mined nonce
-		fn submit_nonce(
+		/// Submit a block
+		fn verify_current_block(
 			header: [u8; 32],
 			nonce: [u8; 64],
-		) -> bool;
+			emit_event: bool
+		) -> (bool, U512, U512);
 
 		/// calculate distance header with nonce to with nonce
 		fn get_nonce_distance(

--- a/qpow-math/src/lib.rs
+++ b/qpow-math/src/lib.rs
@@ -24,6 +24,7 @@ pub fn get_nonce_distance(
 ) -> U512 {
 	// s = 0 is cheating
 	if nonce == [0u8; 64] {
+		log::debug!(target: "math", "zero nonce");
 		return U512::zero();
 	}
 
@@ -36,7 +37,10 @@ pub fn get_nonce_distance(
 	// Compare PoW results
 	let nonce_element = hash_to_group_bigint_sha(&header_int, &m, &n, &nonce_int);
 
-	target.bitxor(nonce_element)
+	let distance = target.bitxor(nonce_element);
+	log::debug!(target: "math", "distance = {}", distance);
+
+	distance
 }
 
 /// Generates a pair of RSA-style numbers (m,n) deterministically from input header

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -127,18 +127,14 @@ impl_runtime_apis! {
 
 	impl sp_consensus_qpow::QPoWApi<Block> for Runtime {
 
-		fn verify_for_import(header: [u8; 32], nonce: [u8; 64]) -> bool {
-			pallet_qpow::Pallet::<Self>::verify_for_import(header, nonce)
-		}
-
 		fn verify_historical_block(header: [u8; 32], nonce: [u8; 64], block_number: u32) -> bool {
 			// Convert u32 to the appropriate BlockNumber type used by your runtime
 			let block_number_param = block_number;
 			pallet_qpow::Pallet::<Self>::verify_historical_block(header, nonce, block_number_param)
 		}
 
-		fn submit_nonce(header: [u8; 32], nonce: [u8; 64]) -> bool {
-			pallet_qpow::Pallet::<Self>::submit_nonce(header, nonce)
+		fn verify_current_block(header: [u8; 32], nonce: [u8; 64], emit_event: bool) -> (bool, U512, U512) {
+			pallet_qpow::Pallet::<Self>::verify_current_block(header, nonce, emit_event)
 		}
 
 		fn get_max_reorg_depth() -> u32 {


### PR DESCRIPTION
- merge submit_nonce and verify_for_import into verify_current_block
- start nonce search at 1, not 0
- post_digests in header now contains difficulty, distance_achieved and seal in separate values

it's a little messy to return a 3-tuple in a runtime-api call, but the values we return are all intermediate values on the block verification, so we might as well return them all at once instead of recomputing them.