### PR TITLE
Sync fix 2 final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 /vendor
 /scripts/apps
 /scripts/js/node_modules
+/test_data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9820,8 +9820,6 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae94e1d2003a4d6e069c95765005720aacca8c4e9fc9109cecbca281fd09848"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,9 +200,9 @@ substrate-wasm-builder = { version = "27.0.0", default-features = false }
 libp2p-identity = { git = "https://github.com/Quantus-Network/libp2p-identity-pqc" }
 libp2p-noise = { git = "https://github.com/Quantus-Network/libp2p-noise-pqc" }
 sc-network = { path = "./client/network" }
+sc-network-sync = { path = "./client/network/sync" }
 sp-state-machine = { path = "./primitives/state-machine" }
 sp-trie = { path = "./primitives/trie" }
-sc-network-sync = { path = "./client/network/sync" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ libp2p-noise = { git = "https://github.com/Quantus-Network/libp2p-noise-pqc" }
 sc-network = { path = "./client/network" }
 sp-state-machine = { path = "./primitives/state-machine" }
 sp-trie = { path = "./primitives/trie" }
+sc-network-sync = { path = "./client/network/sync" }
 
 [profile.release]
 opt-level = 3

--- a/client/network/src/protocol/message.rs
+++ b/client/network/src/protocol/message.rs
@@ -25,6 +25,7 @@ use sc_network_common::message::RequestId;
 
 /// Remote call response.
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[allow(dead_code)]
 pub struct RemoteCallResponse {
 	/// Id of a request this response was made for.
 	pub id: RequestId,
@@ -33,6 +34,7 @@ pub struct RemoteCallResponse {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[allow(dead_code)]
 /// Remote read response.
 pub struct RemoteReadResponse {
 	/// Id of a request this response was made for.
@@ -50,6 +52,7 @@ pub mod generic {
 
 	/// Consensus is mostly opaque to us
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	pub struct ConsensusMessage {
 		/// Identifies consensus engine.
 		pub protocol: ConsensusEngineId,
@@ -64,6 +67,7 @@ pub mod generic {
 	//
 	// and set MIN_VERSION to 6.
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	pub struct CompactStatus<Hash, Number> {
 		/// Protocol version.
 		pub version: u32,
@@ -81,6 +85,7 @@ pub mod generic {
 
 	/// Status sent on connection.
 	#[derive(Debug, PartialEq, Eq, Clone, Encode)]
+	#[allow(dead_code)]
 	pub struct Status<Hash, Number> {
 		/// Protocol version.
 		pub version: u32,
@@ -134,6 +139,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote call request.
 	pub struct RemoteCallRequest<H> {
 		/// Unique request id.
@@ -147,6 +153,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote storage read request.
 	pub struct RemoteReadRequest<H> {
 		/// Unique request id.
@@ -158,6 +165,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote storage read child request.
 	pub struct RemoteReadChildRequest<H> {
 		/// Unique request id.
@@ -171,6 +179,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote header request.
 	pub struct RemoteHeaderRequest<N> {
 		/// Unique request id.
@@ -180,6 +189,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote header response.
 	pub struct RemoteHeaderResponse<Header> {
 		/// Id of a request this response was made for.
@@ -191,6 +201,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote changes request.
 	pub struct RemoteChangesRequest<H> {
 		/// Unique request id.
@@ -211,6 +222,7 @@ pub mod generic {
 	}
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+	#[allow(dead_code)]
 	/// Remote changes response.
 	pub struct RemoteChangesResponse<N, H> {
 		/// Id of a request this response was made for.

--- a/client/network/sync/Cargo.toml
+++ b/client/network/sync/Cargo.toml
@@ -10,22 +10,22 @@
 # See Cargo.toml.orig for the original contents.
 
 [package]
-edition = "2021"
-name = "sc-network-sync"
-version = "0.50.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-build = "build.rs"
-autolib = false
+autobenches = false
 autobins = false
 autoexamples = false
+autolib = false
 autotests = false
-autobenches = false
+build = "build.rs"
 description = "Substrate sync network protocol"
-homepage = "https://paritytech.github.io/polkadot-sdk/"
 documentation = "https://docs.rs/sc-network-sync"
-readme = false
+edition = "2021"
+homepage = "https://paritytech.github.io/polkadot-sdk/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+name = "sc-network-sync"
+readme = false
 repository = "https://github.com/paritytech/polkadot-sdk.git"
+version = "0.50.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -35,8 +35,8 @@ name = "sc_network_sync"
 path = "src/lib.rs"
 
 [dependencies.array-bytes]
-version = "6.2.2"
 default-features = true
+version = "6.2.2"
 
 [dependencies.async-channel]
 version = "1.8.0"
@@ -45,98 +45,98 @@ version = "1.8.0"
 version = "0.1.88"
 
 [dependencies.codec]
-version = "3.7.5"
-features = ["derive"]
 default-features = true
+features = ["derive"]
 package = "parity-scale-codec"
+version = "3.7.5"
 
 [dependencies.fork-tree]
-version = "13.0.1"
 default-features = true
+version = "13.0.1"
 
 [dependencies.futures]
 version = "0.3.31"
 
 [dependencies.log]
-version = "0.4.22"
 default-features = true
+version = "0.4.22"
 
 [dependencies.mockall]
 version = "0.13.1"
 
 [dependencies.prometheus-endpoint]
-version = "0.17.2"
 default-features = true
 package = "substrate-prometheus-endpoint"
+version = "0.17.2"
 
 [dependencies.prost]
 version = "0.12.4"
 
 [dependencies.sc-client-api]
-version = "40.0.0"
 default-features = true
+version = "40.0.0"
 
 [dependencies.sc-consensus]
-version = "0.50.0"
 default-features = true
+version = "0.50.0"
 
 [dependencies.sc-network]
-version = "0.51.0"
 default-features = true
+version = "0.51.0"
 
 [dependencies.sc-network-common]
-version = "0.49.0"
 default-features = true
+version = "0.49.0"
 
 [dependencies.sc-network-types]
-version = "0.17.0"
 default-features = true
+version = "0.17.0"
 
 [dependencies.sc-utils]
-version = "19.0.0"
 default-features = true
+version = "19.0.0"
 
 [dependencies.schnellru]
 version = "0.2.3"
 
 [dependencies.smallvec]
-version = "1.11.0"
 default-features = true
+version = "1.11.0"
 
 [dependencies.sp-arithmetic]
-version = "27.0.0"
 default-features = true
+version = "27.0.0"
 
 [dependencies.sp-blockchain]
-version = "40.0.0"
 default-features = true
+version = "40.0.0"
 
 [dependencies.sp-consensus]
-version = "0.43.0"
 default-features = true
+version = "0.43.0"
 
 [dependencies.sp-consensus-grandpa]
-version = "24.0.0"
 default-features = true
+version = "24.0.0"
 
 [dependencies.sp-core]
-version = "37.0.0"
 default-features = true
+version = "37.0.0"
 
 [dependencies.sp-runtime]
-version = "42.0.0"
 default-features = true
+version = "42.0.0"
 
 [dependencies.thiserror]
 version = "1.0.64"
 
 [dependencies.tokio]
-version = "1.45.0"
-features = [
-    "macros",
-    "time",
-]
 default-features = true
+features = [
+	"macros",
+	"time",
+]
+version = "1.45.0"
 
 [dependencies.tokio-stream]
 version = "0.1.14"
@@ -145,8 +145,8 @@ version = "0.1.14"
 version = "0.13.1"
 
 [dev-dependencies.quickcheck]
-version = "1.0.3"
 default-features = false
+version = "1.0.3"
 
 [build-dependencies.prost-build]
 version = "0.13.2"
@@ -252,13 +252,13 @@ level = "allow"
 priority = 2
 
 [lints.rust.unexpected_cfgs]
+check-cfg = [
+	"cfg(enable_alloc_error_handler)",
+	"cfg(fuzzing)",
+	"cfg(ignore_flaky_test)",
+	"cfg(substrate_runtime)",
+	'cfg(build_opt_level, values("3"))',
+	'cfg(build_profile, values("debug", "release"))',
+]
 level = "warn"
 priority = 0
-check-cfg = [
-    'cfg(build_opt_level, values("3"))',
-    'cfg(build_profile, values("debug", "release"))',
-    "cfg(enable_alloc_error_handler)",
-    "cfg(fuzzing)",
-    "cfg(ignore_flaky_test)",
-    "cfg(substrate_runtime)",
-]

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -260,6 +260,8 @@ pub struct SyncingEngine<B: BlockT, Client> {
 
 	/// Handle to import queue.
 	import_queue: Box<dyn ImportQueueService<B>>,
+	/// Network failure counters per peer (timeouts, refused, etc.).
+	peer_failures: HashMap<PeerId, u32>,
 }
 
 impl<B: BlockT, Client> SyncingEngine<B, Client>
@@ -406,6 +408,7 @@ where
 				},
 				pending_responses: PendingResponses::new(),
 				import_queue,
+				peer_failures: HashMap::new(),
 			},
 			SyncingService::new(tx, num_connected, is_major_syncing),
 			block_announce_config,
@@ -717,6 +720,10 @@ where
 			},
 			ToServiceCommand::OnBlockFinalized(hash, header) =>
 				self.strategy.on_block_finalized(&hash, *header.number()),
+			ToServiceCommand::SetMaxTimeoutsBeforeDrop(value) => {
+				self.strategy.set_peer_drop_threshold(value);
+			},
+
 		}
 	}
 

--- a/client/network/sync/src/justification_requests.rs
+++ b/client/network/sync/src/justification_requests.rs
@@ -137,7 +137,7 @@ impl<B: BlockT> ExtraRequests<B> {
 
 	/// Returns an iterator-like struct that yields peers which extra
 	/// requests can be sent to.
-	pub(crate) fn matcher(&mut self) -> Matcher<B> {
+	pub(crate) fn matcher(&mut self) -> Matcher<'_, B> {
 		Matcher::new(self)
 	}
 

--- a/client/network/sync/src/service/syncing_service.rs
+++ b/client/network/sync/src/service/syncing_service.rs
@@ -54,6 +54,7 @@ pub enum ToServiceCommand<B: BlockT> {
 	NumSyncRequests(oneshot::Sender<usize>),
 	PeersInfo(oneshot::Sender<Vec<(PeerId, ExtendedPeerInfo<B>)>>),
 	OnBlockFinalized(B::Hash, B::Header),
+	SetMaxTimeoutsBeforeDrop(u32),
 	// Status {
 	// 	pending_response: oneshot::Sender<SyncStatus<B>>,
 	// },
@@ -106,6 +107,11 @@ impl<B: BlockT> SyncingService<B> {
 		let _ = self.tx.unbounded_send(ToServiceCommand::NumSyncRequests(tx));
 
 		rx.await
+	}
+
+	/// Update the maximum timeouts threshold before dropping peers (runtime adjustable).
+	pub fn set_max_timeouts_before_drop(&self, value: u32) {
+		let _ = self.tx.unbounded_send(ToServiceCommand::SetMaxTimeoutsBeforeDrop(value));
 	}
 
 	/// Get peer information.

--- a/client/network/sync/src/strategy.rs
+++ b/client/network/sync/src/strategy.rs
@@ -28,6 +28,7 @@ pub mod polkadot;
 pub mod state;
 pub mod state_sync;
 pub mod warp;
+use crate::LOG_TARGET;
 
 use crate::{
 	pending_responses::ResponseFuture,
@@ -136,10 +137,12 @@ where
 
 	/// Peer drop threshold during major sync (timeouts before drop/report).
 	/// Set to 0 to have the old behavior, instant peer drop on timeout.
-	fn peer_drop_threshold(&self) -> u32;
+	fn peer_drop_threshold(&self) -> u32 { 0 }
 
 	/// Update peer drop threshold (runtime adjustable via CLI wiring).
-	fn set_peer_drop_threshold(&mut self, _value: u32);
+	fn set_peer_drop_threshold(&mut self, _value: u32) { 
+		log::info!(target: LOG_TARGET, "set_peer_drop_threshold not implemented for this strategy") 
+	}
 
 	/// Get actions that should be performed by the owner on the strategy's behalf
 	#[must_use]
@@ -220,7 +223,7 @@ impl<B: BlockT> SyncingAction<B> {
 	pub fn is_finished(&self) -> bool {
 		matches!(self, SyncingAction::Finished)
 	}
-
+	#[allow(dead_code)]
 	pub(crate) fn name(&self) -> &'static str {
 		match self {
 			Self::StartRequest { .. } => "StartRequest",

--- a/client/network/sync/src/strategy/chain_sync.rs
+++ b/client/network/sync/src/strategy/chain_sync.rs
@@ -1964,7 +1964,7 @@ where
 						state: AncestorSearchState::ExponentialBackoff(One::one()),
 					};
 					Some((id, ancestry_request::<B>(current)))
-				} else if let Some((range, req)) = peer_block_request(
+				} else if let Some((range, mut req)) = peer_block_request(
 					&id,
 					peer,
 					blocks,

--- a/client/network/sync/src/strategy/chain_sync.rs
+++ b/client/network/sync/src/strategy/chain_sync.rs
@@ -865,7 +865,7 @@ where
 
 	fn on_request_failed(&mut self, peer_id: &PeerId) {
 		// When a request fails, allow issuing new requests immediately and free any held slots.
-		debug!(target: LOG_TARGET, "received on_request_failed for {:?} has peer: {:?}", peer_id, self.peers.get_mut(peer_id));
+		debug!(target: LOG_TARGET, "received on_request_failed for {:?}", peer_id);
 
 		if let Some(peer) = self.peers.get_mut(peer_id) {
 			debug!(

--- a/dilithium-crypto/src/types.rs
+++ b/dilithium-crypto/src/types.rs
@@ -7,8 +7,6 @@ use sp_core::{
 	crypto::{PublicBytes, SignatureBytes},
 	ByteArray, RuntimeDebug,
 };
-#[cfg(feature = "std")]
-use thiserror::Error;
 
 /// Resonance Crypto Types
 ///

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -27,6 +27,10 @@ pub struct Cli {
 	/// Enable peer sharing via RPC endpoint
 	#[arg(long)]
 	pub enable_peer_sharing: bool,
+
+	/// Sync: maximum timeouts before dropping a peer during major sync.
+	#[arg(long, value_name = "MAX_TIMEOUTS_BEFORE_DROP", default_value_t = 10)]
+	pub sync_max_timeouts_before_drop: u32,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -48,7 +48,7 @@ pub mod pallet {
 		traits::{Saturating, Zero},
 		Perbill,
 	};
-	use wormhole_circuit::inputs::{PublicCircuitInputs, PUBLIC_INPUTS_FELTS_LEN};
+	use wormhole_circuit::inputs::PublicCircuitInputs;
 	use wormhole_verifier::ProofWithPublicInputs;
 	use zk_circuits_common::circuit::{C, D, F};
 


### PR DESCRIPTION
Note: Compare with branch sync-fix-2 to see the delta in the sync engine code. 

# What issue does this fix

We noticed that nodes where the network is bad fail to sync - the sync stalls and miners have to just reset everything and try again

It was a common occurrence in the chat, and also our own testing

## Causes of the stall
- A good network connection would cover up the issue - no problems
- On a bad connection, even moderately bad, two things would happen:
- 1. The client would make multiple requests on the exact same block range to the remote peer, leading to a ban from the remote peer after 2 attempts. 
- 2. The client itself would ban the remote peer after a timeout during fetch, meaning it would remove that peer from the list and not try it again for a while, successive fails would keep increasing the timespan of the ban. The ban is persisted through restarts which is why users had to wipe the data directory to make the sync start again

## Fix 

### Overview 

1. Don't drop or report peers during a major sync

New CLI parameter: **--sync-max-timeouts-before-drop** defaults to 10. Set to 0 to disable the feature. 

2. Don't make the same request twice so the remote peer does not ban us. 

### Implementation 

- Adaptive smaller requests on failed requests
- No duplicated requests so the remote peer doesn't ban us
- Only enabled in major sync mode so it doesn't interfere with normal operations
- Allowing peers a number of failures before reporting or banning them
- It now blasts through bad connections and gets them at some point

### Safety
This fix is client side only - only a peer that is in major syncing is affected. No effect on network as a whole, during operations. 

## The Sync Engine

The sync engine is complex, it works similar to bit torrent, trying to get all blocks in a range before importing them, repeating requests and sizing and adjusting requests based on the blocks we did get in requests - a request for 64 blocks would for example load less than 64 - the client stores this information, and makes successive request to load the rest; all this is already in the sync engine. Understanding how it works is required for a fix.

On the remote peer side a maximum of 8MB for a single request is enforced (hard coded) , so if blocks add up to more than 8MB, we get fewer. 

But in our test that was not the issue, the issue was that we could not handle larger requests than a few MB on a bad connection without timing out and mutual peer banning. 


