### PR TITLE
Disallow most extrinsics on high security account

### DIFF
--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -85,11 +85,10 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 					dest,
 					value,
 				}) => (dest, value),
-				_ => {
+				_ =>
 					return Err(frame_support::pallet_prelude::TransactionValidityError::Invalid(
 						InvalidTransaction::Custom(1),
-					))
-				}
+					)),
 			};
 
 			// Schedule the transfer


### PR DESCRIPTION
Kind of a loophole - transfer all was still allowed, allowing someone to take out the entire balance from a high security account. 

Fix: Disallow this call. Not worth making it work with reversible. Just can't use it. 

Update: Just disallowing everything outside of balance transfer !
