### PR TITLE
feat: Finalization during initial import

### DIFF
--- a/client/consensus/qpow/src/chain_management.rs
+++ b/client/consensus/qpow/src/chain_management.rs
@@ -149,7 +149,7 @@ where
 			finalize_number
 		);
 
-		log::info!("✓ Finalized block #{} ({:?})", finalize_number, finalize_hash);
+		log::debug!("✓ Finalized block #{} ({:?})", finalize_number, finalize_hash);
 
 		Ok(())
 	}


### PR DESCRIPTION
Ultra small change: switched from `import_notification_stream()` to `every_import_notification_stream()`.
After the "major sync", both methods behave similarly, but the one with “every_” ensures notifications after every block during the initial import.
Here is a short description of the difference in SDK
https://github.com/paritytech/polkadot-sdk/blob/df12fd34e36848a535892b1e88281faa59bf34b6/substrate/client/api/src/client.rs#L65