### PR TITLE
handle bootstrap kademlia event

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -1017,6 +1017,19 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 							e.key(), e,
 						),
 					},
+					KademliaEvent::OutboundQueryProgressed {
+						result: QueryResult::Bootstrap(res),
+						..
+					} => {
+						match res {
+							Ok(ok) => debug!(
+								target: "sub-libp2p",
+								"Libp2p => Bootstrap completed with peer {} and {} remaining",
+								ok.peer, ok.num_remaining
+							),
+							Err(e) => warn!(target: "sub-libp2p", "Libp2p => Bootstrap failed: {:?}", e),
+						}
+					},
 					// We never start any other type of query.
 					KademliaEvent::OutboundQueryProgressed { result: e, .. } => {
 						warn!(target: "sub-libp2p", "Libp2p => Unhandled Kademlia event: {:?}", e)

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -1020,15 +1020,14 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 					KademliaEvent::OutboundQueryProgressed {
 						result: QueryResult::Bootstrap(res),
 						..
-					} => {
-						match res {
-							Ok(ok) => debug!(
-								target: "sub-libp2p",
-								"Libp2p => Bootstrap completed with peer {} and {} remaining",
-								ok.peer, ok.num_remaining
-							),
-							Err(e) => warn!(target: "sub-libp2p", "Libp2p => Bootstrap failed: {:?}", e),
-						}
+					} => match res {
+						Ok(ok) => debug!(
+							target: "sub-libp2p",
+							"Libp2p => Bootstrap completed with peer {} and {} remaining",
+							ok.peer, ok.num_remaining
+						),
+						Err(e) =>
+							warn!(target: "sub-libp2p", "Libp2p => Bootstrap failed: {:?}", e),
 					},
 					// We never start any other type of query.
 					KademliaEvent::OutboundQueryProgressed { result: e, .. } => {


### PR DESCRIPTION
**Which error does this fix:**

I saw this in the logs:
2025-09-15 15:45:29.755  WARN tokio-runtime-worker sub-libp2p: Libp2p => Unhandled Kademlia event: Bootstrap(Ok(BootstrapOk { peer: PeerId("QmXiDfQWXthqz66Wa3SiqkytutNd3FDBBhFLTsR9JX73eR"), num_remaining: 2 }))    

Added the fix which is the same code that's in the latest sc-network in polkadot. 

**From the description:**

The bootstrap query is initiated in the **libp2p-kad crate's `Behaviour::bootstrap()` method** (around line 946 in `behaviour.rs`). Here's the exact code that starts the bootstrap query:

```rust
pub fn bootstrap(&mut self) -> Result<QueryId, NoKnownPeers> {
    let local_key = *self.kbuckets.local_key();
    let info = QueryInfo::Bootstrap {
        peer: *local_key.preimage(),
        remaining: None,
        step: ProgressStep::first(),
    };
    let peers = self.kbuckets.closest_keys(&local_key).collect::<Vec<_>>();
    if peers.is_empty() {
        self.bootstrap_status.reset_timers();
        Err(NoKnownPeers())
    } else {
        self.bootstrap_status.on_started();
        Ok(self.queries.add_iter_closest(local_key, peers, info))
    }
}
```

## How Bootstrap Works

1. **Query Initiation**: The bootstrap starts by targeting the **local node's own peer ID** as the lookup key
2. **FIND_NODE Requests**: It sends `FIND_NODE` requests to known peers asking "who are the peers closest to my own ID?"
3. **Routing Table Population**: The responses populate the local routing table with peers closer to the local node
4. **Bucket Refresh**: After the initial self-lookup, it may perform additional queries for random keys in distant buckets to ensure full routing table coverage

## When Bootstrap Is Triggered

The bootstrap query can be initiated in several ways:

- **Manual**: By calling `Behaviour::bootstrap()` directly
- **Periodic**: Via the `bootstrap_status` timer (configured with `Config::set_periodic_bootstrap_interval`)
- **Automatic**: When new peers are added to the routing table (via `bootstrap_status.trigger()`)

## Query Execution Flow

1. `Behaviour::bootstrap()` creates a `QueryInfo::Bootstrap` 
2. `queries.add_iter_closest()` starts an iterative query
3. The query sends `FIND_NODE` requests to known peers
4. Responses are processed, updating the routing table
5. When the query completes, it generates the `QueryResult::Bootstrap` event that bubbles up through your Substrate code

The bootstrap is **not initiated by other nodes** - it's a local operation your node performs to discover and connect to the peer-to-peer network. The event you see is the result of your node's own bootstrap query completing successfully.