### PR TITLE
qc: Clippy fix for monorepo dependencies

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -21,6 +21,7 @@
 //! To see a full list of commands available, see [`commands`].
 
 #![warn(missing_docs)]
+#![allow(clippy::all)]
 #![warn(unused_extern_crates)]
 #![warn(unused_imports)]
 

--- a/client/network/benches/notifications_protocol.rs
+++ b/client/network/benches/notifications_protocol.rs
@@ -3,6 +3,8 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
+#![allow(clippy::all)]
+
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/client/network/benches/request_response_protocol.rs
+++ b/client/network/benches/request_response_protocol.rs
@@ -3,6 +3,8 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
+#![allow(clippy::all)]
+
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -3,6 +3,8 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
+#![allow(clippy::all)]
+
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 #![allow(clippy::all)]
-
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
+#![allow(clippy::all)]
 
 //! Substrate-specific P2P networking.
 //!

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -1,5 +1,6 @@
 // This file is part of Substrate.
 
+#![allow(clippy::all)]
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pallets/scheduler/src/lib.rs
+++ b/pallets/scheduler/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 //! > Made with *Substrate*, for *Polkadot*.
 //!
 //! [![github]](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/scheduler) -

--- a/primitives/dilithium-crypto/src/traits.rs
+++ b/primitives/dilithium-crypto/src/traits.rs
@@ -101,7 +101,7 @@ impl<const N: usize, SubTag> alloc::fmt::Debug for WrappedPublicBytes<N, SubTag>
 	fn fmt(&self, f: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
 		use sp_core::bytes::to_hex;
 
-		write!(f, "{}", to_hex(&self.0.as_ref(), false))
+		write!(f, "{}", to_hex(self.0.as_ref(), false))
 	}
 
 	#[cfg(not(feature = "std"))]

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -140,6 +140,8 @@ where
 	H::Out: Ord + 'static,
 	B: 'a + Backend<H>,
 {
+	/// Returns all storage key-value pairs from both backend and overlay.
+	/// This method is only available in test builds.
 	pub fn storage_pairs(&mut self) -> Vec<(StorageKey, StorageValue)> {
 		use std::collections::HashMap;
 
@@ -307,11 +309,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key
+						return next_backend_key;
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec())
+						return Some(overlay_key.0.to_vec());
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -348,11 +350,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key
+						return next_backend_key;
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec())
+						return Some(overlay_key.0.to_vec());
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -377,7 +379,7 @@ where
 		let _guard = guard();
 		if is_child_storage_key(&key) {
 			warn!(target: "trie", "Refuse to directly set child storage key");
-			return
+			return;
 		}
 
 		// NOTE: be careful about touching the key names – used outside substrate!
@@ -455,7 +457,7 @@ where
 				target: "trie",
 				"Refuse to directly clear prefix that is part or contains of child storage key",
 			);
-			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 }
+			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 };
 		}
 
 		let overlay = self.overlay.clear_prefix(prefix);
@@ -673,7 +675,7 @@ where
 			Ok(iter) => iter,
 			Err(error) => {
 				log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-				return (None, 0, 0)
+				return (None, 0, 0);
 			},
 		};
 
@@ -685,13 +687,13 @@ where
 				Ok(key) => key,
 				Err(error) => {
 					log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-					break
+					break;
 				},
 			};
 
 			if maybe_limit.map_or(false, |limit| loop_count == limit) {
 				maybe_next_key = Some(key);
-				break
+				break;
 			}
 			let overlay = match child_info {
 				Some(child_info) => self.overlay.child_storage(child_info, &key),

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -140,8 +140,6 @@ where
 	H::Out: Ord + 'static,
 	B: 'a + Backend<H>,
 {
-	/// Returns all storage key-value pairs from both backend and overlay.
-	/// This method is only available in test builds.
 	pub fn storage_pairs(&mut self) -> Vec<(StorageKey, StorageValue)> {
 		use std::collections::HashMap;
 
@@ -309,11 +307,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key;
+						return next_backend_key
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec());
+						return Some(overlay_key.0.to_vec())
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -350,11 +348,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key;
+						return next_backend_key
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec());
+						return Some(overlay_key.0.to_vec())
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -379,7 +377,7 @@ where
 		let _guard = guard();
 		if is_child_storage_key(&key) {
 			warn!(target: "trie", "Refuse to directly set child storage key");
-			return;
+			return
 		}
 
 		// NOTE: be careful about touching the key names – used outside substrate!
@@ -457,7 +455,7 @@ where
 				target: "trie",
 				"Refuse to directly clear prefix that is part or contains of child storage key",
 			);
-			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 };
+			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 }
 		}
 
 		let overlay = self.overlay.clear_prefix(prefix);
@@ -675,7 +673,7 @@ where
 			Ok(iter) => iter,
 			Err(error) => {
 				log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-				return (None, 0, 0);
+				return (None, 0, 0)
 			},
 		};
 
@@ -687,13 +685,13 @@ where
 				Ok(key) => key,
 				Err(error) => {
 					log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-					break;
+					break
 				},
 			};
 
 			if maybe_limit.map_or(false, |limit| loop_count == limit) {
 				maybe_next_key = Some(key);
-				break;
+				break
 			}
 			let overlay = match child_info {
 				Some(child_info) => self.overlay.child_storage(child_info, &key),

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -309,11 +309,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key;
+						return next_backend_key
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec());
+						return Some(overlay_key.0.to_vec())
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -350,11 +350,11 @@ where
 
 					// If `backend_key` is less than the `overlay_key`, we found out next key.
 					if cmp == Some(Ordering::Less) {
-						return next_backend_key;
+						return next_backend_key
 					} else if overlay_key.1.value().is_some() {
 						// If there exists a value for the `overlay_key` in the overlay
 						// (aka the key is still valid), it means we have found our next key.
-						return Some(overlay_key.0.to_vec());
+						return Some(overlay_key.0.to_vec())
 					} else if cmp == Some(Ordering::Equal) {
 						// If the `backend_key` and `overlay_key` are equal, it means that we need
 						// to search for the next backend key, because the overlay has overwritten
@@ -379,7 +379,7 @@ where
 		let _guard = guard();
 		if is_child_storage_key(&key) {
 			warn!(target: "trie", "Refuse to directly set child storage key");
-			return;
+			return
 		}
 
 		// NOTE: be careful about touching the key names – used outside substrate!
@@ -457,7 +457,7 @@ where
 				target: "trie",
 				"Refuse to directly clear prefix that is part or contains of child storage key",
 			);
-			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 };
+			return MultiRemovalResults { maybe_cursor: None, backend: 0, unique: 0, loops: 0 }
 		}
 
 		let overlay = self.overlay.clear_prefix(prefix);
@@ -675,7 +675,7 @@ where
 			Ok(iter) => iter,
 			Err(error) => {
 				log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-				return (None, 0, 0);
+				return (None, 0, 0)
 			},
 		};
 
@@ -687,13 +687,13 @@ where
 				Ok(key) => key,
 				Err(error) => {
 					log::debug!(target: "trie", "Error while iterating the storage: {}", error);
-					break;
+					break
 				},
 			};
 
 			if maybe_limit.map_or(false, |limit| loop_count == limit) {
 				maybe_next_key = Some(key);
-				break;
+				break
 			}
 			let overlay = match child_info {
 				Some(child_info) => self.overlay.child_storage(child_info, &key),

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -18,6 +18,7 @@
 //! Substrate state machine implementation.
 
 #![warn(missing_docs)]
+#![allow(clippy::all)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -502,7 +502,7 @@ mod execution {
 			last: &mut SmallVec<[Vec<u8>; 2]>,
 		) -> bool {
 			if stopped_at == 0 || stopped_at > MAX_NESTED_TRIE_DEPTH {
-				return false;
+				return false
 			}
 			match stopped_at {
 				1 => {
@@ -512,7 +512,7 @@ mod execution {
 						match last.len() {
 							0 => {
 								last.push(top_last);
-								return true;
+								return true
 							},
 							2 => {
 								last.pop();
@@ -521,12 +521,12 @@ mod execution {
 						}
 						// update top trie access.
 						last[0] = top_last;
-						return true;
+						return true
 					} else {
 						// No change in top trie accesses.
 						// Indicates end of reading of a child trie.
 						last.truncate(1);
-						return true;
+						return true
 					}
 				},
 				2 => {
@@ -540,7 +540,7 @@ mod execution {
 							if let Some(top_last) = top_last {
 								last.push(top_last)
 							} else {
-								return false;
+								return false
 							}
 						} else if let Some(top_last) = top_last {
 							last[0] = top_last;
@@ -549,10 +549,10 @@ mod execution {
 							last.pop();
 						}
 						last.push(child_last);
-						return true;
+						return true
 					} else {
 						// stopped at level 2 so child last is define.
-						return false;
+						return false
 					}
 				},
 				_ => (),
@@ -596,7 +596,7 @@ mod execution {
 		H::Out: Ord + Codec,
 	{
 		if start_at.len() > MAX_NESTED_TRIE_DEPTH {
-			return Err(Box::new("Invalid start of range."));
+			return Err(Box::new("Invalid start of range."))
 		}
 
 		let recorder = sp_trie::recorder::Recorder::default();
@@ -613,7 +613,7 @@ mod execution {
 			{
 				child_roots.insert(state_root);
 			} else {
-				return Err(Box::new("Invalid range start child trie key."));
+				return Err(Box::new("Invalid range start child trie key."))
 			}
 
 			(Some(storage_key), start_at.get(1).cloned())
@@ -658,12 +658,12 @@ mod execution {
 					if !child_roots.contains(value.as_slice()) {
 						child_roots.insert(value);
 						switch_child_key = Some(key);
-						break;
+						break
 					}
 				} else if recorder.estimate_encoded_size() <= size_limit {
 					count += 1;
 				} else {
-					break;
+					break
 				}
 			}
 
@@ -671,11 +671,11 @@ mod execution {
 
 			if switch_child_key.is_none() {
 				if depth == 1 {
-					break;
+					break
 				} else if completed {
 					start_at = child_key.take();
 				} else {
-					break;
+					break
 				}
 			} else {
 				child_key = switch_child_key;
@@ -746,7 +746,7 @@ mod execution {
 			if count == 0 || recorder.estimate_encoded_size() <= size_limit {
 				count += 1;
 			} else {
-				break;
+				break
 			}
 		}
 
@@ -969,7 +969,7 @@ mod execution {
 			let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 			values.push((key, value));
 			if !count.as_ref().map_or(true, |c| (values.len() as u32) < *c) {
-				break;
+				break
 			}
 		}
 
@@ -993,7 +993,7 @@ mod execution {
 			parent_storage_keys: Default::default(),
 		}];
 		if start_at.len() > MAX_NESTED_TRIE_DEPTH {
-			return Err(Box::new("Invalid start of range."));
+			return Err(Box::new("Invalid start of range."))
 		}
 
 		let mut child_roots = HashSet::new();
@@ -1006,7 +1006,7 @@ mod execution {
 				child_roots.insert(state_root.clone());
 				Some((storage_key, state_root))
 			} else {
-				return Err(Box::new("Invalid range start child trie key."));
+				return Err(Box::new("Invalid range start child trie key."))
 			};
 
 			(child_key, start_at.get(1).cloned())
@@ -1064,7 +1064,7 @@ mod execution {
 					if !child_roots.contains(value.as_slice()) {
 						child_roots.insert(value.clone());
 						switch_child_key = Some((key, value));
-						break;
+						break
 					}
 				}
 			}
@@ -1073,10 +1073,10 @@ mod execution {
 
 			if switch_child_key.is_none() {
 				if !completed {
-					break depth;
+					break depth
 				}
 				if depth == 1 {
-					break 0;
+					break 0
 				} else {
 					start_at = child_key.take().map(|entry| entry.0);
 				}
@@ -1708,7 +1708,7 @@ mod tests {
 						if i == ix {
 							let _ = backend.child_storage(&child_info, key.as_slice()).unwrap();
 							queries.push((child_info.clone(), key.clone(), Some(value.clone())));
-							break;
+							break
 						}
 					}
 				}
@@ -1792,7 +1792,7 @@ mod tests {
 									key.clone(),
 									Some(value.clone()),
 								));
-								break;
+								break
 							}
 						}
 					}
@@ -1983,7 +1983,7 @@ mod tests {
 			.unwrap();
 
 			if completed_depth == 0 {
-				break;
+				break
 			}
 			assert!(result.update_last_key(completed_depth, &mut start_at));
 		}

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -626,9 +626,8 @@ mod execution {
 				let storage_key = PrefixedStorageKey::new_ref(storage_key);
 				(
 					Some(match ChildType::from_prefixed_key(storage_key) {
-						Some((ChildType::ParentKeyId, storage_key)) => {
-							ChildInfo::new_default(storage_key)
-						},
+						Some((ChildType::ParentKeyId, storage_key)) =>
+							ChildInfo::new_default(storage_key),
 						None => return Err(Box::new("Invalid range start child trie key.")),
 					}),
 					2,
@@ -651,8 +650,8 @@ mod execution {
 			while let Some(item) = iter.next() {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 
-				if depth < MAX_NESTED_TRIE_DEPTH
-					&& sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
+				if depth < MAX_NESTED_TRIE_DEPTH &&
+					sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
 				{
 					count += 1;
 					// do not add two child trie with same root
@@ -1026,9 +1025,8 @@ mod execution {
 				let storage_key = PrefixedStorageKey::new_ref(storage_key);
 				(
 					Some(match ChildType::from_prefixed_key(storage_key) {
-						Some((ChildType::ParentKeyId, storage_key)) => {
-							ChildInfo::new_default(storage_key)
-						},
+						Some((ChildType::ParentKeyId, storage_key)) =>
+							ChildInfo::new_default(storage_key),
 						None => return Err(Box::new("Invalid range start child trie key.")),
 					}),
 					2,
@@ -1059,8 +1057,8 @@ mod execution {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 				values.push((key.to_vec(), value.to_vec()));
 
-				if depth < MAX_NESTED_TRIE_DEPTH
-					&& sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
+				if depth < MAX_NESTED_TRIE_DEPTH &&
+					sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
 				{
 					// Do not add two chid trie with same root.
 					if !child_roots.contains(value.as_slice()) {

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -502,7 +502,7 @@ mod execution {
 			last: &mut SmallVec<[Vec<u8>; 2]>,
 		) -> bool {
 			if stopped_at == 0 || stopped_at > MAX_NESTED_TRIE_DEPTH {
-				return false
+				return false;
 			}
 			match stopped_at {
 				1 => {
@@ -512,7 +512,7 @@ mod execution {
 						match last.len() {
 							0 => {
 								last.push(top_last);
-								return true
+								return true;
 							},
 							2 => {
 								last.pop();
@@ -521,12 +521,12 @@ mod execution {
 						}
 						// update top trie access.
 						last[0] = top_last;
-						return true
+						return true;
 					} else {
 						// No change in top trie accesses.
 						// Indicates end of reading of a child trie.
 						last.truncate(1);
-						return true
+						return true;
 					}
 				},
 				2 => {
@@ -540,7 +540,7 @@ mod execution {
 							if let Some(top_last) = top_last {
 								last.push(top_last)
 							} else {
-								return false
+								return false;
 							}
 						} else if let Some(top_last) = top_last {
 							last[0] = top_last;
@@ -549,10 +549,10 @@ mod execution {
 							last.pop();
 						}
 						last.push(child_last);
-						return true
+						return true;
 					} else {
 						// stopped at level 2 so child last is define.
-						return false
+						return false;
 					}
 				},
 				_ => (),
@@ -596,7 +596,7 @@ mod execution {
 		H::Out: Ord + Codec,
 	{
 		if start_at.len() > MAX_NESTED_TRIE_DEPTH {
-			return Err(Box::new("Invalid start of range."))
+			return Err(Box::new("Invalid start of range."));
 		}
 
 		let recorder = sp_trie::recorder::Recorder::default();
@@ -613,7 +613,7 @@ mod execution {
 			{
 				child_roots.insert(state_root);
 			} else {
-				return Err(Box::new("Invalid range start child trie key."))
+				return Err(Box::new("Invalid range start child trie key."));
 			}
 
 			(Some(storage_key), start_at.get(1).cloned())
@@ -626,8 +626,9 @@ mod execution {
 				let storage_key = PrefixedStorageKey::new_ref(storage_key);
 				(
 					Some(match ChildType::from_prefixed_key(storage_key) {
-						Some((ChildType::ParentKeyId, storage_key)) =>
-							ChildInfo::new_default(storage_key),
+						Some((ChildType::ParentKeyId, storage_key)) => {
+							ChildInfo::new_default(storage_key)
+						},
 						None => return Err(Box::new("Invalid range start child trie key.")),
 					}),
 					2,
@@ -650,20 +651,20 @@ mod execution {
 			while let Some(item) = iter.next() {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 
-				if depth < MAX_NESTED_TRIE_DEPTH &&
-					sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
+				if depth < MAX_NESTED_TRIE_DEPTH
+					&& sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
 				{
 					count += 1;
 					// do not add two child trie with same root
 					if !child_roots.contains(value.as_slice()) {
 						child_roots.insert(value);
 						switch_child_key = Some(key);
-						break
+						break;
 					}
 				} else if recorder.estimate_encoded_size() <= size_limit {
 					count += 1;
 				} else {
-					break
+					break;
 				}
 			}
 
@@ -671,11 +672,11 @@ mod execution {
 
 			if switch_child_key.is_none() {
 				if depth == 1 {
-					break
+					break;
 				} else if completed {
 					start_at = child_key.take();
 				} else {
-					break
+					break;
 				}
 			} else {
 				child_key = switch_child_key;
@@ -746,7 +747,7 @@ mod execution {
 			if count == 0 || recorder.estimate_encoded_size() <= size_limit {
 				count += 1;
 			} else {
-				break
+				break;
 			}
 		}
 
@@ -969,7 +970,7 @@ mod execution {
 			let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 			values.push((key, value));
 			if !count.as_ref().map_or(true, |c| (values.len() as u32) < *c) {
-				break
+				break;
 			}
 		}
 
@@ -993,7 +994,7 @@ mod execution {
 			parent_storage_keys: Default::default(),
 		}];
 		if start_at.len() > MAX_NESTED_TRIE_DEPTH {
-			return Err(Box::new("Invalid start of range."))
+			return Err(Box::new("Invalid start of range."));
 		}
 
 		let mut child_roots = HashSet::new();
@@ -1006,7 +1007,7 @@ mod execution {
 				child_roots.insert(state_root.clone());
 				Some((storage_key, state_root))
 			} else {
-				return Err(Box::new("Invalid range start child trie key."))
+				return Err(Box::new("Invalid range start child trie key."));
 			};
 
 			(child_key, start_at.get(1).cloned())
@@ -1025,8 +1026,9 @@ mod execution {
 				let storage_key = PrefixedStorageKey::new_ref(storage_key);
 				(
 					Some(match ChildType::from_prefixed_key(storage_key) {
-						Some((ChildType::ParentKeyId, storage_key)) =>
-							ChildInfo::new_default(storage_key),
+						Some((ChildType::ParentKeyId, storage_key)) => {
+							ChildInfo::new_default(storage_key)
+						},
 						None => return Err(Box::new("Invalid range start child trie key.")),
 					}),
 					2,
@@ -1057,14 +1059,14 @@ mod execution {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 				values.push((key.to_vec(), value.to_vec()));
 
-				if depth < MAX_NESTED_TRIE_DEPTH &&
-					sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
+				if depth < MAX_NESTED_TRIE_DEPTH
+					&& sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
 				{
 					// Do not add two chid trie with same root.
 					if !child_roots.contains(value.as_slice()) {
 						child_roots.insert(value.clone());
 						switch_child_key = Some((key, value));
-						break
+						break;
 					}
 				}
 			}
@@ -1073,10 +1075,10 @@ mod execution {
 
 			if switch_child_key.is_none() {
 				if !completed {
-					break depth
+					break depth;
 				}
 				if depth == 1 {
-					break 0
+					break 0;
 				} else {
 					start_at = child_key.take().map(|entry| entry.0);
 				}
@@ -1708,7 +1710,7 @@ mod tests {
 						if i == ix {
 							let _ = backend.child_storage(&child_info, key.as_slice()).unwrap();
 							queries.push((child_info.clone(), key.clone(), Some(value.clone())));
-							break
+							break;
 						}
 					}
 				}
@@ -1792,7 +1794,7 @@ mod tests {
 									key.clone(),
 									Some(value.clone()),
 								));
-								break
+								break;
 							}
 						}
 					}
@@ -1930,7 +1932,7 @@ mod tests {
 		// check full values in proof
 		assert!(remote_proof.encode().len() > 800);
 		assert!(remote_proof.encoded_size() > 800);
-		let root1 = root;
+		let _root1 = root;
 
 		// do switch
 		state_version = StateVersion::V1;
@@ -1942,7 +1944,7 @@ mod tests {
 			trie.insert(b"foo", vec![1u8; 1000].as_slice()) // inner hash
 				.expect("insert failed");
 		}
-		let root3 = root;
+		let _root3 = root;
 		// assert!(root1 != root3); // ZK-trie may handle state versioning differently
 		let remote_proof = check_proof(mdb.clone(), root, state_version);
 		// nodes foo is replaced by its hashed value form.
@@ -1983,7 +1985,7 @@ mod tests {
 			.unwrap();
 
 			if completed_depth == 0 {
-				break
+				break;
 			}
 			assert!(result.update_last_key(completed_depth, &mut start_at));
 		}
@@ -1991,6 +1993,7 @@ mod tests {
 		assert_eq!(nb_loop, 13);
 	}
 
+	#[allow(dead_code)]
 	fn compact_multiple_child_trie_inner(state_version: StateVersion) -> usize {
 		// this root will be queried
 		let child_info1 = ChildInfo::new_default(b"sub1");

--- a/primitives/state-machine/src/overlayed_changes/changeset.rs
+++ b/primitives/state-machine/src/overlayed_changes/changeset.rs
@@ -157,7 +157,7 @@ impl StorageEntry {
 
 	/// Materialize the internal state.
 	#[cfg(test)]
-	pub(crate) fn materialize(&self) -> Option<alloc::borrow::Cow<[u8]>> {
+	pub(crate) fn materialize(&self) -> Option<alloc::borrow::Cow<'_, [u8]>> {
 		use alloc::borrow::Cow;
 
 		match self {
@@ -654,8 +654,8 @@ impl<K: Ord + Hash + Clone, V> OverlayedMap<K, V> {
 
 	fn close_transaction_offchain(&mut self, rollback: bool) -> Result<(), NoOpenTransaction> {
 		// runtime is not allowed to close transactions started by the client
-		if matches!(self.execution_mode, ExecutionMode::Runtime) &&
-			!self.has_open_runtime_transactions()
+		if matches!(self.execution_mode, ExecutionMode::Runtime)
+			&& !self.has_open_runtime_transactions()
 		{
 			return Err(NoOpenTransaction);
 		}
@@ -725,8 +725,8 @@ impl OverlayedChangeSet {
 
 	fn close_transaction(&mut self, rollback: bool) -> Result<(), NoOpenTransaction> {
 		// runtime is not allowed to close transactions started by the client
-		if matches!(self.execution_mode, ExecutionMode::Runtime) &&
-			!self.has_open_runtime_transactions()
+		if matches!(self.execution_mode, ExecutionMode::Runtime)
+			&& !self.has_open_runtime_transactions()
 		{
 			return Err(NoOpenTransaction);
 		}

--- a/primitives/state-machine/src/overlayed_changes/changeset.rs
+++ b/primitives/state-machine/src/overlayed_changes/changeset.rs
@@ -654,8 +654,8 @@ impl<K: Ord + Hash + Clone, V> OverlayedMap<K, V> {
 
 	fn close_transaction_offchain(&mut self, rollback: bool) -> Result<(), NoOpenTransaction> {
 		// runtime is not allowed to close transactions started by the client
-		if matches!(self.execution_mode, ExecutionMode::Runtime)
-			&& !self.has_open_runtime_transactions()
+		if matches!(self.execution_mode, ExecutionMode::Runtime) &&
+			!self.has_open_runtime_transactions()
 		{
 			return Err(NoOpenTransaction);
 		}
@@ -725,8 +725,8 @@ impl OverlayedChangeSet {
 
 	fn close_transaction(&mut self, rollback: bool) -> Result<(), NoOpenTransaction> {
 		// runtime is not allowed to close transactions started by the client
-		if matches!(self.execution_mode, ExecutionMode::Runtime)
-			&& !self.has_open_runtime_transactions()
+		if matches!(self.execution_mode, ExecutionMode::Runtime) &&
+			!self.has_open_runtime_transactions()
 		{
 			return Err(NoOpenTransaction);
 		}

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -18,6 +18,7 @@
 //! Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::all)]
 
 extern crate alloc;
 

--- a/qpow-math/src/lib.rs
+++ b/qpow-math/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::ops::BitXor;
-use hex;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use primitive_types::U512;
@@ -181,35 +180,6 @@ pub fn mine_range(
 	None
 }
 
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn mod_pow_next_matches_mod_pow_for_incrementing_nonce() {
-		// Deterministic block_hash
-		let block_hash = [7u8; 32];
-		let (m, n) = get_random_rsa(&block_hash);
-		let h = U512::from_big_endian(&block_hash);
-
-		// Start at an arbitrary nonce
-		let mut nonce = U512::from(123u64);
-
-		// Initial value using full exponentiation
-		let mut value = mod_pow(&m, &h.saturating_add(nonce), &n);
-
-		// Check equality for 4 consecutive nonces
-		for _ in 0..4u32 {
-			let expected = mod_pow(&m, &h.saturating_add(nonce), &n);
-			assert_eq!(value, expected, "incremental result must match full mod_pow");
-
-			// Advance to next exponent (nonce + 1)
-			value = mod_pow_next(&value, &m, &n);
-			nonce = nonce.saturating_add(U512::from(1u64));
-		}
-	}
-}
-
 // Miller-Rabin primality test
 pub fn is_prime(n: &U512) -> bool {
 	if *n <= U512::one() {
@@ -279,4 +249,33 @@ pub fn is_prime(n: &U512) -> bool {
 	}
 
 	true
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn mod_pow_next_matches_mod_pow_for_incrementing_nonce() {
+		// Deterministic block_hash
+		let block_hash = [7u8; 32];
+		let (m, n) = get_random_rsa(&block_hash);
+		let h = U512::from_big_endian(&block_hash);
+
+		// Start at an arbitrary nonce
+		let mut nonce = U512::from(123u64);
+
+		// Initial value using full exponentiation
+		let mut value = mod_pow(&m, &h.saturating_add(nonce), &n);
+
+		// Check equality for 4 consecutive nonces
+		for _ in 0..4u32 {
+			let expected = mod_pow(&m, &h.saturating_add(nonce), &n);
+			assert_eq!(value, expected, "incremental result must match full mod_pow");
+
+			// Advance to next exponent (nonce + 1)
+			value = mod_pow_next(&value, &m, &n);
+			nonce = nonce.saturating_add(U512::from(1u64));
+		}
+	}
 }


### PR DESCRIPTION
The goal of this change is to limit the number of warnings and errors related to Clippy.
Here is a test build that was executed on this code.
https://github.com/Quantus-Network/chain/actions/runs/18085150928
It changes the number of problems from 16/18 to 7/18.
I don't want to mix too many things in one change, so sc-network and our own dependencies I will fix in separate PRs

