### PR TITLE
fix: correct planck genesis endowment and preset logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11900,6 +11900,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.4",
+ "qp-poseidon",
  "rand 0.8.5",
  "scale-info",
  "schnellru",

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -46,6 +46,7 @@ trie-root = { workspace = true, default-features = false }
 [dev-dependencies]
 array-bytes = { workspace = true, default-features = true }
 criterion = { workspace = true, default-features = true }
+qp-poseidon = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 trie-bench = { workspace = true }
 trie-standardmap = { workspace = true }

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -139,7 +139,7 @@ pub struct LayoutV1<H>(PhantomData<H>);
 
 // Set to 0 to force all values to be hashed, never inlined
 // This removes the need for length prefixes in the storage proof
-const FELT_ALIGNED_MAX_INLINE_VALUE: u32 = 0;
+const FELT_ALIGNED_MAX_INLINE_VALUE: u32 = 30;
 
 impl<H> TrieLayout for LayoutV0<H>
 where
@@ -938,6 +938,48 @@ mod tests {
 
 	type MemoryDBMeta<H> = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>;
 
+	/// Test-only layout that forces *all* values into external value nodes.
+	struct ForceHashedValuesLayoutV1<H>(core::marker::PhantomData<H>);
+
+	impl<H> TrieLayout for ForceHashedValuesLayoutV1<H>
+	where
+		H: Hasher,
+	{
+		const USE_EXTENSION: bool = false;
+		const ALLOW_EMPTY: bool = true;
+		const MAX_INLINE_VALUE: Option<u32> = Some(0);
+
+		type Hash = H;
+		type Codec = NodeCodec<Self::Hash>;
+	}
+
+	impl<H> TrieConfiguration for ForceHashedValuesLayoutV1<H>
+	where
+		H: Hasher,
+	{
+		fn trie_root<I, A, B>(input: I) -> <Self::Hash as Hasher>::Out
+		where
+			I: IntoIterator<Item = (A, B)>,
+			A: AsRef<[u8]> + Ord,
+			B: AsRef<[u8]>,
+		{
+			trie_root::trie_root_no_extension::<H, TrieStream, _, _, _>(input, Some(0))
+		}
+
+		fn trie_root_unhashed<I, A, B>(input: I) -> Vec<u8>
+		where
+			I: IntoIterator<Item = (A, B)>,
+			A: AsRef<[u8]> + Ord,
+			B: AsRef<[u8]>,
+		{
+			trie_root::unhashed_trie_no_extension::<H, TrieStream, _, _, _>(input, Some(0))
+		}
+
+		fn encode_index(input: u32) -> Vec<u8> {
+			codec::Encode::encode(&codec::Compact(input))
+		}
+	}
+
 	pub fn create_trie<L: TrieLayout>(
 		data: &[(&[u8], &[u8])],
 	) -> (MemoryDB<L::Hash>, trie_db::TrieHash<L>) {
@@ -1029,6 +1071,35 @@ mod tests {
 		check_iteration::<LayoutV0>(input);
 		check_equivalent::<LayoutV1>(input);
 		check_iteration::<LayoutV1>(input);
+	}
+
+	/// Exposes the `MAX_INLINE_VALUE = 0` issue for short zero-prefixed values with Poseidon
+	/// hashing (the chain hasher).
+	#[test]
+	fn force_hashed_values_preserve_distinct_zero_prefixed_values_poseidon() {
+		use trie_db::TrieDBMutBuilder;
+		type PoseidonLayout = ForceHashedValuesLayoutV1<qp_poseidon::PoseidonHasher>;
+
+		let mut memdb = MemoryDBMeta::<qp_poseidon::PoseidonHasher>::new(&0u64.to_le_bytes());
+		let mut root = Default::default();
+
+		let k1 = b"k1";
+		let k2 = b"k2";
+		let v1 = vec![0u8];
+		let v2 = vec![0u8, 0u8];
+
+		{
+			let mut trie = TrieDBMutBuilder::<PoseidonLayout>::new(&mut memdb, &mut root).build();
+			trie.insert(k1, &v1).expect("insert v1 should succeed");
+			trie.insert(k2, &v2).expect("insert v2 should succeed");
+		}
+
+		let trie = trie_db::TrieDBBuilder::<PoseidonLayout>::new(&memdb, &root).build();
+		let read_v1 = trie.get(k1).expect("read v1 should succeed").expect("v1 should exist");
+		let read_v2 = trie.get(k2).expect("read v2 should succeed").expect("v2 should exist");
+
+		assert_eq!(read_v1, v1, "value 0x00 should round-trip exactly");
+		assert_eq!(read_v2, v2, "value 0x0000 should round-trip exactly");
 	}
 
 	#[test]

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -139,7 +139,7 @@ pub struct LayoutV1<H>(PhantomData<H>);
 
 // Set to 0 to force all values to be hashed, never inlined
 // This removes the need for length prefixes in the storage proof
-const FELT_ALIGNED_MAX_INLINE_VALUE: u32 = 30;
+const FELT_ALIGNED_MAX_INLINE_VALUE: u32 = 0;
 
 impl<H> TrieLayout for LayoutV0<H>
 where

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -196,23 +196,52 @@ fn genesis_template(
 	v
 }
 
-/// Return the development genesis config.
-pub fn development_config_genesis() -> Value {
-	let mut endowed_accounts = vec![];
-	endowed_accounts.extend(dilithium_default_accounts());
-
-	// Add the test address derived from TEST_WORMHOLE_SECRET.
-	// This is useful for testing ZK spending with a known secret.
-	let test_account = test_wormhole_account();
-	endowed_accounts.push(test_account.clone());
-
-	let ss58_version = sp_core::crypto::Ss58AddressFormat::custom(189);
-	for account in endowed_accounts.iter() {
-		log::info!("🍆 Endowed account: {:?}", account.to_ss58check_with_version(ss58_version));
+fn log_genesis_accounts(
+	preset: &str,
+	endowed: &[AccountId],
+	treasury_account: &AccountId,
+	treasury_signers: &[AccountId],
+	tech_collective: &[AccountId],
+) {
+	let ss58 = ss58_version();
+	for account in endowed {
+		log::info!("[{preset}] 💰 Endowed: {:?}", account.to_ss58check_with_version(ss58));
 	}
 	log::info!(
-		"🕳️  Test ZK address (use TEST_WORMHOLE_SECRET to spend): {:?}",
-		test_account.to_ss58check_with_version(ss58_version)
+		"[{preset}] 🏦 Treasury: {:?}",
+		treasury_account.to_ss58check_with_version(ss58)
+	);
+	for signer in treasury_signers {
+		log::info!(
+			"[{preset}] 🔑 Treasury signer: {:?}",
+			signer.to_ss58check_with_version(ss58)
+		);
+	}
+	for member in tech_collective {
+		log::info!(
+			"[{preset}] 🏛️  Tech collective: {:?}",
+			member.to_ss58check_with_version(ss58)
+		);
+	}
+}
+
+/// Return the development genesis config.
+pub fn development_config_genesis() -> Value {
+	let mut endowed_accounts = dilithium_default_accounts();
+	let test_account = test_wormhole_account();
+	endowed_accounts.push(test_account.clone());
+	let treasury_account = development_treasury_account();
+	let tech_collective = development_tech_collective_seed();
+	log_genesis_accounts(
+		"dev",
+		&endowed_accounts,
+		&treasury_account,
+		&dilithium_default_accounts(),
+		&tech_collective,
+	);
+	log::info!(
+		"[dev] 🕳️  Test ZK: {:?}",
+		test_account.to_ss58check_with_version(ss58_version())
 	);
 
 	#[cfg(feature = "runtime-benchmarks")]
@@ -236,13 +265,13 @@ pub fn development_config_genesis() -> Value {
 		};
 
 		let treasury = TreasuryGenesis {
-			account: development_treasury_account(),
+			account: treasury_account,
 			portion: Permill::from_percent(30),
 		};
 		let mut config: RuntimeGenesisConfig = serde_json::from_value(genesis_template(
 			endowed_accounts,
 			treasury,
-			development_tech_collective_seed(),
+			tech_collective,
 		))
 		.expect("genesis_template returns valid config");
 		config.reversible_transfers = rt_genesis;
@@ -252,23 +281,28 @@ pub fn development_config_genesis() -> Value {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	{
 		let treasury = TreasuryGenesis {
-			account: development_treasury_account(),
+			account: treasury_account,
 			portion: Permill::from_percent(30),
 		};
-		genesis_template(endowed_accounts, treasury, development_tech_collective_seed())
+		genesis_template(endowed_accounts, treasury, tech_collective)
 	}
 }
 
 pub fn heisenberg_config_genesis() -> Value {
 	let endowed_accounts = dilithium_default_accounts();
-	for account in endowed_accounts.iter() {
-		log::info!("🍆 Endowed account: {:?}", account.to_ss58check_with_version(ss58_version()));
-	}
-	let treasury = TreasuryGenesis {
-		account: heisenberg_treasury_account(),
-		portion: Permill::from_percent(30),
-	};
-	genesis_template(endowed_accounts, treasury, heisenberg_tech_collective_seed())
+	let treasury_signers = heisenberg_treasury_signers();
+	let tech_collective = heisenberg_tech_collective_seed();
+	let treasury_account = heisenberg_treasury_account();
+	log_genesis_accounts(
+		"heisenberg",
+		&endowed_accounts,
+		&treasury_account,
+		&treasury_signers,
+		&tech_collective,
+	);
+	let treasury =
+		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+	genesis_template(endowed_accounts, treasury, tech_collective)
 }
 
 fn planck_faucet_account() -> AccountId {
@@ -347,14 +381,21 @@ pub fn seed_tech_collective(members: &[AccountId]) {
 }
 
 pub fn planck_config_genesis() -> Value {
+	let treasury_signers = planck_treasury_signers();
+	let tech_collective = planck_tech_collective_seed();
+	let treasury_account = planck_treasury_account();
 	let mut endowed_accounts = vec![planck_faucet_account()];
-	endowed_accounts.extend(dilithium_default_accounts());
-	for account in endowed_accounts.iter() {
-		log::info!("🍆 Endowed account: {:?}", account.to_ss58check_with_version(ss58_version()));
-	}
+	endowed_accounts.extend(treasury_signers.clone());
+	log_genesis_accounts(
+		"planck",
+		&endowed_accounts,
+		&treasury_account,
+		&treasury_signers,
+		&tech_collective,
+	);
 	let treasury =
-		TreasuryGenesis { account: planck_treasury_account(), portion: Permill::from_percent(30) };
-	genesis_template(endowed_accounts, treasury, planck_tech_collective_seed())
+		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+	genesis_template(endowed_accounts, treasury, tech_collective)
 }
 
 /// Provides the JSON representation of predefined genesis config for given `id`.

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -372,8 +372,7 @@ pub fn planck_config_genesis() -> Value {
 	let tech_collective = planck_tech_collective_seed();
 	let treasury_account = planck_treasury_account();
 	let endowed_accounts = vec![planck_faucet_account()];
-	let signer_fee_seed: Vec<_> =
-		treasury_signers.iter().cloned().map(|a| (a, UNIT)).collect();
+	let signer_fee_seed: Vec<_> = treasury_signers.iter().cloned().map(|a| (a, UNIT)).collect();
 	log_genesis_accounts(
 		"planck",
 		&endowed_accounts,

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -148,6 +148,7 @@ fn genesis_template(
 	endowed_accounts: Vec<AccountId>,
 	treasury: TreasuryGenesis,
 	tech_collective_members: Vec<AccountId>,
+	extra_balances: Vec<(AccountId, u128)>,
 ) -> Value {
 	const ENDOWED_BALANCE_UNITS: u128 = 100_000;
 	let mut balances = endowed_accounts
@@ -155,6 +156,7 @@ fn genesis_template(
 		.cloned()
 		.map(|k| (k, ENDOWED_BALANCE_UNITS.saturating_mul(UNIT)))
 		.collect::<Vec<_>>();
+	balances.extend(extra_balances);
 
 	let total_supply_raw = GENESIS_SUPPLY.saturating_mul(UNIT);
 	let treasury_balance = treasury.portion.mul_floor(total_supply_raw);
@@ -254,9 +256,13 @@ pub fn development_config_genesis() -> Value {
 
 		let treasury =
 			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
-		let mut config: RuntimeGenesisConfig =
-			serde_json::from_value(genesis_template(endowed_accounts, treasury, tech_collective))
-				.expect("genesis_template returns valid config");
+		let mut config: RuntimeGenesisConfig = serde_json::from_value(genesis_template(
+			endowed_accounts,
+			treasury,
+			tech_collective,
+			vec![],
+		))
+		.expect("genesis_template returns valid config");
 		config.reversible_transfers = rt_genesis;
 		return serde_json::to_value(config).expect("Could not build genesis config.");
 	}
@@ -265,7 +271,7 @@ pub fn development_config_genesis() -> Value {
 	{
 		let treasury =
 			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
-		genesis_template(endowed_accounts, treasury, tech_collective)
+		genesis_template(endowed_accounts, treasury, tech_collective, vec![])
 	}
 }
 
@@ -283,7 +289,7 @@ pub fn heisenberg_config_genesis() -> Value {
 	);
 	let treasury =
 		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
-	genesis_template(endowed_accounts, treasury, tech_collective)
+	genesis_template(endowed_accounts, treasury, tech_collective, vec![])
 }
 
 fn planck_faucet_account() -> AccountId {
@@ -365,8 +371,9 @@ pub fn planck_config_genesis() -> Value {
 	let treasury_signers = planck_treasury_signers();
 	let tech_collective = planck_tech_collective_seed();
 	let treasury_account = planck_treasury_account();
-	let mut endowed_accounts = vec![planck_faucet_account()];
-	endowed_accounts.extend(treasury_signers.clone());
+	let endowed_accounts = vec![planck_faucet_account()];
+	let signer_fee_seed: Vec<_> =
+		treasury_signers.iter().cloned().map(|a| (a, UNIT)).collect();
 	log_genesis_accounts(
 		"planck",
 		&endowed_accounts,
@@ -376,7 +383,7 @@ pub fn planck_config_genesis() -> Value {
 	);
 	let treasury =
 		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
-	genesis_template(endowed_accounts, treasury, tech_collective)
+	genesis_template(endowed_accounts, treasury, tech_collective, signer_fee_seed)
 }
 
 /// Provides the JSON representation of predefined genesis config for given `id`.

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -207,21 +207,12 @@ fn log_genesis_accounts(
 	for account in endowed {
 		log::info!("[{preset}] 💰 Endowed: {:?}", account.to_ss58check_with_version(ss58));
 	}
-	log::info!(
-		"[{preset}] 🏦 Treasury: {:?}",
-		treasury_account.to_ss58check_with_version(ss58)
-	);
+	log::info!("[{preset}] 🏦 Treasury: {:?}", treasury_account.to_ss58check_with_version(ss58));
 	for signer in treasury_signers {
-		log::info!(
-			"[{preset}] 🔑 Treasury signer: {:?}",
-			signer.to_ss58check_with_version(ss58)
-		);
+		log::info!("[{preset}] 🔑 Treasury signer: {:?}", signer.to_ss58check_with_version(ss58));
 	}
 	for member in tech_collective {
-		log::info!(
-			"[{preset}] 🏛️  Tech collective: {:?}",
-			member.to_ss58check_with_version(ss58)
-		);
+		log::info!("[{preset}] 🏛️  Tech collective: {:?}", member.to_ss58check_with_version(ss58));
 	}
 }
 
@@ -239,10 +230,7 @@ pub fn development_config_genesis() -> Value {
 		&dilithium_default_accounts(),
 		&tech_collective,
 	);
-	log::info!(
-		"[dev] 🕳️  Test ZK: {:?}",
-		test_account.to_ss58check_with_version(ss58_version())
-	);
+	log::info!("[dev] 🕳️  Test ZK: {:?}", test_account.to_ss58check_with_version(ss58_version()));
 
 	#[cfg(feature = "runtime-benchmarks")]
 	{
@@ -264,26 +252,19 @@ pub fn development_config_genesis() -> Value {
 			initial_high_security_accounts: vec![(multisig_address, interceptor, delay)],
 		};
 
-		let treasury = TreasuryGenesis {
-			account: treasury_account,
-			portion: Permill::from_percent(30),
-		};
-		let mut config: RuntimeGenesisConfig = serde_json::from_value(genesis_template(
-			endowed_accounts,
-			treasury,
-			tech_collective,
-		))
-		.expect("genesis_template returns valid config");
+		let treasury =
+			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+		let mut config: RuntimeGenesisConfig =
+			serde_json::from_value(genesis_template(endowed_accounts, treasury, tech_collective))
+				.expect("genesis_template returns valid config");
 		config.reversible_transfers = rt_genesis;
 		return serde_json::to_value(config).expect("Could not build genesis config.");
 	}
 
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	{
-		let treasury = TreasuryGenesis {
-			account: treasury_account,
-			portion: Permill::from_percent(30),
-		};
+		let treasury =
+			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
 		genesis_template(endowed_accounts, treasury, tech_collective)
 	}
 }

--- a/runtime/tests/governance/tech_collective.rs
+++ b/runtime/tests/governance/tech_collective.rs
@@ -1283,6 +1283,140 @@ mod tests {
 		});
 	}
 
+	#[test]
+	fn test_genesis_seeded_members_can_vote() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let proposer = TestCommons::account_id(1);
+			let voter = TestCommons::account_id(2);
+
+			Balances::make_free_balance_be(&proposer, 3000 * UNIT);
+			Balances::make_free_balance_be(&voter, 2000 * UNIT);
+
+			quantus_runtime::genesis_config_presets::seed_tech_collective(&[
+				proposer.clone(),
+				voter.clone(),
+			]);
+
+			assert!(
+				pallet_ranked_collective::Members::<Runtime>::contains_key(&proposer),
+				"Proposer should be in Members storage after genesis seeding"
+			);
+			assert!(
+				pallet_ranked_collective::Members::<Runtime>::contains_key(&voter),
+				"Voter should be in Members storage after genesis seeding"
+			);
+
+			let proposal = RuntimeCall::System(frame_system::Call::remark {
+				remark: b"genesis-seeded voting test".to_vec(),
+			});
+			let encoded = proposal.encode();
+			let hash = <Runtime as frame_system::Config>::Hashing::hash(&encoded);
+			assert_ok!(Preimage::note_preimage(
+				RuntimeOrigin::signed(proposer.clone()),
+				encoded.clone()
+			));
+
+			assert_ok!(TechReferenda::submit(
+				RuntimeOrigin::signed(proposer.clone()),
+				Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
+				frame_support::traits::Bounded::Lookup { hash, len: encoded.len() as u32 },
+				frame_support::traits::schedule::DispatchTime::After(0u32)
+			));
+
+			let referendum_index =
+				pallet_referenda::ReferendumCount::<Runtime, TechReferendaInstance>::get() - 1;
+
+			assert_ok!(TechReferenda::place_decision_deposit(
+				RuntimeOrigin::signed(proposer.clone()),
+				referendum_index
+			));
+
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(voter.clone()),
+				referendum_index,
+				true
+			));
+
+			let track_info =
+				<Runtime as pallet_referenda::Config<TechReferendaInstance>>::Tracks::info(
+					TRACK_ID,
+				)
+				.expect("Track info should exist");
+
+			let total_blocks = TestCommons::calculate_governance_blocks(
+				track_info.prepare_period,
+				track_info.decision_period,
+				track_info.confirm_period,
+				track_info.min_enactment_period,
+			);
+			TestCommons::run_to_block(total_blocks);
+
+			let final_info =
+				pallet_referenda::ReferendumInfoFor::<Runtime, TechReferendaInstance>::get(
+					referendum_index,
+				)
+				.expect("Referendum info should exist");
+			assert!(
+				matches!(final_info, pallet_referenda::ReferendumInfo::Approved(_, _, _)),
+				"Referendum should be approved, but is {:?}",
+				final_info
+			);
+		});
+	}
+
+	#[test]
+	fn test_non_seeded_member_cannot_vote() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let proposer = TestCommons::account_id(1);
+			let non_member = TestCommons::account_id(99);
+
+			Balances::make_free_balance_be(&proposer, 3000 * UNIT);
+			Balances::make_free_balance_be(&non_member, 3000 * UNIT);
+
+			quantus_runtime::genesis_config_presets::seed_tech_collective(&[proposer.clone()]);
+
+			assert!(
+				!pallet_ranked_collective::Members::<Runtime>::contains_key(&non_member),
+				"Non-seeded account should not be in Members storage"
+			);
+
+			let proposal = RuntimeCall::System(frame_system::Call::remark {
+				remark: b"non-member voting test".to_vec(),
+			});
+			let encoded = proposal.encode();
+			let hash = <Runtime as frame_system::Config>::Hashing::hash(&encoded);
+			assert_ok!(Preimage::note_preimage(
+				RuntimeOrigin::signed(proposer.clone()),
+				encoded.clone()
+			));
+
+			assert_ok!(TechReferenda::submit(
+				RuntimeOrigin::signed(proposer.clone()),
+				Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
+				frame_support::traits::Bounded::Lookup { hash, len: encoded.len() as u32 },
+				frame_support::traits::schedule::DispatchTime::After(0u32)
+			));
+
+			let referendum_index =
+				pallet_referenda::ReferendumCount::<Runtime, TechReferendaInstance>::get() - 1;
+
+			assert_ok!(TechReferenda::place_decision_deposit(
+				RuntimeOrigin::signed(proposer.clone()),
+				referendum_index
+			));
+
+			assert!(
+				TechCollective::vote(
+					RuntimeOrigin::signed(non_member),
+					referendum_index,
+					true
+				)
+				.is_err(),
+				"Non-seeded account should be rejected with NotMember"
+			);
+		});
+	}
+
 	// Treasury spend tests removed: treasury pallet is now config-only (account + portion for
 	// mining-rewards).
 

--- a/runtime/tests/governance/tech_collective.rs
+++ b/runtime/tests/governance/tech_collective.rs
@@ -1406,12 +1406,8 @@ mod tests {
 			));
 
 			assert!(
-				TechCollective::vote(
-					RuntimeOrigin::signed(non_member),
-					referendum_index,
-					true
-				)
-				.is_err(),
+				TechCollective::vote(RuntimeOrigin::signed(non_member), referendum_index, true)
+					.is_err(),
 				"Non-seeded account should be rejected with NotMember"
 			);
 		});


### PR DESCRIPTION
## Summary

- **Fix planck endowment bug**: `planck_config_genesis()` was calling `endowed_accounts.extend(planck_treasury_account())` which extended with the single multisig AccountId instead of the individual treasury signers. Changed to `endowed_accounts.extend(planck_treasury_signers())` so the three actual signers are endowed.
- **Add shared `log_genesis_accounts` helper**: All three presets (dev, heisenberg, planck) now use a single DRY function that logs endowed accounts, treasury address, treasury signers, and tech collective members on startup — regardless of how the chain spec was loaded.

## Context

Running `--chain planck_live_spec` produced wrong endowed accounts (3 bogus addresses from byte iteration of the multisig AccountId) and the tech collective was correctly seeded but endowed accounts did not match.

## Note

This PR does **not** include a regenerated `planck.json` chain spec. That will be done separately after a new runtime release is cut, using `scripts/genesis_generate_spec.sh` with the srtool-built WASM.

## Test plan

- [x] `cargo check -p quantus-runtime` passes
- [x] `build-spec --chain planck_live_spec --raw` produces correct accounts
- [x] CI passes
- [x] `cargo test -p quantus-runtime` passes