### PR TITLE
replace static variable with feature for fast governance during testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           cargo clean
           df -h
       - name: test
-        run: SKIP_WASM_BUILD=1 cargo test --locked --workspace
+        run: SKIP_WASM_BUILD=1 cargo test --locked --workspace --features quantus-runtime/fast-governance
 
   analysis:
     name: 🤖 Analysis (Clippy & Doc)

--- a/pallets/reversible-transfers/src/lib.rs
+++ b/pallets/reversible-transfers/src/lib.rs
@@ -26,7 +26,6 @@ pub use weights::WeightInfo;
 
 use alloc::vec::Vec;
 use frame_support::{
-	defensive,
 	pallet_prelude::*,
 	traits::tokens::{fungibles::MutateHold as AssetsHold, Fortitude, Restriction},
 };

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -193,10 +193,10 @@ try-runtime = [
 metadata-hash = ["substrate-wasm-builder/metadata-hash"]
 
 
-# Feature for running governance tests with production timing values
-# These tests use real mainnet timing (hours/days) instead of fast 2-block periods
-# Useful for comprehensive validation but much slower than default fast tests
-production-governance-tests = []
+# Collapses every referenda track timing window to 2 blocks at compile time.
+# Enabled by CI for fast integration tests. Production builds must NEVER enable
+# this — the feature being off is what guarantees mainnet timing.
+fast-governance = []
 
 # A convenience feature for enabling things when doing a build
 # for an on-chain release.

--- a/runtime/src/governance/definitions.rs
+++ b/runtime/src/governance/definitions.rs
@@ -80,57 +80,26 @@ impl Consideration<AccountId, Footprint> for PreimageDeposit {
 	}
 }
 
-/// Global dynamic configuration for ALL governance tracks
-/// This allows tests to override the production timing values at runtime
-pub struct GlobalTrackConfig;
+/// Collapses every referenda timing window to 2 blocks when the
+/// `fast-governance` feature is enabled; otherwise leaves the track untouched.
+/// Selected at compile time so production builds carry no override state.
+#[cfg(feature = "fast-governance")]
+fn apply_test_timing(
+	mut info: pallet_referenda::TrackInfo<Balance, BlockNumber>,
+) -> pallet_referenda::TrackInfo<Balance, BlockNumber> {
+	info.prepare_period = 2;
+	info.decision_period = 2;
+	info.confirm_period = 2;
+	info.min_enactment_period = 2;
+	info
+}
 
-static mut GLOBAL_TRACK_OVERRIDE: Option<(BlockNumber, BlockNumber, BlockNumber, BlockNumber)> =
-	None;
-
-impl GlobalTrackConfig {
-	/// Set global track timing overrides for ALL governance tracks
-	/// This affects CommunityTracksInfo and TechCollectiveTracksInfo
-	pub fn set_track_override(
-		prepare_period: BlockNumber,
-		decision_period: BlockNumber,
-		confirm_period: BlockNumber,
-		min_enactment_period: BlockNumber,
-	) {
-		unsafe {
-			GLOBAL_TRACK_OVERRIDE =
-				Some((prepare_period, decision_period, confirm_period, min_enactment_period));
-		}
-	}
-
-	/// Get current global timing override, or None if using production values
-	pub fn get_track_override() -> Option<(BlockNumber, BlockNumber, BlockNumber, BlockNumber)> {
-		unsafe { GLOBAL_TRACK_OVERRIDE }
-	}
-
-	/// Clear global overrides - return to production values
-	pub fn clear_track_override() {
-		unsafe {
-			GLOBAL_TRACK_OVERRIDE = None;
-		}
-	}
-
-	/// Set fast test timing (2 blocks for all periods) for ALL tracks
-	pub fn set_fast_test_timing() {
-		Self::set_track_override(2, 2, 2, 2);
-	}
-
-	/// Apply timing overrides to a track if global overrides are set
-	pub fn apply_timing_override(
-		mut track: pallet_referenda::TrackInfo<Balance, BlockNumber>,
-	) -> pallet_referenda::TrackInfo<Balance, BlockNumber> {
-		if let Some((prepare, decision, confirm, enactment)) = Self::get_track_override() {
-			track.prepare_period = prepare;
-			track.decision_period = decision;
-			track.confirm_period = confirm;
-			track.min_enactment_period = enactment;
-		}
-		track
-	}
+#[cfg(not(feature = "fast-governance"))]
+#[inline]
+fn apply_test_timing(
+	info: pallet_referenda::TrackInfo<Balance, BlockNumber>,
+) -> pallet_referenda::TrackInfo<Balance, BlockNumber> {
+	info
 }
 
 // Define tracks for referenda
@@ -141,31 +110,28 @@ impl CommunityTracksInfo {
 	/// Only one track (Signed) - RawOrigin::None removed to fix F-04 (inherent-only call
 	/// vulnerability).
 	fn create_community_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
-		[
-			// Track 0: Signed Track (authenticated proposals, incl. System::remark for signaling)
-			pallet_referenda::Track {
-				id: 0,
-				info: pallet_referenda::TrackInfo {
-					name: str_array("signed"),
-					max_deciding: 5,                   // Allow several concurrent proposals
-					decision_deposit: 500_u128 * UNIT, // Moderate deposit
-					prepare_period: 12 * HOURS,        // Shorter preparation time
-					decision_period: 7 * DAYS,         // 1 week voting period
-					confirm_period: 12 * HOURS,        // 12 hours confirmation
-					min_enactment_period: DAYS,        // 1 day until execution
-					min_approval: pallet_referenda::Curve::LinearDecreasing {
-						length: Perbill::from_percent(100),
-						floor: Perbill::from_percent(55), // Majority approval required
-						ceil: Perbill::from_percent(70),
-					},
-					min_support: pallet_referenda::Curve::LinearDecreasing {
-						length: Perbill::from_percent(100),
-						floor: Perbill::from_percent(5),
-						ceil: Perbill::from_percent(25),
-					},
+		[pallet_referenda::Track {
+			id: 0,
+			info: apply_test_timing(pallet_referenda::TrackInfo {
+				name: str_array("signed"),
+				max_deciding: 5,
+				decision_deposit: 500_u128 * UNIT,
+				prepare_period: 12 * HOURS,
+				decision_period: 7 * DAYS,
+				confirm_period: 12 * HOURS,
+				min_enactment_period: DAYS,
+				min_approval: pallet_referenda::Curve::LinearDecreasing {
+					length: Perbill::from_percent(100),
+					floor: Perbill::from_percent(55),
+					ceil: Perbill::from_percent(70),
 				},
-			},
-		]
+				min_support: pallet_referenda::Curve::LinearDecreasing {
+					length: Perbill::from_percent(100),
+					floor: Perbill::from_percent(5),
+					ceil: Perbill::from_percent(25),
+				},
+			}),
+		}]
 	}
 }
 
@@ -175,35 +141,11 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for CommunityTracksInfo 
 
 	fn tracks(
 	) -> impl Iterator<Item = alloc::borrow::Cow<'static, Track<Self::Id, Balance, BlockNumber>>> {
-		// Static tracks with production values
 		lazy_static! {
-			static ref STATIC_TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] =
+			static ref TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] =
 				CommunityTracksInfo::create_community_tracks();
 		}
-
-		// Test tracks with fast governance timing
-		lazy_static! {
-			static ref TEST_TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] = {
-				let base_tracks = CommunityTracksInfo::create_community_tracks();
-				let mut test_tracks = base_tracks.clone();
-
-				// Apply global timing overrides to all tracks
-				for track in &mut test_tracks {
-					track.info = GlobalTrackConfig::apply_timing_override(track.info.clone());
-				}
-
-				test_tracks
-			};
-		}
-
-		// Return the appropriate tracks based on whether global overrides are set
-		let tracks_slice = if GlobalTrackConfig::get_track_override().is_some() {
-			&*TEST_TRACKS
-		} else {
-			&*STATIC_TRACKS
-		};
-
-		tracks_slice.iter().map(Cow::Borrowed)
+		TRACKS.iter().map(Cow::Borrowed)
 	}
 
 	fn track_for(id: &Self::RuntimeOrigin) -> Result<Self::Id, ()> {
@@ -231,7 +173,7 @@ impl TechCollectiveTracksInfo {
 	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
 		[pallet_referenda::Track {
 			id: 0,
-			info: pallet_referenda::TrackInfo {
+			info: apply_test_timing(pallet_referenda::TrackInfo {
 				name: str_array("tech_collective_members"),
 				max_deciding: 1,
 				decision_deposit: 1000 * UNIT,
@@ -249,7 +191,7 @@ impl TechCollectiveTracksInfo {
 					floor: Perbill::from_percent(0),
 					ceil: Perbill::from_percent(0),
 				},
-			},
+			}),
 		}]
 	}
 }
@@ -261,33 +203,11 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TechCollectiveTracks
 	fn tracks(
 	) -> impl Iterator<Item = Cow<'static, pallet_referenda::Track<Self::Id, Balance, BlockNumber>>>
 	{
-		// Static tracks with production values
 		lazy_static! {
-			static ref STATIC_TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] =
+			static ref TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] =
 				TechCollectiveTracksInfo::create_tech_collective_tracks();
 		}
-
-		// Test tracks with fast governance timing
-		lazy_static! {
-			static ref TEST_TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] = {
-				let base_tracks = TechCollectiveTracksInfo::create_tech_collective_tracks();
-				let mut test_tracks = [base_tracks[0].clone()];
-
-				// Apply global timing override to the track
-				test_tracks[0].info = GlobalTrackConfig::apply_timing_override(test_tracks[0].info.clone());
-
-				test_tracks
-			};
-		}
-
-		// Return the appropriate tracks based on whether global overrides are set
-		let tracks_slice = if GlobalTrackConfig::get_track_override().is_some() {
-			&*TEST_TRACKS
-		} else {
-			&*STATIC_TRACKS
-		};
-
-		tracks_slice.iter().map(Cow::Borrowed)
+		TRACKS.iter().map(Cow::Borrowed)
 	}
 
 	fn track_for(id: &Self::RuntimeOrigin) -> Result<Self::Id, ()> {

--- a/runtime/src/governance/definitions.rs
+++ b/runtime/src/governance/definitions.rs
@@ -81,8 +81,8 @@ impl Consideration<AccountId, Footprint> for PreimageDeposit {
 }
 
 /// Collapses every referenda timing window to 2 blocks when the
-/// `fast-governance` feature is enabled; otherwise leaves the track untouched.
-/// Selected at compile time so production builds carry no override state.
+/// `fast-governance` feature is enabled. Only compiled into test builds; production
+/// builds never reference this function or its callers.
 #[cfg(feature = "fast-governance")]
 fn apply_test_timing(
 	mut info: pallet_referenda::TrackInfo<Balance, BlockNumber>,
@@ -94,14 +94,6 @@ fn apply_test_timing(
 	info
 }
 
-#[cfg(not(feature = "fast-governance"))]
-#[inline]
-fn apply_test_timing(
-	info: pallet_referenda::TrackInfo<Balance, BlockNumber>,
-) -> pallet_referenda::TrackInfo<Balance, BlockNumber> {
-	info
-}
-
 // Define tracks for referenda
 pub struct CommunityTracksInfo;
 
@@ -110,28 +102,28 @@ impl CommunityTracksInfo {
 	/// Only one track (Signed) - RawOrigin::None removed to fix F-04 (inherent-only call
 	/// vulnerability).
 	fn create_community_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
-		[pallet_referenda::Track {
-			id: 0,
-			info: apply_test_timing(pallet_referenda::TrackInfo {
-				name: str_array("signed"),
-				max_deciding: 5,
-				decision_deposit: 500_u128 * UNIT,
-				prepare_period: 12 * HOURS,
-				decision_period: 7 * DAYS,
-				confirm_period: 12 * HOURS,
-				min_enactment_period: DAYS,
-				min_approval: pallet_referenda::Curve::LinearDecreasing {
-					length: Perbill::from_percent(100),
-					floor: Perbill::from_percent(55),
-					ceil: Perbill::from_percent(70),
-				},
-				min_support: pallet_referenda::Curve::LinearDecreasing {
-					length: Perbill::from_percent(100),
-					floor: Perbill::from_percent(5),
-					ceil: Perbill::from_percent(25),
-				},
-			}),
-		}]
+		let info = pallet_referenda::TrackInfo {
+			name: str_array("signed"),
+			max_deciding: 5,
+			decision_deposit: 500_u128 * UNIT,
+			prepare_period: 12 * HOURS,
+			decision_period: 7 * DAYS,
+			confirm_period: 12 * HOURS,
+			min_enactment_period: DAYS,
+			min_approval: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(55),
+				ceil: Perbill::from_percent(70),
+			},
+			min_support: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(5),
+				ceil: Perbill::from_percent(25),
+			},
+		};
+		#[cfg(feature = "fast-governance")]
+		let info = apply_test_timing(info);
+		[pallet_referenda::Track { id: 0, info }]
 	}
 }
 
@@ -171,28 +163,28 @@ pub struct TechCollectiveTracksInfo;
 
 impl TechCollectiveTracksInfo {
 	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
-		[pallet_referenda::Track {
-			id: 0,
-			info: apply_test_timing(pallet_referenda::TrackInfo {
-				name: str_array("tech_collective_members"),
-				max_deciding: 1,
-				decision_deposit: 1000 * UNIT,
-				prepare_period: 20,
-				decision_period: DAYS,
-				confirm_period: 20,
-				min_enactment_period: 20,
-				min_approval: pallet_referenda::Curve::LinearDecreasing {
-					length: Perbill::from_percent(100),
-					floor: Perbill::from_percent(50),
-					ceil: Perbill::from_percent(100),
-				},
-				min_support: pallet_referenda::Curve::LinearDecreasing {
-					length: Perbill::from_percent(100),
-					floor: Perbill::from_percent(0),
-					ceil: Perbill::from_percent(0),
-				},
-			}),
-		}]
+		let info = pallet_referenda::TrackInfo {
+			name: str_array("tech_collective_members"),
+			max_deciding: 1,
+			decision_deposit: 1000 * UNIT,
+			prepare_period: 20,
+			decision_period: DAYS,
+			confirm_period: 20,
+			min_enactment_period: 20,
+			min_approval: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(50),
+				ceil: Perbill::from_percent(100),
+			},
+			min_support: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(0),
+				ceil: Perbill::from_percent(0),
+			},
+		};
+		#[cfg(feature = "fast-governance")]
+		let info = apply_test_timing(info);
+		[pallet_referenda::Track { id: 0, info }]
 	}
 }
 

--- a/runtime/tests/common.rs
+++ b/runtime/tests/common.rs
@@ -50,28 +50,16 @@ impl TestCommons {
 		ext
 	}
 
-	/// Create a test externality with governance track timing based on feature flags
-	/// - Without `production-governance-tests`: Uses fast 2-block periods for all governance tracks
-	/// - With `production-governance-tests`: Uses production timing (hours/days) This allows CI to
-	///   test both fast (for speed) and slow (for correctness) governance
+	/// Create a test externality. Governance track timing is selected at
+	/// compile time via the `quantus-runtime/fast-governance` feature:
+	/// - feature ON:  all referenda windows collapse to 2 blocks (fast tests)
+	/// - feature OFF: production timing (hours/days) — slow but mainnet-accurate
 	pub fn new_fast_governance_test_ext() -> sp_io::TestExternalities {
-		#[cfg(feature = "production-governance-tests")]
-		{
-			println!("Production governance test config: Using production timing (hours/days).");
-			Self::new_test_ext()
-		}
-
-		#[cfg(not(feature = "production-governance-tests"))]
-		{
-			use quantus_runtime::governance::definitions::GlobalTrackConfig;
-
-			// Set global fast timing for ALL governance tracks (Community, Treasury, Tech
-			// Collective)
-			GlobalTrackConfig::set_fast_test_timing(); // Sets 2 blocks for all periods
-
-			println!("Fast governance test config activated: All tracks use 2-block periods");
-			Self::new_test_ext()
-		}
+		#[cfg(feature = "fast-governance")]
+		println!("Fast governance: all referenda windows = 2 blocks (compile-time).");
+		#[cfg(not(feature = "fast-governance"))]
+		println!("Production governance: real mainnet timing (hours/days).");
+		Self::new_test_ext()
 	}
 
 	// Helper function to run blocks


### PR DESCRIPTION
Every audit flagged this, so removing the static governance override