### PR TITLE
remove seed public and private key from cli command

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -99,6 +99,10 @@ pub enum QuantusKeySubcommand {
 		/// Disable HD derivation. Generates the same result as current behavior.
 		#[arg(long, default_value_t = false)]
 		no_derivation: bool,
+
+		/// Print sensitive key material (seed, public key, secret key). Useful for debugging.
+		#[arg(long, short = 'v', default_value_t = false)]
+		verbose: bool,
 	},
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -278,6 +278,7 @@ pub fn run() -> sc_cli::Result<()> {
 					words,
 					wallet_index,
 					no_derivation,
+					verbose,
 				} => {
 					match generate_quantus_key(
 						scheme.clone(),
@@ -326,6 +327,11 @@ pub fn run() -> sc_cli::Result<()> {
 										);
 									}
 									println!("Address: {}", details.address);
+									if *verbose {
+										println!("Seed: {}", details.seed_hex);
+										println!("Pub key: {}", details.public_key_hex);
+										println!("Secret key: {}", details.secret_key_hex);
+									}
 									println!(
                                         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
                                     );
@@ -352,6 +358,10 @@ pub fn run() -> sc_cli::Result<()> {
 										"Inner Hash: 0x{}",
 										details.inner_hash.unwrap_or_default()
 									);
+									if *verbose {
+										println!("Address hex: {}", details.public_key_hex);
+										println!("Secret: {}", details.secret_key_hex);
+									}
 									println!(
                                         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
                                     );

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -326,9 +326,6 @@ pub fn run() -> sc_cli::Result<()> {
 										);
 									}
 									println!("Address: {}", details.address);
-									println!("Seed: {}", details.seed_hex);
-									println!("Pub key: {}", details.public_key_hex);
-									println!("Secret key: {}", details.secret_key_hex);
 									println!(
                                         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
                                     );
@@ -351,12 +348,10 @@ pub fn run() -> sc_cli::Result<()> {
 										);
 									}
 									println!("Address: {}", details.address);
-									println!("Address hex: {}", details.public_key_hex);
 									println!(
 										"Inner Hash: 0x{}",
 										details.inner_hash.unwrap_or_default()
 									);
-									println!("Secret: {}", details.secret_key_hex);
 									println!(
                                         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
                                     );


### PR DESCRIPTION
❯ ./target/release/quantus-node key quantus 
Deriving HD path: m/44'/189189'/0'/0'/0'
Generating Quantus Standard address...
No seed or words provided. Generating a new 24-word phrase...
Deriving child with index 0 (path m/44'/189189'/0'/0'/0')
XXXXXXXXXXXXXXX Quantus Account Details XXXXXXXXXXXXXXXXX
Secret phrase: chapter pottery myself shine liberty load guilt health nurse bless thrive law embrace swear coast glue frost replace loyal garlic hill panic horror please
Account index: 0
Derivation path: m/44'/189189'/0'/0'/0'
Address: qzqD14n3eNm3fjScGDbY4ShXZxFrw8WbEUU622B3gvjywhQHj
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX