### PR TITLE
feat: Miner-Stack - update

### DIFF
--- a/.github/workflows/miner-stack-compose.yml
+++ b/.github/workflows/miner-stack-compose.yml
@@ -1,0 +1,63 @@
+name: miner-stack compose config
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render default Compose config
+        working-directory: miner-stack
+        env:
+          REWARDS_INNER_HASH: "0x0000000000000000000000000000000000000000000000000000000000000000"
+        run: docker compose config >/tmp/quantus-miner-stack.default.yml
+
+      - name: Check default Compose config
+        run: |
+          set -euo pipefail
+          file=/tmp/quantus-miner-stack.default.yml
+          grep -Eq 'target: 9833' "$file"
+          grep -Eq 'published: "9833"' "$file"
+          grep -Eq 'protocol: udp' "$file"
+          grep -Eq 'target: 9900' "$file"
+          grep -Eq 'published: "9900"' "$file"
+          grep -Eq 'ipv4_address: 172\.28\.0\.10' "$file"
+          grep -Eq 'subnet: 172\.28\.0\.0/16' "$file"
+          grep -Eq 'MINER_CPU_WORKERS: "4"' "$file"
+          grep -Eq '172\.28\.0\.10:9833' "$file"
+          grep -Eq -- '--miner-listen-port' "$file"
+          grep -Eq -- '--metrics-port' "$file"
+
+      - name: Render override Compose config
+        working-directory: miner-stack
+        env:
+          REWARDS_INNER_HASH: "0x0000000000000000000000000000000000000000000000000000000000000000"
+          HOST_MINER_LISTEN_PORT: "9844"
+          HOST_MINER_METRICS_PORT: "9911"
+          QUANTUS_DOCKER_SUBNET: "172.29.0.0/16"
+          QUANTUS_NODE_IPV4: "172.29.0.10"
+          CPU_WORKERS: "8"
+        run: docker compose config >/tmp/quantus-miner-stack.override.yml
+
+      - name: Check override Compose config
+        run: |
+          set -euo pipefail
+          file=/tmp/quantus-miner-stack.override.yml
+          grep -Eq '172\.29\.0\.10:9833' "$file"
+          grep -Eq 'target: 9833' "$file"
+          grep -Eq 'published: "9844"' "$file"
+          grep -Eq 'protocol: udp' "$file"
+          grep -Eq 'target: 9900' "$file"
+          grep -Eq 'published: "9911"' "$file"
+          grep -Eq 'ipv4_address: 172\.29\.0\.10' "$file"
+          grep -Eq 'subnet: 172\.29\.0\.0/16' "$file"
+          grep -Eq 'MINER_CPU_WORKERS: "8"' "$file"
+          grep -Eq 'cpus: 8' "$file"
+          grep -Eq -- '--miner-listen-port' "$file"
+          grep -Eq -- '--metrics-port' "$file"

--- a/miner-stack/.env.example
+++ b/miner-stack/.env.example
@@ -7,6 +7,9 @@
 #   key quantus --scheme wormhole
 # Save the `inner_hash` value from the output and paste it below.
 # Mining rewards will be sent to the wormhole address derived from this preimage.
+# Treat REWARDS_INNER_HASH as sensitive ownership material. Do not commit `.env`,
+# paste it into support tickets, or share docker inspect, Compose config, logs,
+# or process output containing it.
 REWARDS_INNER_HASH=0xyour_inner_hash_here
 
 CHAIN=planck
@@ -28,11 +31,16 @@ NODE_NAME=my-quantus-node
 # P2P_PORT=30333
 # RPC_PORT=9944
 # PROMETHEUS_PORT=9615
-# MINER_LISTEN_PORT=9833    # QUIC port the node uses to accept miner connections (UDP)
-# MINER_METRICS_PORT=9900   # Prometheus endpoint exposed by the miner
+# HOST_MINER_LISTEN_PORT=9833 # Host UDP port mapped to node internal QUIC port 9833
+# HOST_MINER_METRICS_PORT=9900 # Host TCP port mapped to miner internal metrics port 9900
+
+# Docker network overrides
+# QUANTUS_DOCKER_SUBNET=172.28.0.0/16 # Change if this subnet overlaps another Docker network
+# QUANTUS_NODE_IPV4=172.28.0.10 # Static node IP inside the quantus Docker network
+# MINER_NODE_ADDR=172.28.0.10:9833 # Optional full override for bundled miner node address
 
 # Mining workers
-# CPU_WORKERS=4              # Number of CPU worker threads (default: auto-detect)
+# CPU_WORKERS=4 # Number of CPU worker threads and Docker CPU limit (Compose default: 4)
 # GPU_DEVICES=0              # Number of GPU devices to use (0 = CPU-only)
 # MINER_LOG=info             # RUST_LOG value for the miner (e.g. info, debug)
 

--- a/miner-stack/.env.example
+++ b/miner-stack/.env.example
@@ -2,17 +2,23 @@
 # REQUIRED - Edit these values
 # ============================================
 
-REWARDS_ADDRESS=your_ss58_address_here
+# Wormhole inner hash (32-byte preimage, 0x-prefixed hex).
+# Generate with: docker run --rm ghcr.io/quantus-network/quantus-node:latest \
+#   key quantus --scheme wormhole
+# Save the `inner_hash` value from the output and paste it below.
+# Mining rewards will be sent to the wormhole address derived from this preimage.
+REWARDS_INNER_HASH=0xyour_inner_hash_here
+
 CHAIN=planck
 NODE_NAME=my-quantus-node
-NODE_VERSION=v0.4.2
 
 # ============================================
 # OPTIONAL - Defaults are fine for most users
 # ============================================
 
-# NODE_VERSION=v0.4.2
-# MINER_VERSION=v1.0.0
+# Image versions
+# NODE_VERSION=latest
+# MINER_VERSION=latest
 
 # Network settings
 # IN_PEERS=256
@@ -22,9 +28,13 @@ NODE_VERSION=v0.4.2
 # P2P_PORT=30333
 # RPC_PORT=9944
 # PROMETHEUS_PORT=9615
+# MINER_LISTEN_PORT=9833    # QUIC port the node uses to accept miner connections (UDP)
+# MINER_METRICS_PORT=9900   # Prometheus endpoint exposed by the miner
 
-# Miner CPU workers (default: auto-detect)
-# WORKERS=4
+# Mining workers
+# CPU_WORKERS=4              # Number of CPU worker threads (default: auto-detect)
+# GPU_DEVICES=0              # Number of GPU devices to use (0 = CPU-only)
+# MINER_LOG=info             # RUST_LOG value for the miner (e.g. info, debug)
 
 # ============================================
 # MONITORING (optional - only if using docker-compose.monitoring.yml)

--- a/miner-stack/README.md
+++ b/miner-stack/README.md
@@ -1,8 +1,51 @@
-# Quantus Node & Miner - Docker Setup
+# Quantus Node & External Miner - Docker Setup
 
-Minimal Docker Compose setup for running a Quantus node with external miner.
+Minimal Docker Compose setup for running a Quantus validator node together with the
+external [`quantus-miner`](https://github.com/Quantus-Network/quantus-miner)
+service.
 
-## 🚀 Quick Start
+## Architecture
+
+```
+┌──────────────────────────┐                  ┌──────────────────────────┐
+│      quantus-node        │   QUIC :9833     │     quantus-miner        │
+│   (QUIC server, mining   │ ◀──────────────  │   (QUIC client, computes │
+│    job broadcaster)      │                  │    hashes on CPU/GPU)    │
+└──────────────────────────┘                  └──────────────────────────┘
+            ▲
+            │ p2p/rpc/prometheus
+            ▼
+       Quantus network
+```
+
+Since `quantus-miner v1.x` and the QUIC-based external miner protocol, the
+**node acts as the QUIC server** on `--miner-listen-port 9833` and one or
+more **miners connect to it as clients**. When `--miner-listen-port` is set,
+the node disables local mining and exclusively delegates work to connected
+miners.
+
+## Prerequisites
+
+You need a wormhole inner hash (a 32-byte preimage). Mining rewards are sent to
+the wormhole address derived from this preimage by the runtime, not directly
+to your SS58 address.
+
+Generate a wormhole keypair and copy the `inner_hash` value:
+
+```bash
+docker run --rm ghcr.io/quantus-network/quantus-node:latest \
+  key quantus --scheme wormhole
+```
+
+The output contains:
+
+- `Address` — your wormhole address (where rewards will be sent)
+- `inner_hash` — your 32-byte preimage (use this as `REWARDS_INNER_HASH`)
+
+**Save the mnemonic and inner_hash somewhere safe.** Without the inner_hash you
+cannot prove ownership of the rewards.
+
+## Quick Start
 
 ### 1. Configure
 
@@ -11,143 +54,260 @@ cp .env.example .env
 nano .env
 ```
 
-Edit these values:
-- `REWARDS_ADDRESS` - Your SS58 address for mining rewards
-- `NODE_NAME` - Your node name (visible in network)
+Edit at minimum:
+
+- `REWARDS_INNER_HASH` — your wormhole preimage (`0x...`, 64 hex chars)
+- `NODE_NAME` — your node name (visible in network)
 
 ### 2. Start
 
 ```bash
-# Start node and miner
+# Start node + miner
 docker compose up -d
 
-# Optional: Start with monitoring (Prometheus + Grafana)
+# Or, with monitoring (Prometheus + Grafana + node-exporter)
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 ### 3. Monitor
 
 ```bash
-# Check logs
 docker compose logs -f quantus-node
 docker compose logs -f quantus-miner
 ```
 
-**If monitoring is enabled**, access dashboards:
+If monitoring is enabled:
 
-- **Grafana** (metrics visualization): http://localhost:3000
-  - Default login: `quantus` / `quantus`
-  - Change credentials in `.env` via `GRAFANA_USER` and `GRAFANA_PASSWORD`
-  
-- **Prometheus** (metrics storage): http://localhost:9090
+- **Grafana**: http://localhost:3000
+  - Default login: `quantus` / `quantus` (change via `GRAFANA_USER` / `GRAFANA_PASSWORD` in `.env`)
+- **Prometheus**: http://localhost:9090
+- **Node Prometheus exporter**: http://localhost:9615/metrics
+- **Miner Prometheus exporter**: http://localhost:9900/metrics
 
-## 📋 Configuration
+## Configuration
 
-### Essential Settings
-
-Edit `.env` file:
+All configuration goes through `.env`:
 
 ```bash
 # Required
-REWARDS_ADDRESS=your_ss58_address_here
+REWARDS_INNER_HASH=0xyour_inner_hash_here
 CHAIN=planck
 NODE_NAME=my-quantus-node
+
+# Optional - image versions
+# NODE_VERSION=latest
+# MINER_VERSION=latest
+
+# Optional - mining workers
+# CPU_WORKERS=4         # CPU worker threads (default: auto-detect)
+# GPU_DEVICES=0         # GPU devices to use (0 = CPU-only)
+# MINER_LOG=info        # RUST_LOG for the miner
+
+# Optional - networking
+# IN_PEERS=256
+# OUT_PEERS=256
+
+# Optional - host port mapping
+# P2P_PORT=30333         # libp2p networking
+# RPC_PORT=9944          # JSON-RPC
+# PROMETHEUS_PORT=9615   # node Prometheus
+# MINER_LISTEN_PORT=9833 # QUIC port for miner connections (UDP)
+# MINER_METRICS_PORT=9900# miner Prometheus
 ```
 
-### Optional Settings
+> The node maps `9833/udp` to the host so that miners on other machines can
+> connect. If you only run the bundled miner inside this Compose project, you
+> can comment out that mapping — the miner reaches the node via the internal
+> Docker network at `172.28.0.10:9833` (the node has a pinned IPv4 in the
+> `quantus` bridge network because `quantus-miner` parses `--node-addr` as a
+> `SocketAddr` and cannot resolve service names).
 
-```bash
-NODE_VERSION=v0.4.2
-MINER_VERSION=v1.0.0
+## Commands
 
-# Miner workers (default: auto-detect)
-WORKERS=4
-
-# Network settings
-IN_PEERS=256
-OUT_PEERS=256
-
-# Ports
-P2P_PORT=30333
-RPC_PORT=9944
-PROMETHEUS_PORT=9615
-
-# Grafana credentials (only if using monitoring)
-GRAFANA_USER=quantus
-GRAFANA_PASSWORD=quantus
-```
-
-## 🛠️ Commands
-
-### Basic (Node + Miner)
+### Basic (node + miner)
 
 ```bash
 docker compose up -d        # Start
 docker compose down         # Stop
-docker compose logs -f      # View logs
-docker compose restart      # Restart
-docker compose ps           # Check status
+docker compose logs -f      # Tail all logs
+docker compose restart      # Restart all
+docker compose ps           # Status
 ```
 
-### With Monitoring
+### With monitoring
 
 ```bash
-# Start all (node + miner + monitoring)
+# Start everything (node + miner + monitoring)
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
-# Stop all
+# Stop everything
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml down
 
 # Stop only monitoring (keep node + miner running)
 docker compose -f docker-compose.monitoring.yml down
 ```
 
-## 📁 Data Structure
+### Pull updated images
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+## Layout
 
 ```
 miner-stack/
-├── docker-compose.yml            # Main: node + miner
-├── docker-compose.monitoring.yml # Optional: Prometheus + Grafana
-├── init-node.sh
-├── .env
-├── node-keys/                    # Node identity (persistent)
+├── docker-compose.yml             # Node + miner
+├── docker-compose.monitoring.yml  # Prometheus + Grafana + node-exporter
+├── init-node.sh                   # Generates node identity on first start
+├── .env                           # Local config (gitignored)
+├── .env.example                   # Reference config
+├── node-keys/                     # Persistent node identity (BACK THIS UP)
 │   └── key_node
-├── node-data/                    # Chain data (can be deleted)
+├── node-data/                     # Chain data (safe to delete)
 │   └── chains/
 ├── prometheus/
-│   └── prometheus.yml
+│   └── prometheus.yml             # Scrape config
 └── grafana/
-    └── provisioning/
+    ├── grafana.ini
+    ├── provisioning/              # Datasources + dashboards provider
+    └── dashboards/                # Bundled dashboards
+        └── quantus-node/
+            ├── overview.json
+            ├── quantus-business.json
+            ├── quantus-miner.json
+            ├── quantus-node-metrics.json
+            └── system-monitoring.json
 ```
 
-**Important:** `node-keys/` persists your node identity. Backup this directory!
+`node-keys/` persists the node's libp2p identity. Back it up — losing it
+means a new peer ID and a fresh sync.
 
-## 🔧 Troubleshooting
+## Bundled Dashboards
 
-### Check node status
+| Dashboard | Description |
+|-----------|-------------|
+| **Overview** | High-level snapshot: block height, peers, miner hash rate, host CPU & memory |
+| **Quantus Business** | Chain-level QPoW metrics: chain height, block time EMA, last block duration, difficulty |
+| **Quantus Miner Metrics** | Miner: total/CPU/GPU hash rate, active jobs, workers, GPU devices, cumulative hashes |
+| **Quantus Node Metrics** | Substrate metrics: block height, peers, network traffic, task polling |
+| **System Monitoring** | Host: CPU, memory, disk, network, load |
+
+## Adjusting Miner Workload
+
+The miner reads worker counts from environment variables (forwarded from
+`.env`):
+
+- `CPU_WORKERS` → `MINER_CPU_WORKERS` (number of CPU threads, default auto-detect)
+- `GPU_DEVICES` → `MINER_GPU_DEVICES` (number of GPU devices, default `0`)
+- `MINER_LOG` → `RUST_LOG` for the miner
+
+Examples:
+
 ```bash
-docker compose logs quantus-node | grep "Syncing"
+# 8 CPU workers, no GPU
+echo "CPU_WORKERS=8" >> .env
+
+# CPU + GPU hybrid (requires GPU-enabled image / drivers)
+echo "CPU_WORKERS=4" >> .env
+echo "GPU_DEVICES=1" >> .env
+
+# Verbose miner logs
+echo "MINER_LOG=debug" >> .env
+
+docker compose up -d --force-recreate quantus-miner
 ```
 
-### Check peer count
+> The default `ghcr.io/quantus-network/quantus-miner:latest` image is built
+> without CUDA. For GPU mining on Linux you typically need a GPU-enabled
+> build of the miner and the NVIDIA Container Toolkit. See the
+> [`quantus-miner` repository](https://github.com/Quantus-Network/quantus-miner)
+> for GPU build instructions.
+
+## Troubleshooting
+
+### Node sync status
+
 ```bash
-curl -H "Content-Type: application/json" \
-  -d '{"id":1, "jsonrpc":"2.0", "method": "system_peers"}' \
-  http://localhost:9944
+docker compose logs quantus-node | grep -E "Syncing|Idle|Imported"
 ```
+
+### Peer count
+
+```bash
+curl -s -H "Content-Type: application/json" \
+  -d '{"id":1,"jsonrpc":"2.0","method":"system_peers"}' \
+  http://localhost:9944 | jq '.result | length'
+```
+
+### Miner connectivity
+
+The miner periodically retries the QUIC connection to the node. Check that:
+
+```bash
+docker compose logs quantus-miner | grep -E "connect|connected|node-addr|error"
+```
+
+If the miner cannot reach the node, ensure:
+- Both containers are on the same `quantus` Docker network (default).
+- The node started successfully and printed something like
+  `External miner QUIC server listening on 0.0.0.0:9833`.
+
+### Verify miner metrics
+
+```bash
+curl -s http://localhost:9900/metrics | grep -E "miner_(hash_rate|active_jobs|workers|cpu_workers|gpu_devices|hashes_total)"
+```
+
+You should see values for:
+
+- `miner_hash_rate` (total H/s)
+- `miner_cpu_hash_rate` / `miner_gpu_hash_rate`
+- `miner_active_jobs` (0 or 1)
+- `miner_cpu_workers` / `miner_gpu_devices` / `miner_workers` / `miner_effective_cpus`
+- `miner_hashes_total` (counter)
 
 ### Port conflicts
-Change ports in `.env` file.
+
+Override ports in `.env` (see `MINER_LISTEN_PORT`, `MINER_METRICS_PORT`,
+`P2P_PORT`, `RPC_PORT`, `PROMETHEUS_PORT`).
 
 ### Reset chain data
+
 ```bash
 docker compose down
 rm -rf node-data/
 docker compose up -d
 ```
 
-Node key will be preserved in `node-keys/`.
+The node identity in `node-keys/` is preserved.
+
+### Rotate / regenerate node identity
+
+```bash
+docker compose down
+rm -rf node-keys/
+docker compose up -d   # init-node.sh will regenerate key_node on startup
+```
+
+## Multiple Miners
+
+You can connect additional miners (on the same host or another host) to the
+node. The node broadcasts every job to all connected miners; whoever finds a
+valid solution first wins. To run an extra miner from another host, expose
+`MINER_LISTEN_PORT` (UDP) on the node's host and start a miner anywhere with:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -p 9900:9900 \
+  ghcr.io/quantus-network/quantus-miner:latest \
+  serve \
+  --node-addr <NODE_HOST>:9833 \
+  --cpu-workers 4 \
+  --metrics-port 9900
+```
 
 ---
 
-**Happy Mining! ⛏️**
+**Happy mining.**

--- a/miner-stack/README.md
+++ b/miner-stack/README.md
@@ -45,6 +45,10 @@ The output contains:
 **Save the mnemonic and inner_hash somewhere safe.** Without the inner_hash you
 cannot prove ownership of the rewards.
 
+Treat `REWARDS_INNER_HASH` as sensitive ownership material. Do not commit
+`.env`, paste it into support tickets, or share `docker inspect`,
+`docker compose config`, logs, or process output containing it.
+
 ## Quick Start
 
 ### 1. Configure
@@ -82,7 +86,8 @@ If monitoring is enabled:
   - Default login: `quantus` / `quantus` (change via `GRAFANA_USER` / `GRAFANA_PASSWORD` in `.env`)
 - **Prometheus**: http://localhost:9090
 - **Node Prometheus exporter**: http://localhost:9615/metrics
-- **Miner Prometheus exporter**: http://localhost:9900/metrics
+- **Miner Prometheus exporter**: http://localhost:9900/metrics by default. If
+  `HOST_MINER_METRICS_PORT` is changed, use that host port instead.
 
 ## Configuration
 
@@ -99,7 +104,7 @@ NODE_NAME=my-quantus-node
 # MINER_VERSION=latest
 
 # Optional - mining workers
-# CPU_WORKERS=4         # CPU worker threads (default: auto-detect)
+# CPU_WORKERS=4         # CPU worker threads and Docker CPU limit (Compose default: 4)
 # GPU_DEVICES=0         # GPU devices to use (0 = CPU-only)
 # MINER_LOG=info        # RUST_LOG for the miner
 
@@ -111,16 +116,25 @@ NODE_NAME=my-quantus-node
 # P2P_PORT=30333         # libp2p networking
 # RPC_PORT=9944          # JSON-RPC
 # PROMETHEUS_PORT=9615   # node Prometheus
-# MINER_LISTEN_PORT=9833 # QUIC port for miner connections (UDP)
-# MINER_METRICS_PORT=9900# miner Prometheus
+# HOST_MINER_LISTEN_PORT=9833  # Host UDP port mapped to node internal QUIC port 9833
+# HOST_MINER_METRICS_PORT=9900 # Host TCP port mapped to miner internal metrics port 9900
+
+# Optional - Docker network overrides
+# QUANTUS_DOCKER_SUBNET=172.28.0.0/16 # Change if this subnet overlaps another Docker network
+# QUANTUS_NODE_IPV4=172.28.0.10       # Static node IP inside the quantus Docker network
+# MINER_NODE_ADDR=172.28.0.10:9833    # Optional full override for bundled miner node address
 ```
 
-> The node maps `9833/udp` to the host so that miners on other machines can
-> connect. If you only run the bundled miner inside this Compose project, you
-> can comment out that mapping — the miner reaches the node via the internal
-> Docker network at `172.28.0.10:9833` (the node has a pinned IPv4 in the
-> `quantus` bridge network because `quantus-miner` parses `--node-addr` as a
-> `SocketAddr` and cannot resolve service names).
+Inside Compose, the node listens for miner QUIC connections on UDP `9833`.
+The bundled miner connects to `${QUANTUS_NODE_IPV4:-172.28.0.10}:9833` by
+default. `HOST_MINER_LISTEN_PORT` only changes the host-published UDP port for
+miners outside the Compose network, and `HOST_MINER_METRICS_PORT` only changes
+the host-published TCP port for reading miner metrics from the host.
+
+> The node has a pinned IPv4 in the `quantus` bridge network because
+> `quantus-miner` parses `--node-addr` as a `SocketAddr` and cannot rely on
+> Docker DNS names. If `172.28.0.0/16` overlaps another Docker network, set
+> `QUANTUS_DOCKER_SUBNET` and `QUANTUS_NODE_IPV4` in `.env`.
 
 ## Commands
 
@@ -199,7 +213,9 @@ means a new peer ID and a fresh sync.
 The miner reads worker counts from environment variables (forwarded from
 `.env`):
 
-- `CPU_WORKERS` → `MINER_CPU_WORKERS` (number of CPU threads, default auto-detect)
+- `CPU_WORKERS` → `MINER_CPU_WORKERS`; in this Compose stack, `CPU_WORKERS`
+  defaults to `4` and is also used as the miner container CPU limit. Set
+  `CPU_WORKERS=<n>` in `.env` to use a different number.
 - `GPU_DEVICES` → `MINER_GPU_DEVICES` (number of GPU devices, default `0`)
 - `MINER_LOG` → `RUST_LOG` for the miner
 
@@ -260,6 +276,9 @@ If the miner cannot reach the node, ensure:
 curl -s http://localhost:9900/metrics | grep -E "miner_(hash_rate|active_jobs|workers|cpu_workers|gpu_devices|hashes_total)"
 ```
 
+The default metrics endpoint is `http://localhost:9900/metrics`. If
+`HOST_MINER_METRICS_PORT` is changed, use that host port instead.
+
 You should see values for:
 
 - `miner_hash_rate` (total H/s)
@@ -270,8 +289,20 @@ You should see values for:
 
 ### Port conflicts
 
-Override ports in `.env` (see `MINER_LISTEN_PORT`, `MINER_METRICS_PORT`,
-`P2P_PORT`, `RPC_PORT`, `PROMETHEUS_PORT`).
+Override host-published ports in `.env` (see `HOST_MINER_LISTEN_PORT`,
+`HOST_MINER_METRICS_PORT`, `P2P_PORT`, `RPC_PORT`, `PROMETHEUS_PORT`).
+
+### Docker subnet conflicts
+
+If Docker reports an overlapping address pool or subnet, set
+`QUANTUS_DOCKER_SUBNET` and `QUANTUS_NODE_IPV4` in `.env` to an unused private
+subnet/IP, then recreate the stack. Update `MINER_NODE_ADDR` only if you need
+to override the full bundled miner node address.
+
+```bash
+QUANTUS_DOCKER_SUBNET=172.29.0.0/16
+QUANTUS_NODE_IPV4=172.29.0.10
+```
 
 ### Reset chain data
 
@@ -296,17 +327,23 @@ docker compose up -d   # init-node.sh will regenerate key_node on startup
 You can connect additional miners (on the same host or another host) to the
 node. The node broadcasts every job to all connected miners; whoever finds a
 valid solution first wins. To run an extra miner from another host, expose
-`MINER_LISTEN_PORT` (UDP) on the node's host and start a miner anywhere with:
+`HOST_MINER_LISTEN_PORT` (UDP) on the node's host and start a miner anywhere
+with:
 
 ```bash
 docker run --rm --platform linux/amd64 \
   -p 9900:9900 \
   ghcr.io/quantus-network/quantus-miner:latest \
   serve \
-  --node-addr <NODE_HOST>:9833 \
+  --node-addr <node-host-ip>:9833 \
   --cpu-workers 4 \
   --metrics-port 9900
 ```
+
+Replace `<node-host-ip>` with the Docker host's reachable IP or DNS name.
+Replace `9833` with `HOST_MINER_LISTEN_PORT` if changed. The `-p 9900:9900`
+mapping exposes that extra miner's metrics endpoint and can be changed if
+needed.
 
 ---
 

--- a/miner-stack/docker-compose.yml
+++ b/miner-stack/docker-compose.yml
@@ -27,12 +27,14 @@ services:
       - "${P2P_PORT:-30333}:30333"
       - "${RPC_PORT:-9944}:9944"
       - "${PROMETHEUS_PORT:-9615}:9615"
-      - "${MINER_LISTEN_PORT:-9833}:9833/udp"
+      # Host-published UDP port only; the node still listens on internal QUIC port 9833.
+      - "${HOST_MINER_LISTEN_PORT:-9833}:9833/udp"
     networks:
       quantus:
-        # Pinned IPv4: quantus-miner needs --node-addr as IP:port (SocketAddr),
-        # it cannot resolve the "quantus-node" DNS name on its own.
-        ipv4_address: 172.28.0.10
+        # Pinned IPv4: quantus-miner needs --node-addr as IP:port (SocketAddr)
+        # and cannot rely on Docker DNS names. Change QUANTUS_DOCKER_SUBNET and
+        # QUANTUS_NODE_IPV4 if the default subnet overlaps another Docker network.
+        ipv4_address: ${QUANTUS_NODE_IPV4:-172.28.0.10}
     deploy:
       resources:
         limits:
@@ -46,7 +48,7 @@ services:
     restart: unless-stopped
     command: >
       serve
-      --node-addr ${MINER_NODE_ADDR:-172.28.0.10:9833}
+      --node-addr ${MINER_NODE_ADDR:-${QUANTUS_NODE_IPV4:-172.28.0.10}:9833}
       --metrics-port 9900
     environment:
       - MINER_CPU_WORKERS=${CPU_WORKERS:-4}
@@ -55,7 +57,8 @@ services:
     depends_on:
       - quantus-node
     ports:
-      - "${MINER_METRICS_PORT:-9900}:9900"
+      # Host-published TCP port only; the miner still exposes metrics internally on 9900.
+      - "${HOST_MINER_METRICS_PORT:-9900}:9900"
     networks:
       - quantus
     deploy:
@@ -70,4 +73,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.28.0.0/16
+        - subnet: ${QUANTUS_DOCKER_SUBNET:-172.28.0.0/16}

--- a/miner-stack/docker-compose.yml
+++ b/miner-stack/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       --base-path /var/lib/quantus
       --chain ${CHAIN:-planck}
       --node-key-file /node-keys/key_node
-      --rewards-address ${REWARDS_ADDRESS}
+      --rewards-inner-hash ${REWARDS_INNER_HASH}
       --name ${NODE_NAME:-my-quantus-node}
       --wasm-execution compiled
       --db-cache 2048
@@ -18,19 +18,21 @@ services:
       --in-peers ${IN_PEERS:-256}
       --out-peers ${OUT_PEERS:-256}
       --prometheus-external
-      --external-miner-url http://quantus-miner:9833
+      --miner-listen-port 9833
     volumes:
       - ./init-node.sh:/init-node.sh:ro
       - ./node-keys:/node-keys
       - ./node-data:/var/lib/quantus
-    depends_on:
-      - quantus-miner
     ports:
       - "${P2P_PORT:-30333}:30333"
       - "${RPC_PORT:-9944}:9944"
       - "${PROMETHEUS_PORT:-9615}:9615"
+      - "${MINER_LISTEN_PORT:-9833}:9833/udp"
     networks:
-      - quantus
+      quantus:
+        # Pinned IPv4: quantus-miner needs --node-addr as IP:port (SocketAddr),
+        # it cannot resolve the "quantus-node" DNS name on its own.
+        ipv4_address: 172.28.0.10
     deploy:
       resources:
         limits:
@@ -42,20 +44,30 @@ services:
     container_name: ${MINER_CONTAINER_NAME:-quantus-miner}
     platform: linux/amd64
     restart: unless-stopped
-    command: --metrics-port 9900
+    command: >
+      serve
+      --node-addr ${MINER_NODE_ADDR:-172.28.0.10:9833}
+      --metrics-port 9900
     environment:
-      - WORKERS=${WORKERS:-4}
+      - MINER_CPU_WORKERS=${CPU_WORKERS:-4}
+      - MINER_GPU_DEVICES=${GPU_DEVICES:-0}
+      - RUST_LOG=${MINER_LOG:-info}
+    depends_on:
+      - quantus-node
     ports:
-      - "9833:9833"  # Miner API
-      - "9900:9900"  # Miner metrics
+      - "${MINER_METRICS_PORT:-9900}:9900"
     networks:
       - quantus
     deploy:
       resources:
         limits:
-          cpus: '${WORKERS:-4}'
+          cpus: '${CPU_WORKERS:-4}'
           memory: 4G
 
 networks:
   quantus:
     driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16

--- a/miner-stack/grafana/dashboards/quantus-node/quantus-miner.json
+++ b/miner-stack/grafana/dashboards/quantus-node/quantus-miner.json
@@ -33,8 +33,8 @@
         }
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 6,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -64,7 +64,7 @@
           "refId": "A"
         }
       ],
-      "title": "Hash Rate",
+      "title": "Total Hash Rate",
       "type": "stat"
     },
     {
@@ -87,16 +87,134 @@
                 "value": null
               }
             ]
+          },
+          "unit": "Hashes/sec"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "miner_cpu_hash_rate{job=\"quantus-miner\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Hash Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Hashes/sec"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "miner_gpu_hash_rate{job=\"quantus-miner\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Hash Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
           }
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 4,
         "w": 6,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 6
       },
-      "id": 2,
+      "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -133,7 +251,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "purple",
+            "fixedColor": "blue",
             "mode": "fixed"
           },
           "mappings": [],
@@ -141,7 +259,125 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "purple",
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "miner_cpu_workers{job=\"quantus-miner\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "miner_gpu_devices{job=\"quantus-miner\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Devices",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
                 "value": null
               }
             ]
@@ -150,12 +386,12 @@
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 4,
         "w": 6,
         "x": 18,
-        "y": 0
+        "y": 6
       },
-      "id": 3,
+      "id": 7,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -209,7 +445,7 @@
               "legend": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -238,21 +474,21 @@
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 10
       },
-      "id": 4,
+      "id": 8,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -263,95 +499,28 @@
           },
           "expr": "miner_hash_rate{job=\"quantus-miner\"}",
           "refId": "A",
-          "legendFormat": "Hash Rate"
-        }
-      ],
-      "title": "Hash Rate Over Time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "Hashes/sec"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "legendFormat": "Total"
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "miner_thread_hash_rate{job=\"quantus-miner\"}",
-          "refId": "A",
-          "legendFormat": "Thread {{thread}}"
+          "expr": "miner_cpu_hash_rate{job=\"quantus-miner\"}",
+          "refId": "B",
+          "legendFormat": "CPU"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "miner_gpu_hash_rate{job=\"quantus-miner\"}",
+          "refId": "C",
+          "legendFormat": "GPU"
         }
       ],
-      "title": "Hash Rate Per Thread",
+      "title": "Hash Rate Over Time (Total / CPU / GPU)",
       "type": "timeseries"
     },
     {
@@ -362,7 +531,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "blue",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -378,8 +548,8 @@
               "viz": false,
               "legend": false
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -399,20 +569,23 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "short",
+          "max": 1.5,
+          "min": 0
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 19
       },
-      "id": 6,
+      "id": 9,
       "options": {
         "legend": {
           "calcs": [],
@@ -430,12 +603,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "miner_jobs_total{job=\"quantus-miner\"}",
+          "expr": "miner_active_jobs{job=\"quantus-miner\"}",
           "refId": "A",
-          "legendFormat": "{{status}}"
+          "legendFormat": "Active Jobs"
         }
       ],
-      "title": "Jobs by Status",
+      "title": "Active Jobs Over Time",
       "type": "timeseries"
     },
     {
@@ -463,91 +636,7 @@
               "legend": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(miner_mine_requests_total{job=\"quantus-miner\"}[5m])",
-          "refId": "A",
-          "legendFormat": "{{result}}"
-        }
-      ],
-      "title": "Mine Requests Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -576,12 +665,98 @@
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(miner_hashes_total{job=\"quantus-miner\"}[1m])",
+          "refId": "A",
+          "legendFormat": "Hashes/sec (rate over 1m)"
+        }
+      ],
+      "title": "Hash Throughput (rate of total hashes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 26
       },
-      "id": 8,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [],
@@ -604,7 +779,7 @@
           "legendFormat": "Total Hashes"
         }
       ],
-      "title": "Total Hashes",
+      "title": "Cumulative Hashes Computed",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
Brings `miner-stack/` up to date with the current node + miner contracts.
### Node ↔ miner protocol
- Switch from the deprecated HTTP `--external-miner-url` to the new QUIC-based
  protocol: node now runs as the QUIC server (`--miner-listen-port 9833`) and
  miners connect to it as clients via `serve --node-addr`.
- Pin `quantus-node` to a static IPv4 (`172.28.0.10`) on the bridge network —
  `quantus-miner` requires a `SocketAddr` for `--node-addr` and cannot resolve
  the Docker DNS name on its own.
- Expose `9833/udp` on the host so miners on other machines can attach.
### Rewards
- Replace SS58 `REWARDS_ADDRESS` with `REWARDS_INNER_HASH` (32-byte wormhole
  preimage), matching the current node CLI. The wormhole address is derived
  by the runtime.
### Configuration
- New env knobs: `CPU_WORKERS`, `GPU_DEVICES`, `MINER_LOG`,
  `MINER_LISTEN_PORT`, `MINER_METRICS_PORT`.
- `.env.example` cleaned up; image versions default to `latest`.
### Docs & dashboards
- README rewritten: setup, prerequisites (wormhole keypair generation),
  monitoring, multi-miner topology, troubleshooting.
- Refreshed `quantus-miner` Grafana dashboard.