### PR TITLE
docs(mining): add Windows Setup section for Defender exclusion and recommended flags

### DIFF
--- a/MINING.md
+++ b/MINING.md
@@ -132,7 +132,7 @@ These flags are recommended for all platforms but are especially important on Wi
 
 #### Alternative: WSL2
 
-If you cannot add a Defender exclusion (e.g. managed device, no admin rights), running the Linux build under WSL2 is also supported — follow the Manual Installation instructions above from inside your WSL2 shell.
+If you cannot add a Defender exclusion (e.g. managed device, no admin rights), running the Linux build under WSL2 is also supported: follow the Manual Installation instructions above from inside your WSL2 shell.
 
 ### Docker Installation
 

--- a/MINING.md
+++ b/MINING.md
@@ -54,7 +54,7 @@ Get started mining on the Quantus Network testnet in minutes.
 - **RAM**: 4GB
 - **Storage**: 100GB available space
 - **Network**: Stable internet connection (3+ Mbps)
-- **OS**: Linux (Ubuntu 20.04+), macOS (10.15+), or Windows WSL2
+- **OS**: Linux (Ubuntu 20.04+), macOS (10.15+), or Windows 10/11 (native MSVC build or WSL2)
 
 > ⚠️ Connections below 3 Mbps will likely fail to keep the node synced with the network.
 
@@ -105,6 +105,35 @@ Minimal command - see --help for many more options
 ```
 
 **Note:** Use the `inner_hash` from step 3 as your `--rewards-inner-hash`. The node will derive your wormhole address and log it on startup.
+
+### Windows Setup
+
+The native Windows MSVC build (`quantus-node-*-x86_64-pc-windows-msvc.zip`) works on Windows 10/11, but requires two pieces of one-time setup before a full sync will complete.
+
+#### 1. Exclude the base-path from Windows Defender
+
+Real-time scanning on the RocksDB directory will block block-import IO and cause silent sync stalls (healthy peers, active network download, zero block progression).
+
+In an **elevated PowerShell** (Run as administrator):
+
+```powershell
+Add-MpPreference -ExclusionPath "$env:USERPROFILE\.quantus"
+```
+
+Adjust the path if you pass a custom `--base-path`. The exclusion only needs to be added once per machine.
+
+#### 2. Recommended sync flags
+
+```
+--sync full --max-blocks-per-request 64
+```
+
+These flags are recommended for all platforms but are especially important on Windows, where they reduce the blast radius of any residual IO hiccups during block-import.
+
+#### Alternative: WSL2
+
+If you cannot add a Defender exclusion (e.g. managed device, no admin rights), running the Linux build under WSL2 is also supported — follow the Manual Installation instructions above from inside your WSL2 shell.
+
 ### Docker Installation
 
 For users who prefer containerized deployment or have only Docker installed:


### PR DESCRIPTION
## Summary

Adds a `### Windows Setup` section to `MINING.md` covering two pieces of setup that a native MSVC build (`quantus-node-*-x86_64-pc-windows-msvc.zip`) requires before a full sync will complete on Windows 10/11:

1. Windows Defender exclusion for the base-path, to prevent real-time scanning from blocking RocksDB IO during block-import.
2. Recommended sync flags (`--sync full --max-blocks-per-request 64`) with a Windows-specific rationale.

Also updates the System Requirements OS line from "Windows WSL2" to "Windows 10/11 (native MSVC build or WSL2)" to reflect what's actually published in the release assets.

Fixes #550.

## Context

On a fresh Windows 11 install, a native MSVC node silently stalls during sync: healthy peers, active network download, `0.0 bps` block progression, no ERROR or WARN lines. Root cause is Windows Defender real-time scanning the hot RocksDB directory on every batch write.

Adding the base-path as a Defender exclusion fully resolves the stall. This PR does not add code. It documents the environment setup that's currently implicit. See #550 for the full symptom analysis, reproduction, and fix confirmation.

## Test plan

- [x] Fresh Windows 11 install, no prior `.quantus` dir
- [x] Applied Defender exclusion per new section
- [x] Ran with recommended flags
- [x] Confirmed sync to chain tip without stall (node stable at `💤 Idle` with steady `🏆 Imported`)
