### PR TITLE
Remove duplicate call to algorithm.verify

### DIFF
--- a/client/consensus/pow/src/worker.rs
+++ b/client/consensus/pow/src/worker.rs
@@ -139,30 +139,6 @@ where
 	/// Submit a mined seal. The seal will be validated again. Returns true if the submission is
 	/// successful.
 	pub async fn submit(&self, seal: Seal) -> bool {
-		if let Some(metadata) = self.metadata() {
-			let result = self.algorithm.verify(
-				&BlockId::Hash(metadata.best_hash),
-				&metadata.pre_hash,
-				metadata.pre_runtime.as_ref().map(|v| &v[..]),
-				&seal,
-				metadata.difficulty,
-			);
-			match result {
-				Ok((verified, _)) =>
-					if !verified {
-						warn!(target: LOG_TARGET, "Unable to import mined block: seal is invalid",);
-						return false;
-					},
-				Err(err) => {
-					warn!(target: LOG_TARGET, "Unable to import mined block: {}", err,);
-					return false;
-				},
-			}
-		} else {
-			warn!(target: LOG_TARGET, "Unable to import mined block: metadata does not exist",);
-			return false;
-		}
-
 		let build = if let Some(build) = {
 			let mut build = self.build.lock();
 			let value = build.take();


### PR DESCRIPTION
submit calls algorithm.verify, but later calls import_block which also calls algorithm.verify, so we just remove the first one, especially since it now generates an event

<img width="1191" height="272" alt="Screenshot 2025-08-21 at 10 35 07 AM" src="https://github.com/user-attachments/assets/a1b1fbd4-cc5f-4f78-b9c9-e213646fd63d" />
