### PR TITLE
fix: Dilithium API - from_raw public constuctor

### DIFF
--- a/primitives/dilithium-crypto/src/pair.rs
+++ b/primitives/dilithium-crypto/src/pair.rs
@@ -314,4 +314,26 @@ mod tests {
 			"Different seeds should produce different public keys"
 		);
 	}
+
+	#[test]
+	fn test_from_raw_matching_keys_succeeds() {
+		let seed = [0u8; 32];
+		let pair = DilithiumPair::from_seed(&seed).expect("Failed to create pair");
+		let public = pair.public().as_ref().to_vec();
+		let secret = pair.secret_bytes().to_vec();
+		let restored =
+			DilithiumPair::from_raw(&public, &secret).expect("Matching keys should succeed");
+		assert_eq!(restored.public().as_ref(), pair.public().as_ref());
+	}
+
+	#[test]
+	fn test_from_raw_mismatched_keys_fails() {
+		let seed1 = [0u8; 32];
+		let seed2 = [1u8; 32];
+		let pair1 = DilithiumPair::from_seed(&seed1).expect("Failed to create pair1");
+		let pair2 = DilithiumPair::from_seed(&seed2).expect("Failed to create pair2");
+		// Swap: pair1's secret with pair2's public - should fail validation
+		let result = DilithiumPair::from_raw(pair2.public().as_ref(), pair1.secret_bytes());
+		assert!(result.is_err(), "Mismatched public/secret should be rejected");
+	}
 }

--- a/primitives/dilithium-crypto/src/traits.rs
+++ b/primitives/dilithium-crypto/src/traits.rs
@@ -253,8 +253,18 @@ impl DilithiumPair {
 
 	/// Create DilithiumPair from raw public and secret key bytes.
 	/// Use when reconstructing a pair from stored/serialized key material (e.g. wallet restore).
+	///
+	/// Verifies that the public key corresponds to the secret by signing a test message and
+	/// verifying it. Rejects mismatched or corrupted key pairs that would otherwise cause
+	/// non-obvious signature verification failures downstream.
 	pub fn from_raw(public: &[u8], secret: &[u8]) -> Result<Self, Error> {
 		let keypair = crate::pair::create_keypair(public, secret)?;
+		// Verify public corresponds to secret (create_keypair only deserializes, does not validate)
+		const VALIDATION_MSG: &[u8] = b"qp_dilithium_crypto::from_raw_validation";
+		let sig = keypair.sign(VALIDATION_MSG, None, None).map_err(|_| Error::InvalidSecretKey)?;
+		if !keypair.verify(VALIDATION_MSG, sig.as_ref(), None) {
+			return Err(Error::InvalidPublicKey);
+		}
 		Ok(DilithiumPair { secret: keypair.secret.to_bytes(), public: keypair.public.to_bytes() })
 	}
 


### PR DESCRIPTION
Add from_raw constructor to DilithiumPair
After the previous change that hid the secret and public fields, there was no way to reconstruct a pair from raw bytes. This adds from_raw(public, secret) so callers can restore a pair from stored/serialized key material (e.g. wallet restore), with validation via create_keypair.