### PR TITLE
Set up qemu for multi-arch docker build

### DIFF
--- a/.github/workflows/quantus-docker-image.yml
+++ b/.github/workflows/quantus-docker-image.yml
@@ -64,6 +64,9 @@ jobs:
       TARGET_VERSION_WITH_V: ${{ needs.determine_version.outputs.version_with_v }}
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+    
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Apparently, the previous change for supporting arm64 wasn't complete. We need to set up Qemu to support multi-arch build from linux.