### PR TITLE
rpc: avoid blocking executor in peer_getbasicinfo

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 clap = { features = ["derive"], workspace = true }
 codec.workspace = true
+async-trait.workspace = true
 frame-benchmarking-cli = { workspace = true, default-features = true, optional = true }
 frame-metadata-hash-extension.default-features = true
 frame-metadata-hash-extension.workspace = true

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
 use quantus_runtime::{opaque::Block, AccountId, Balance, Nonce};
 use sc_network::service::traits::NetworkService;
@@ -36,7 +37,7 @@ pub struct PeerInfo {
 pub trait PeerApi {
 	/// Get basic peer information
 	#[method(name = "peer_getBasicInfo")]
-	fn get_basic_info(&self) -> RpcResult<PeerInfo>;
+	async fn get_basic_info(&self) -> RpcResult<PeerInfo>;
 }
 
 /// Peer RPC implementation
@@ -52,17 +53,17 @@ impl Peer {
 	}
 }
 
+#[async_trait]
 impl PeerApiServer for Peer {
-	fn get_basic_info(&self) -> RpcResult<PeerInfo> {
+	async fn get_basic_info(&self) -> RpcResult<PeerInfo> {
 		if let Some(network) = &self.network {
-			let network_state =
-				futures::executor::block_on(network.network_state()).map_err(|_| {
-					jsonrpsee::types::error::ErrorObject::owned(
-						5001,
-						"Failed to get network state",
-						None::<()>,
-					)
-				})?;
+			let network_state = network.network_state().await.map_err(|_| {
+				jsonrpsee::types::error::ErrorObject::owned(
+					5001,
+					"Failed to get network state",
+					None::<()>,
+				)
+			})?;
 
 			let connected_peers: Vec<String> =
 				network_state.connected_peers.keys().cloned().collect();


### PR DESCRIPTION
This change replaces blocking on the async runtime with a proper await when fetching network state for peer_getBasicInfo.

Using futures::executor::block_on inside jsonrpsee RPC handlers blocks the async runtime and can stall other RPC under load; this matches the async pattern already used in txwatch.rs.

made by mooncitydev