### PR TITLE
Pin stable rust toolchain version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.89"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32v1-none"]
 profile = "minimal"


### PR DESCRIPTION
Pins it to the last stable version that was around this PR #194 