### PR TITLE
Add arm64 platform to docker image workflows output

### DIFF
--- a/.github/workflows/quantus-docker-image.yml
+++ b/.github/workflows/quantus-docker-image.yml
@@ -105,7 +105,7 @@ jobs:
           context: ./source_code_for_build
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION_ARG=${{ env.TARGET_VERSION_WITH_V }}
           tags: |


### PR DESCRIPTION
## Problem
I want to run node as a docker container in my mac machine but it said I can't which is kind of sad 😢 . 

## Proposed Solution
Add linux/arm64 to the docker image workflows
