### PR TITLE
Automate release for v0.1.3-morbo-news

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8118,7 +8118,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.1.2"
+version = "0.1.3-morbo-news"
 dependencies = [
  "async-trait",
  "circuit-builder",
@@ -8179,7 +8179,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.1.1-nibbler-snack"
+version = "0.1.3-morbo-news"
 dependencies = [
  "dilithium-crypto",
  "env_logger 0.11.8",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quantus-node"
 description = "Quantus Node - Echo Chamber"
-version = "0.1.2"
+version = "0.1.3-morbo-news"
 license = "Apache-2.0"
 authors.workspace = true
 homepage.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.1.1-nibbler-snack"
+version = "0.1.3-morbo-news"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 106,
+	spec_version: 107,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.1.3-morbo-news.

https://github.com/Quantus-Network/chain/actions/runs/17067466868

Triggered by workflow run: patch

Type: 