### PR TITLE
fix: Multisig - Approved&Expired - cleaned by any signer

### DIFF
--- a/pallets/multisig/README.md
+++ b/pallets/multisig/README.md
@@ -148,7 +148,7 @@ Dispatches an **Approved** proposal. Can be called by any signer of the multisig
 **Economic Costs:** Weight depends on call size (charged upfront for MaxCallSize, refunded for actual size).
 
 ### 6. Remove Expired
-Manually removes a single expired **Active** proposal from storage. Only signers can call this. Deposit is returned to the original proposer.
+Manually removes a single expired **Active or Approved** proposal from storage. Only signers can call this. Deposit is returned to the original proposer.
 
 **Required Parameters:**
 - `multisig_address: AccountId` - Target multisig (REQUIRED)
@@ -156,10 +156,10 @@ Manually removes a single expired **Active** proposal from storage. Only signers
 
 **Validation:**
 - Caller must be a signer of the multisig
-- Proposal must exist and be Active
+- Proposal must exist and be Active or Approved
 - Must be expired (current_block > expiry)
 
-**Note:** Executed/Cancelled proposals are removed immediately when executed/cancelled. This extrinsic only applies to **Active** proposals that are past expiry.
+**Note:** Executed/Cancelled proposals are removed immediately when executed/cancelled. This extrinsic applies to **Active+Expired** and **Approved+Expired** proposals. Approved+expired proposals would otherwise be stuck if the proposer is unavailable (e.g. lost keys); any signer can remove them to unblock deposits and enable multisig dissolution.
 
 **Economic Effects:**
 - ProposalDeposit returned to **original proposer** (not caller)
@@ -176,12 +176,12 @@ Batch cleanup operation to recover all caller's expired proposal deposits.
 
 **Validation:**
 - Only cleans proposals where caller is proposer
-- Only removes Active+Expired proposals (Executed/Cancelled already auto-removed)
+- Only removes Active+Expired and Approved+Expired proposals (Executed/Cancelled already auto-removed)
 - Must be expired (current_block > expiry)
 
 **Behavior:**
 - Iterates through ALL proposals in the multisig
-- Removes all that match: proposer=caller AND expired AND status=Active
+- Removes all that match: proposer=caller AND expired AND (status=Active OR status=Approved)
 - No iteration limits - cleans all in one call
 
 **Economic Effects:**
@@ -485,7 +485,7 @@ This event structure is optimized for indexing by SubSquid and similar indexers:
 
 ### Storage Cleanup
 - No auto-cleanup in `propose()` (predictable weight; proposer must free slots via cleanup)
-- Manual cleanup via `remove_expired()`: any signer can remove a single expired Active proposal (deposit → proposer)
+- Manual cleanup via `remove_expired()`: any signer can remove a single expired Active or Approved proposal (deposit → proposer)
 - Batch cleanup via `claim_deposits()`: proposer recovers all their expired proposal deposits at once and frees per-signer quota
 
 ### Economic Attacks

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -866,11 +866,14 @@ pub mod pallet {
 		/// Remove expired proposals and return deposits to proposers
 		///
 		/// Can only be called by signers of the multisig.
-		/// Only removes Active proposals that have expired (past expiry block).
+		/// Removes Active or Approved proposals that have expired (past expiry block).
 		/// Executed and Cancelled proposals are automatically cleaned up immediately.
 		///
+		/// Approved+expired proposals can become stuck if proposer is unavailable (e.g. lost
+		/// keys, compromise). Allowing any signer to remove them prevents permanent deposit
+		/// lockup and enables multisig dissolution.
+		///
 		/// The deposit is always returned to the original proposer, not the caller.
-		/// This allows any signer to help clean up storage even if proposer is inactive.
 		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::remove_expired(T::MaxCallSize::get()))]
 		pub fn remove_expired(
@@ -887,9 +890,14 @@ pub mod pallet {
 			let proposal = Proposals::<T>::get(&multisig_address, proposal_id)
 				.ok_or(Error::<T>::ProposalNotFound)?;
 
-			// Only Active proposals can be manually removed (Executed/Cancelled already
-			// auto-removed)
-			ensure!(proposal.status == ProposalStatus::Active, Error::<T>::ProposalNotActive);
+			// Active or Approved proposals can be removed when expired (Executed/Cancelled
+			// are auto-removed). Approved+expired would otherwise be stuck if proposer
+			// unavailable.
+			ensure!(
+				proposal.status == ProposalStatus::Active ||
+					proposal.status == ProposalStatus::Approved,
+				Error::<T>::ProposalNotActive,
+			);
 
 			// Check if expired
 			let current_block = frame_system::Pallet::<T>::block_number();
@@ -918,10 +926,10 @@ pub mod pallet {
 		///
 		/// This is a batch operation that removes all expired proposals where:
 		/// - Caller is the proposer
-		/// - Proposal is Active and past expiry block
+		/// - Proposal is Active or Approved and past expiry block
 		///
 		/// Note: Executed and Cancelled proposals are automatically cleaned up immediately,
-		/// so only Active+Expired proposals need manual cleanup.
+		/// so only Active+Expired and Approved+Expired proposals need manual cleanup.
 		///
 		/// Returns all proposal deposits to the proposer in a single transaction.
 		#[pallet::call_index(5)]
@@ -1226,9 +1234,10 @@ pub mod pallet {
 						total_iterated += 1; // Count every proposal we iterate through
 						total_call_bytes += proposal.call.len() as u32;
 
-						// Only proposer's expired active proposals
+						// Only proposer's expired proposals (Active or Approved)
 						if proposal.proposer == *proposer &&
-							proposal.status == ProposalStatus::Active &&
+							(proposal.status == ProposalStatus::Active ||
+								proposal.status == ProposalStatus::Approved) &&
 							current_block > proposal.expiry
 						{
 							Some((proposal_id, proposal.proposer, proposal.deposit))

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -699,6 +699,177 @@ fn remove_expired_fails_for_non_signer() {
 }
 
 #[test]
+fn remove_expired_works_for_approved_expired_proposal() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		let creator = alice();
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			2,
+			0
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+
+		let call = make_call(vec![1, 2, 3]);
+		let expiry = 100;
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			call.clone(),
+			expiry
+		));
+
+		let proposal_id = get_last_proposal_id(&multisig_address);
+
+		// Charlie approves → status becomes Approved
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			proposal_id
+		));
+
+		let proposal = Proposals::<Test>::get(&multisig_address, proposal_id).unwrap();
+		assert_eq!(proposal.status, ProposalStatus::Approved);
+
+		// Move past expiry - proposal can no longer be executed
+		System::set_block_number(expiry + 1);
+
+		// Any signer (charlie, not proposer) can remove expired Approved proposal
+		// This unblocks deposits and enables multisig dissolution when proposer unavailable
+		assert_ok!(Multisig::remove_expired(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			proposal_id
+		));
+
+		// Proposal should be gone
+		assert!(!Proposals::<Test>::contains_key(&multisig_address, proposal_id));
+
+		// Deposit returned to proposer (bob)
+		assert_eq!(Balances::reserved_balance(bob()), 0);
+	});
+}
+
+#[test]
+fn claim_deposits_works_for_approved_expired_proposals() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		let creator = alice();
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			2,
+			0
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+
+		// Bob creates 2 proposals
+		for i in 0..2 {
+			let call = make_call(vec![i as u8; 32]);
+			assert_ok!(Multisig::propose(
+				RuntimeOrigin::signed(bob()),
+				multisig_address.clone(),
+				call,
+				100
+			));
+		}
+
+		// Charlie approves both → Approved
+		for proposal_id in 0..=1 {
+			assert_ok!(Multisig::approve(
+				RuntimeOrigin::signed(charlie()),
+				multisig_address.clone(),
+				proposal_id
+			));
+		}
+
+		// Move past expiry
+		System::set_block_number(201);
+
+		// Bob (proposer) claims deposits from expired Approved proposals
+		assert_ok!(Multisig::claim_deposits(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone()
+		));
+
+		// All deposits returned
+		assert_eq!(Balances::reserved_balance(bob()), 0);
+
+		// Proposals removed
+		assert!(Proposals::<Test>::get(&multisig_address, 0).is_none());
+		assert!(Proposals::<Test>::get(&multisig_address, 1).is_none());
+	});
+}
+
+#[test]
+fn remove_expired_unblocks_undecodable_approved_proposal() {
+	// Non-high-security multisig can have proposals with invalid call bytes.
+	// Execute fails with InvalidCall, proposal stays. After expiry, remove_expired unblocks.
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		let creator = alice();
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			2,
+			0
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+		// Non-high-security (not account 100), so no decode at propose
+		assert!(!MockHighSecurity::is_high_security(&multisig_address));
+
+		// Invalid call bytes - will fail decode at execute
+		let undecodable_call = vec![0xff; 32];
+		let expiry = 100;
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			undecodable_call,
+			expiry
+		));
+
+		let proposal_id = get_last_proposal_id(&multisig_address);
+
+		// Charlie approves → Approved
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			proposal_id
+		));
+
+		// Execute fails (InvalidCall) - proposal stays in storage
+		assert_err_ignore_postinfo(
+			Multisig::execute(RuntimeOrigin::signed(bob()), multisig_address.clone(), proposal_id),
+			Error::<Test>::InvalidCall.into(),
+		);
+		assert!(Proposals::<Test>::contains_key(&multisig_address, proposal_id));
+
+		// Move past expiry
+		System::set_block_number(expiry + 1);
+
+		// Any signer can remove expired Approved proposal (even with undecodable call)
+		assert_ok!(Multisig::remove_expired(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			proposal_id
+		));
+
+		assert!(!Proposals::<Test>::contains_key(&multisig_address, proposal_id));
+		assert_eq!(Balances::reserved_balance(bob()), 0);
+	});
+}
+
+#[test]
 fn claim_deposits_works() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);


### PR DESCRIPTION
## Fix: Allow cleanup of expired Approved proposals (Q4.2)

### Problem

Proposals in `Approved` state that expired could become permanently stuck:

- `remove_expired` and `claim_deposits` only handled `Active` proposals
- Only the proposer could call `cancel`, so if the proposer was unavailable, deposits and slots stayed locked
- Multisig dissolution was blocked while any such proposal existed
- For non-high-security multisigs, undecodable proposals could reach `Approved`, fail on `execute`, and remain stuck

### Solution

- **`remove_expired`**: Accept both `Active` and `Approved` proposals when expired; any signer can remove them
- **`claim_deposits`**: Include expired `Approved` proposals in cleanup so the proposer can reclaim deposits

### Safety

- Expiry is still enforced: `current_block > proposal.expiry` is required
- Only signers can call `remove_expired`
- Deposits are always returned to the proposer, not the caller

### Tests

- `remove_expired_works_for_approved_expired_proposal` – signer removes expired Approved proposal
- `claim_deposits_works_for_approved_expired_proposals` – proposer reclaims deposits from expired Approved proposals
- `remove_expired_unblocks_undecodable_approved_proposal` – undecodable Approved proposal is cleaned up after expiry