### PR TITLE
Threading improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9992,7 +9992,6 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
- "tokio 1.47.1",
 ]
 
 [[package]]

--- a/client/consensus/qpow/Cargo.toml
+++ b/client/consensus/qpow/Cargo.toml
@@ -28,7 +28,6 @@ sp-core = { workspace = true, default-features = true }
 sp-inherents = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = false }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
 
 [features]
 default = ["std"]

--- a/client/consensus/qpow/src/worker.rs
+++ b/client/consensus/qpow/src/worker.rs
@@ -76,7 +76,7 @@ pub struct MiningHandle<Block: BlockT, AC, L: sc_consensus::JustificationSyncLin
 	client: Arc<AC>,
 	justification_sync_link: Arc<L>,
 	build: Arc<Mutex<Option<MiningBuild<Block, Proof>>>>,
-	block_import: Arc<tokio::sync::Mutex<BoxBlockImport<Block>>>,
+	block_import: Arc<BoxBlockImport<Block>>,
 }
 
 impl<Block, AC, L, Proof> MiningHandle<Block, AC, L, Proof>
@@ -100,7 +100,7 @@ where
 			client,
 			justification_sync_link: Arc::new(justification_sync_link),
 			build: Arc::new(Mutex::new(None)),
-			block_import: Arc::new(tokio::sync::Mutex::new(block_import)),
+			block_import: Arc::new(block_import),
 		}
 	}
 
@@ -218,7 +218,7 @@ where
 			StateAction::ApplyChanges(StorageChanges::Changes(build.proposal.storage_changes));
 
 		let header = import_block.post_header();
-		let import_result = self.block_import.lock().await.import_block(import_block).await;
+		let import_result = self.block_import.import_block(import_block).await;
 
 		match import_result {
 			Ok(res) => {


### PR DESCRIPTION
**Remove blocking executor and unnecessary mutex from mining submission**

The mining loop (`qpow-mining`) runs as an async task on the tokio thread pool. Block submission previously used `futures::executor::block_on(worker_handle.submit(seal))`, which parked the tokio worker thread for the duration of the block import. This was a workaround because `parking_lot::MutexGuard` is `!Send`, making the `submit()` future incompatible with `.await` in a tokio context.

The underlying issue was that `block_import` was wrapped in a `parking_lot::Mutex` despite not needing one -- `BlockImport::import_block` takes `&self`, and `submit()` is only ever called from the single mining loop. There is no concurrent access to synchronize.

Changes:
- Remove the `Mutex` around `block_import` in `MiningHandle`, replacing `Arc<Mutex<BoxBlockImport>>` with `Arc<BoxBlockImport>`
- Replace `futures::executor::block_on(worker_handle.submit(seal))` with `.await` at both call sites
- Make `submit_mined_block` async
- Remove `#[allow(clippy::await_holding_lock)]`