### PR TITLE
qpow: Ethereum EIP-2 additive difficulty adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,6 +6683,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "primitive-types 0.13.1",
+ "proptest",
  "qp-poseidon-core",
  "qpow-math",
  "scale-info",

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -46,8 +46,6 @@ pub enum Error<B: BlockT> {
 	InvalidSeal,
 	#[error("PoW validation error: preliminary verification failed")]
 	FailedPreliminaryVerify,
-	#[error("Rejecting block too far in future")]
-	TooFarInFuture,
 	#[error("Fetching best header failed: {0}")]
 	BestHeader(sp_blockchain::Error),
 	#[error("Best header does not exist")]

--- a/pallets/qpow/Cargo.toml
+++ b/pallets/qpow/Cargo.toml
@@ -35,6 +35,7 @@ sp-runtime.workspace = true
 
 [dev-dependencies]
 primitive-types.workspace = true
+proptest = "1"
 
 [features]
 default = ["std"]

--- a/pallets/qpow/src/lib.rs
+++ b/pallets/qpow/src/lib.rs
@@ -318,7 +318,23 @@ pub mod pallet {
 
 			let min_difficulty = Self::get_min_difficulty();
 			let max_difficulty = Self::get_max_difficulty();
-			let adjusted = raw_adjusted.max(min_difficulty).min(max_difficulty);
+			let adjusted = if raw_adjusted < min_difficulty {
+				log::warn!(
+					target: "qpow",
+					"difficulty clipped UP to floor: raw={:x} -> min={:x} (block_time={}ms, adj={})",
+					raw_adjusted.low_u64(), min_difficulty.low_u64(), observed_block_time, adj_factor
+				);
+				min_difficulty
+			} else if raw_adjusted > max_difficulty {
+				log::warn!(
+					target: "qpow",
+					"difficulty clipped DOWN to ceiling: raw_low={:x} -> max (block_time={}ms, adj={})",
+					raw_adjusted.low_u64(), observed_block_time, adj_factor
+				);
+				max_difficulty
+			} else {
+				raw_adjusted
+			};
 
 			log::debug!(target: "qpow",
 				"📊 current={:x} block_time={}ms buckets={} adj={} step={:x} delta={:x} new={:x}",

--- a/pallets/qpow/src/lib.rs
+++ b/pallets/qpow/src/lib.rs
@@ -22,12 +22,11 @@ pub mod pallet {
 	use core::ops::Shr;
 	use frame_support::{
 		pallet_prelude::*,
-		sp_runtime::{traits::One, SaturatedConversion, Saturating},
+		sp_runtime::{traits::One, SaturatedConversion},
 		traits::{BuildGenesisConfig, Time},
 	};
 	use frame_system::pallet_prelude::BlockNumberFor;
 	use qpow_math::{achieved_difficulty_from_hash, get_nonce_hash, is_valid_nonce};
-	use sp_arithmetic::FixedU128;
 	use sp_core::U512;
 
 	pub type NonceType = [u8; 64];
@@ -54,17 +53,46 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
-		/// Pallet's weight info
+		/// Genesis mining difficulty. Must satisfy
+		/// `InitialDifficulty >= DifficultyBoundDivisor` so the per-block step
+		/// `parent_difficulty / DifficultyBoundDivisor` is at least 1.
 		#[pallet::constant]
 		type InitialDifficulty: Get<U512>;
 
+		/// Ethereum's `DIFF_BOUND_DIVISOR` (EIP-2). The per-block unit step is
+		/// `parent_difficulty / DifficultyBoundDivisor`, applied additively in
+		/// both directions. Standard Ethereum value is `2048`.
 		#[pallet::constant]
-		type DifficultyAdjustPercentClamp: Get<FixedU128>;
+		type DifficultyBoundDivisor: Get<U512>;
+
+		/// Bucket size in milliseconds for computing the signed adjustment
+		/// factor (EIP-2's `// 10` divisor, generalised). The factor is
+		/// `MaxUpAdjFactor - (block_time_ms / BlockTimeBucketMs)`, then
+		/// clamped to `[MaxDownAdjFactor, MaxUpAdjFactor]`. With
+		/// `MaxUpAdjFactor = 1` the no-change band is `[bucket, 2*bucket)`;
+		/// pick `bucket ≈ 2 * target / 3` to centre the band on the target.
+		#[pallet::constant]
+		type BlockTimeBucketMs: Get<u64>;
+
+		/// Maximum upward adjustment factor (Ethereum Homestead = 1,
+		/// Byzantium = 2 when the parent has uncles; Quantus has no uncles,
+		/// so use 1).
+		#[pallet::constant]
+		type MaxUpAdjFactor: Get<i32>;
+
+		/// Minimum (most-negative) adjustment factor cap. Ethereum uses
+		/// `-99`, which triggers only when a single block takes
+		/// `(MaxUpAdjFactor - MaxDownAdjFactor) * BlockTimeBucketMs` or
+		/// longer (≈13 minutes for the standard `(1, -99, 8s)` set).
+		#[pallet::constant]
+		type MaxDownAdjFactor: Get<i32>;
 
 		#[pallet::constant]
 		type TargetBlockTime: Get<BlockDuration>;
 
-		/// EMA smoothing factor (0-1000, where 1000 = 1.0)
+		/// EMA smoothing factor used only for the observability runtime API
+		/// `get_block_time_ema`. **Does not** drive the difficulty
+		/// controller (see EIP-2 §Rationale). Scaled by 1000.
 		#[pallet::constant]
 		type EmaAlpha: Get<u32>;
 
@@ -183,118 +211,125 @@ pub mod pallet {
 		}
 
 		fn adjust_difficulty() {
-			// Get current time
 			let now = pallet_timestamp::Pallet::<T>::now().saturated_into::<u64>();
 			let last_time = <LastBlockTime<T>>::get();
 			let current_difficulty = <CurrentDifficulty<T>>::get();
 			let current_block_number = <frame_system::Pallet<T>>::block_number();
-
-			// Only calculate block time if we're past the genesis block
-			if current_block_number > One::one() {
-				let block_time = now.saturating_sub(last_time);
-
-				log::debug!(target: "qpow",
-					"Time calculation: now={}, last_time={}, diff={}ms",
-					now,
-					last_time,
-					block_time
-				);
-
-				// Store the actual block duration
-				<LastBlockDuration<T>>::put(block_time);
-
-				Self::update_block_time_ema(block_time);
-			}
-
-			// Add last block time for the next calculations
-			<LastBlockTime<T>>::put(now);
-
-			let observed_block_time = <BlockTimeEma<T>>::get();
 			let target_time = T::TargetBlockTime::get();
 
-			let new_difficulty =
-				Self::calculate_difficulty(current_difficulty, observed_block_time, target_time);
+			// On the first non-genesis block we have no real previous timestamp,
+			// so feed the controller `target_time` (i.e. adj_factor = 0).
+			let block_time = if current_block_number > One::one() {
+				let bt = now.saturating_sub(last_time);
+				log::debug!(target: "qpow",
+					"Time calculation: now={}, last_time={}, diff={}ms",
+					now, last_time, bt
+				);
+				<LastBlockDuration<T>>::put(bt);
+				Self::update_block_time_ema(bt);
+				bt
+			} else {
+				target_time
+			};
 
-			// Save new difficulty
+			<LastBlockTime<T>>::put(now);
+
+			let new_difficulty =
+				Self::calculate_difficulty(current_difficulty, block_time, target_time);
+
 			<CurrentDifficulty<T>>::put(new_difficulty);
 
-			log::debug!(target: "qpow", "Stored new difficulty: {}",
-				new_difficulty.low_u128());
-
-			// Propagate new Event
 			Self::deposit_event(Event::DifficultyAdjusted {
 				old_difficulty: current_difficulty,
 				new_difficulty,
-				observed_block_time,
+				observed_block_time: block_time,
 			});
 
 			let (pct_change, is_positive) =
 				Self::percentage_change(current_difficulty, new_difficulty);
 
 			log::debug!(target: "qpow",
-				"🟢 Adjusted mining difficulty {}{}%: {:x} -> {:x} (observed block time: {}ms, target: {}ms) ",
+				"🟢 Adjusted mining difficulty {}{}%: {:x} -> {:x} (block_time={}ms target={}ms)",
 				if is_positive {"+"} else {"-"},
 				pct_change,
 				current_difficulty.low_u64(),
 				new_difficulty.low_u64(),
-				observed_block_time,
+				block_time,
 				target_time
 			);
 		}
 
+		/// Difficulty adjustment per Ethereum EIP-2 / EIP-100, in its additive form:
+		///
+		/// ```text
+		/// adj_factor      = clamp(MaxUpAdjFactor - block_time_ms / BlockTimeBucketMs,
+		///                         MaxDownAdjFactor, MaxUpAdjFactor)
+		/// step            = parent_difficulty / DifficultyBoundDivisor
+		/// new_difficulty  = clamp(parent_difficulty + step * adj_factor,
+		///                         min_difficulty, max_difficulty)
+		/// ```
+		///
+		/// Input is the **single block's** wall-clock time, not a moving average.
+		/// `target_block_time` is unused but kept in the signature for ABI
+		/// stability with callers that still pass it.
 		pub fn calculate_difficulty(
 			current_difficulty: U512,
 			observed_block_time: u64,
-			target_block_time: u64,
+			_target_block_time: u64,
 		) -> U512 {
-			log::debug!(target: "qpow", "📊 Calculating new difficulty ---------------------------------------------");
-			let observed_block_time = observed_block_time.max(1);
-			let clamp = T::DifficultyAdjustPercentClamp::get(); // 10%
-			let one = FixedU128::one();
-			let ratio =
-				FixedU128::from_rational(target_block_time as u128, observed_block_time as u128)
-					.min(one.saturating_add(clamp))
-					.max(one.saturating_sub(clamp));
-			log::debug!(target: "qpow", "💧 Clamped block_time ratio as FixedU128: {} ", ratio);
+			let bucket = T::BlockTimeBucketMs::get().max(1);
+			let max_up = T::MaxUpAdjFactor::get();
+			let max_down = T::MaxDownAdjFactor::get();
+			let divisor = T::DifficultyBoundDivisor::get();
 
-			let ratio_512 = U512::from(ratio.into_inner());
-			let max_difficulty = Self::get_max_difficulty();
+			if divisor.is_zero() {
+				log::error!(
+					target: "qpow",
+					"DifficultyBoundDivisor is zero; controller is misconfigured. Returning current difficulty."
+				);
+				return current_difficulty;
+			}
+			if max_down > max_up {
+				log::error!(
+					target: "qpow",
+					"MaxDownAdjFactor ({}) > MaxUpAdjFactor ({}); controller is misconfigured. Returning current difficulty.",
+					max_down, max_up
+				);
+				return current_difficulty;
+			}
 
-			// For Bitcoin-style difficulty adjustment:
-			// If observed_time > target_time (slow blocks), difficulty should decrease
-			// If observed_time < target_time (fast blocks), difficulty should increase
-			// new_difficulty = current_difficulty * target_time / observed_time
-			let mut adjusted = match current_difficulty.checked_mul(ratio_512) {
-				Some(numerator) => {
-					// unchecked division, we know the denominator is not zero
-					let result = numerator / U512::from(one.into_inner());
-					log::debug!(target: "qpow",
-					    "Difficulty calculation: current={:x}, target_time={}, observed_time={}, new={:x}",
-						current_difficulty.low_u32() as u16, target_block_time, observed_block_time, result.low_u32() as u16);
-					result
-				},
-				None => {
-					log::error!("Multiplication overflow in difficulty calculation");
-					return max_difficulty;
-				},
+			let buckets_elapsed_u64 = observed_block_time / bucket;
+			let buckets_elapsed: i32 = if buckets_elapsed_u64 > i32::MAX as u64 {
+				i32::MAX
+			} else {
+				buckets_elapsed_u64 as i32
+			};
+			let adj_factor = max_up.saturating_sub(buckets_elapsed).max(max_down);
+
+			let step = current_difficulty / divisor;
+			let abs_adj = U512::from(adj_factor.unsigned_abs());
+			let delta = step.saturating_mul(abs_adj);
+
+			let raw_adjusted = if adj_factor >= 0 {
+				current_difficulty.saturating_add(delta)
+			} else {
+				current_difficulty.saturating_sub(delta)
 			};
 
 			let min_difficulty = Self::get_min_difficulty();
-			if adjusted < min_difficulty {
-				log::warn!("Min difficulty achieved, clipping to: {:x}", min_difficulty.low_u64());
-				adjusted = min_difficulty;
-			} else if adjusted > max_difficulty {
-				log::warn!("Max difficulty achieved, clipping to: {:x}", max_difficulty.low_u64());
-				adjusted = max_difficulty;
-			}
+			let max_difficulty = Self::get_max_difficulty();
+			let adjusted = raw_adjusted.max(min_difficulty).min(max_difficulty);
 
 			log::debug!(target: "qpow",
-				"🟢 Current Difficulty: {:x}",
-				current_difficulty.low_u64()
+				"📊 current={:x} block_time={}ms buckets={} adj={} step={:x} delta={:x} new={:x}",
+				current_difficulty.low_u64(),
+				observed_block_time,
+				buckets_elapsed,
+				adj_factor,
+				step.low_u64(),
+				delta.low_u64(),
+				adjusted.low_u64()
 			);
-			log::debug!(target: "qpow", "🟢 Next Difficulty:    {:x}", adjusted.low_u64());
-			log::debug!(target: "qpow", "🕒 Observed Block Time Sum: {}ms", observed_block_time);
-			log::debug!(target: "qpow", "🎯 Target Block Time Sum:   {target_block_time}ms");
 
 			adjusted
 		}
@@ -387,10 +422,13 @@ pub mod pallet {
 		}
 
 		pub fn get_min_difficulty() -> Difficulty {
-			// This value is related to clamp value,
-			// ie, if clamp is 10% this value must be at least 10
-			// 1000 is safe for clamp values >= 0.01%
-			U512::from(1000u64)
+			// Constraint: `min_difficulty >= DifficultyBoundDivisor`, otherwise the
+			// per-block step `min_difficulty / DifficultyBoundDivisor` floors to
+			// zero and the controller cannot ever lift difficulty off the floor.
+			// We additionally floor at Ethereum's `MinimumDifficulty` (2^17 =
+			// 131_072) so the smallest valid network still requires real work.
+			let divisor = T::DifficultyBoundDivisor::get();
+			U512::from(131_072u64).max(divisor)
 		}
 
 		pub fn get_max_difficulty() -> Difficulty {

--- a/pallets/qpow/src/mock.rs
+++ b/pallets/qpow/src/mock.rs
@@ -2,13 +2,13 @@ use crate as pallet_qpow;
 use frame_support::{
 	pallet_prelude::ConstU32,
 	parameter_types,
-	traits::{ConstU64, Everything},
+	traits::{ConstI32, ConstU64, Everything},
 };
 use primitive_types::U512;
 use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage, FixedU128,
+	BuildStorage,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -69,15 +69,21 @@ impl pallet_timestamp::Config for Test {
 }
 
 parameter_types! {
-	pub const TestInitialDifficulty: U512 = U512([1000000, 0, 0, 0, 0, 0, 0, 0]);
-	pub const TestDifficultyAdjustPercentClamp: FixedU128 = FixedU128::from_rational(10, 100);
+	/// Test target = 1000ms. Bucket = 750ms places `target` inside the
+	/// `[bucket, 2*bucket) = [750, 1500)` no-change band, mirroring the
+	/// runtime's `bucket ≈ 2*target/3` design.
+	pub const TestInitialDifficulty: U512 = U512([1_000_000, 0, 0, 0, 0, 0, 0, 0]);
+	pub const TestDifficultyBoundDivisor: U512 = U512([2048, 0, 0, 0, 0, 0, 0, 0]);
 }
 
 impl pallet_qpow::Config for Test {
 	type WeightInfo = ();
-	type EmaAlpha = ConstU32<500>;
+	type EmaAlpha = ConstU32<100>;
 	type InitialDifficulty = TestInitialDifficulty;
-	type DifficultyAdjustPercentClamp = TestDifficultyAdjustPercentClamp;
+	type DifficultyBoundDivisor = TestDifficultyBoundDivisor;
+	type BlockTimeBucketMs = ConstU64<750>;
+	type MaxUpAdjFactor = ConstI32<1>;
+	type MaxDownAdjFactor = ConstI32<-99>;
 	type TargetBlockTime = ConstU64<1000>;
 	type MaxReorgDepth = ConstU32<10>;
 }

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -109,8 +109,10 @@ fn test_difficulty_bounds() {
 		let min_difficulty = QPow::get_min_difficulty();
 		let max_difficulty = QPow::get_max_difficulty();
 		let initial_difficulty = QPow::initial_difficulty();
+		let divisor = <Test as Config>::DifficultyBoundDivisor::get();
 
-		assert_eq!(min_difficulty, U512::from(1000u64));
+		assert!(min_difficulty >= divisor, "floor must allow non-zero step");
+		assert_eq!(min_difficulty, U512::from(131_072u64));
 		assert!(max_difficulty > initial_difficulty);
 		assert!(initial_difficulty > min_difficulty);
 	});
@@ -196,19 +198,114 @@ fn test_ema_block_time_tracking() {
 #[test]
 fn test_difficulty_calculation() {
 	new_test_ext().execute_with(|| {
-		let current_difficulty = U512::from(1000u64);
-		let observed_time = 2000u64; // 2x target
-		let target_time = 1000u64;
+		// Mid-difficulty value far from min/max so adjustments are visible.
+		let current_difficulty = U512::from(1_000_000u64);
 
-		// When blocks are slow, difficulty should decrease
-		let new_difficulty =
-			QPow::calculate_difficulty(current_difficulty, observed_time, target_time);
+		// Slow block (2x target). With bucket=750ms and target=1000ms,
+		// buckets_elapsed = 2000/750 = 2, adj_factor = 1 - 2 = -1.
+		// step = 1_000_000 / 2048 = 488. Δ = -488. New = 999_512.
+		let slower = QPow::calculate_difficulty(current_difficulty, 2000, 1000);
+		assert!(slower < current_difficulty);
 
-		// Should be bounded by min/max
+		// Fast block (sub-bucket). adj_factor = +1. Δ = +488. New = 1_000_488.
+		let faster = QPow::calculate_difficulty(current_difficulty, 100, 1000);
+		assert!(faster > current_difficulty);
+
+		// At-target block sits in the no-change band [750, 1500).
+		let unchanged = QPow::calculate_difficulty(current_difficulty, 1000, 1000);
+		assert_eq!(unchanged, current_difficulty);
+
 		let min_difficulty = QPow::get_min_difficulty();
 		let max_difficulty = QPow::get_max_difficulty();
-		assert!(new_difficulty >= min_difficulty);
-		assert!(new_difficulty <= max_difficulty);
+		assert!(slower >= min_difficulty && slower <= max_difficulty);
+		assert!(faster >= min_difficulty && faster <= max_difficulty);
+	});
+}
+
+#[test]
+fn test_adj_factor_table() {
+	new_test_ext().execute_with(|| {
+		// With bucket=750ms, max_up=+1, max_down=-99, divisor=2048:
+		// adj_factor = clamp(1 - block_time/750, -99, 1)
+		let d = U512::from(2_048_000_000u64); // step = 1_000_000
+
+		// block_time in [0, 750): buckets=0, adj=+1, Δ=+1_000_000
+		let r = QPow::calculate_difficulty(d, 0, 1000);
+		assert_eq!(r, d + U512::from(1_000_000u64));
+		let r = QPow::calculate_difficulty(d, 749, 1000);
+		assert_eq!(r, d + U512::from(1_000_000u64));
+
+		// block_time in [750, 1500): buckets=1, adj=0, no change
+		let r = QPow::calculate_difficulty(d, 750, 1000);
+		assert_eq!(r, d);
+		let r = QPow::calculate_difficulty(d, 1499, 1000);
+		assert_eq!(r, d);
+
+		// block_time in [1500, 2250): buckets=2, adj=-1
+		let r = QPow::calculate_difficulty(d, 1500, 1000);
+		assert_eq!(r, d - U512::from(1_000_000u64));
+
+		// block_time in [75_000, 75_750): buckets=100, adj=-99 (cap)
+		let r = QPow::calculate_difficulty(d, 75_000, 1000);
+		assert_eq!(r, d - U512::from(99_000_000u64));
+
+		// Far past the cap: still -99
+		let r = QPow::calculate_difficulty(d, 10_000_000, 1000);
+		assert_eq!(r, d - U512::from(99_000_000u64));
+
+		// Pathological u64::MAX block_time: still -99, saturates cleanly
+		let r = QPow::calculate_difficulty(d, u64::MAX, 1000);
+		assert_eq!(r, d - U512::from(99_000_000u64));
+	});
+}
+
+#[test]
+fn test_min_difficulty_escape_from_floor() {
+	// Critical regression: with the new additive form and a min derived from the
+	// divisor, the floor must be escapable in a single fast block. The
+	// pre-existing multiplicative-clamp implementation had a floor trap at
+	// min=1000 with up-clamp=1/2048 where 1000*(1+1/2048) truncated back to 1000.
+	new_test_ext().execute_with(|| {
+		let min_diff = QPow::get_min_difficulty();
+		assert!(min_diff >= U512::from(131_072u64), "min should be >= Ethereum's MinimumDifficulty");
+
+		let lifted = QPow::calculate_difficulty(min_diff, 0, 1000);
+		assert!(
+			lifted > min_diff,
+			"floor must be liftable: lifted={} min={}",
+			lifted.low_u64(),
+			min_diff.low_u64()
+		);
+
+		// Step at the floor should equal exactly +(min/divisor).
+		let divisor = <Test as Config>::DifficultyBoundDivisor::get();
+		let expected_step = min_diff / divisor;
+		assert_eq!(lifted, min_diff + expected_step);
+	});
+}
+
+#[test]
+fn test_overflow_saturation() {
+	new_test_ext().execute_with(|| {
+		// Max difficulty: fast block should saturate, not overflow.
+		let max = QPow::get_max_difficulty();
+		let r = QPow::calculate_difficulty(max, 0, 1000);
+		assert_eq!(r, max);
+
+		// Min difficulty: slow block should clip to min, not underflow.
+		let min = QPow::get_min_difficulty();
+		let r = QPow::calculate_difficulty(min, u64::MAX, 1000);
+		assert_eq!(r, min);
+	});
+}
+
+#[test]
+fn test_no_change_when_at_target() {
+	new_test_ext().execute_with(|| {
+		let d = U512::from(1_000_000u64);
+		// target=1000ms sits in the no-change band [750, 1500).
+		let r = QPow::calculate_difficulty(d, 1000, 1000);
+		assert_eq!(r, d);
 	});
 }
 
@@ -330,74 +427,36 @@ fn test_difficulty_recovers_after_sleep() {
 	new_test_ext().execute_with(|| {
 		let target = <Test as Config>::TargetBlockTime::get();
 
+		// Warm up at target — adj_factor = 0, no change.
 		for i in 1u64..=10 {
 			run_block(i, i * target);
 		}
-
 		let pre_sleep = QPow::get_difficulty();
 		assert_eq!(pre_sleep, U512::from(1_000_000u64));
 
-		// Simulate laptop sleep: 1-hour gap between blocks
+		// Simulate laptop sleep: 1-hour gap between blocks. With bucket=750ms,
+		// 3_600_000 / 750 = 4800 buckets → adj_factor = max(1-4800, -99) = -99.
+		// Step = 1_000_000 / 2048 = 488. Δ = -488*99 = -48_312. New = 951_688.
 		run_block(11, 10 * target + 3_600_000);
+		let post_sleep = QPow::get_difficulty();
+		assert!(post_sleep < pre_sleep);
+		assert!(post_sleep > pre_sleep * U512::from(95u64) / U512::from(100u64));
 
-		// 20 normal blocks after waking
+		// 20 normal blocks at target → adj_factor=0, difficulty stays put.
+		// (Single-block input means the slow patch does not keep echoing into
+		// future adjustments — exactly the property EIP-2 §Rationale calls out.)
 		for i in 12u64..=31 {
 			run_block(i, 10 * target + 3_600_000 + (i - 11) * target);
 		}
-
-		let recovered = QPow::get_difficulty();
-		// EMA smoothing limits the spike, but alpha=500 is aggressive so recovery
-		// takes many blocks. 20 normal blocks bring difficulty to ~18% of pre-sleep.
-		assert!(
-			recovered > pre_sleep / 10,
-			"Difficulty should stay above 10% after sleep. Pre: {}, Post: {}",
-			pre_sleep.low_u64(),
-			recovered.low_u64()
-		);
+		let after_normal = QPow::get_difficulty();
+		assert_eq!(after_normal, post_sleep, "no slow tail after one bad block");
 	});
 }
 
 #[test]
-fn test_zero_observed_block_time() {
+fn test_min_difficulty_matches_ethereum_floor() {
 	new_test_ext().execute_with(|| {
-		let difficulty = U512::from(1_000_000u64);
-		let result = QPow::calculate_difficulty(difficulty, 0, 1000);
-		let min = QPow::get_min_difficulty();
-		let max = QPow::get_max_difficulty();
-		assert!(result >= min);
-		assert!(result <= max);
-	});
-}
-
-#[test]
-fn test_min_difficulty_derived_from_clamp() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(QPow::get_min_difficulty(), U512::from(1000u64));
-	});
-}
-
-#[test]
-fn test_min_difficulty_can_increase() {
-	new_test_ext().execute_with(|| {
-		let min_diff = QPow::get_min_difficulty();
-		// Fast blocks → ratio clamped to 1.1 → floor(1000 * 1.1) = 1100
-		let result = QPow::calculate_difficulty(min_diff, 1, 1000);
-		assert!(
-			result > min_diff,
-			"Min difficulty must be able to increase: {} should be > {}",
-			result.low_u64(),
-			min_diff.low_u64()
-		);
-	});
-}
-
-#[test]
-fn test_min_difficulty_floors_on_slow_blocks() {
-	new_test_ext().execute_with(|| {
-		let min_diff = QPow::get_min_difficulty();
-		// Slow blocks → ratio clamped to 0.9 → floor(1000 * 0.9) = 900, clips to 1000
-		let result = QPow::calculate_difficulty(min_diff, 100_000, 1000);
-		assert_eq!(result, min_diff);
+		assert_eq!(QPow::get_min_difficulty(), U512::from(131_072u64));
 	});
 }
 
@@ -405,7 +464,8 @@ fn test_min_difficulty_floors_on_slow_blocks() {
 fn test_difficulty_below_min_clips_up() {
 	new_test_ext().execute_with(|| {
 		let min_diff = QPow::get_min_difficulty();
-		// Starting at 1 (below min), any result clips to min_difficulty
+		// Starting at 1 (below min): step = 1/2048 = 0, but post-adjustment clip
+		// brings the value up to min_difficulty.
 		let result_fast = QPow::calculate_difficulty(U512::from(1u64), 1, 1000);
 		let result_slow = QPow::calculate_difficulty(U512::from(1u64), 100_000, 1000);
 		assert_eq!(result_fast, min_diff);

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -472,3 +472,82 @@ fn test_difficulty_below_min_clips_up() {
 		assert_eq!(result_slow, min_diff);
 	});
 }
+
+#[cfg(test)]
+mod proptests {
+	use super::*;
+	use crate::mock::{new_test_ext, QPow, Test};
+	use proptest::prelude::*;
+
+	fn arb_difficulty() -> impl Strategy<Value = U512> {
+		prop_oneof![
+			Just(U512::from(131_072u64)),
+			Just(U512::MAX),
+			Just(U512::from(2_700_000u64)),
+			(1u128..=u128::MAX).prop_map(U512::from),
+		]
+	}
+
+	fn run<T>(f: impl FnOnce() -> T) -> T {
+		new_test_ext().execute_with(f)
+	}
+
+	proptest! {
+		#[test]
+		fn result_always_in_bounds(d in arb_difficulty(), bt in 0u64..=u64::MAX) {
+			let (r, min, max) = run(|| (
+				QPow::calculate_difficulty(d, bt, 1000),
+				QPow::get_min_difficulty(),
+				QPow::get_max_difficulty(),
+			));
+			prop_assert!(r >= min, "result {} < min {}", r.low_u64(), min.low_u64());
+			prop_assert!(r <= max);
+		}
+
+		#[test]
+		fn monotone_in_block_time(
+			d in arb_difficulty(),
+			bt1 in 0u64..1_000_000,
+			bt2 in 0u64..1_000_000,
+		) {
+			let (a, b) = if bt1 <= bt2 { (bt1, bt2) } else { (bt2, bt1) };
+			let (fast, slow) = run(|| (
+				QPow::calculate_difficulty(d, a, 1000),
+				QPow::calculate_difficulty(d, b, 1000),
+			));
+			prop_assert!(fast >= slow,
+				"monotonicity broken: bt={} -> {}, bt={} -> {}",
+				a, fast.low_u64(), b, slow.low_u64());
+		}
+
+		#[test]
+		fn no_change_band_is_flat(d in arb_difficulty(), offset in 0u64..750u64) {
+			let (r, expected) = run(|| {
+				let bucket = <Test as Config>::BlockTimeBucketMs::get();
+				let r = QPow::calculate_difficulty(d, bucket + offset, 1000);
+				let min = QPow::get_min_difficulty();
+				let max = QPow::get_max_difficulty();
+				(r, d.max(min).min(max))
+			});
+			prop_assert_eq!(r, expected);
+		}
+
+		#[test]
+		fn step_magnitude_bounded(d in arb_difficulty(), bt in 0u64..=u64::MAX) {
+			let (r, min, divisor) = run(|| (
+				QPow::calculate_difficulty(d, bt, 1000),
+				QPow::get_min_difficulty(),
+				<Test as Config>::DifficultyBoundDivisor::get(),
+			));
+			if d < min { return Ok(()); }
+			let max_factor = U512::from(
+				(<Test as Config>::MaxUpAdjFactor::get() as u32)
+					.max(<Test as Config>::MaxDownAdjFactor::get().unsigned_abs()),
+			);
+			let max_delta = (d / divisor).saturating_mul(max_factor);
+			let actual_delta = if r >= d { r - d } else { d - r };
+			prop_assert!(actual_delta <= max_delta,
+				"delta {} exceeds max step {}", actual_delta.low_u64(), max_delta.low_u64());
+		}
+	}
+}

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -267,7 +267,10 @@ fn test_min_difficulty_escape_from_floor() {
 	// min=1000 with up-clamp=1/2048 where 1000*(1+1/2048) truncated back to 1000.
 	new_test_ext().execute_with(|| {
 		let min_diff = QPow::get_min_difficulty();
-		assert!(min_diff >= U512::from(131_072u64), "min should be >= Ethereum's MinimumDifficulty");
+		assert!(
+			min_diff >= U512::from(131_072u64),
+			"min should be >= Ethereum's MinimumDifficulty"
+		);
 
 		let lifted = QPow::calculate_difficulty(min_diff, 0, 1000);
 		assert!(

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -35,7 +35,8 @@ use crate::{
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{
-		AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU8, Get, NeverEnsureOrigin, VariantCountOf,
+		AsEnsureOriginWithArg, ConstI32, ConstU128, ConstU32, ConstU8, Get, NeverEnsureOrigin,
+		VariantCountOf,
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -55,7 +56,7 @@ use smallvec::smallvec;
 use qp_scheduler::BlockNumberOrTimestamp;
 use sp_runtime::{
 	traits::{BlakeTwo256, One},
-	AccountId32, FixedU128, Perbill, Permill,
+	AccountId32, Perbill, Permill,
 };
 use sp_version::RuntimeVersion;
 
@@ -150,21 +151,35 @@ parameter_types! {
 	/// Target block time ms
 	pub const TargetBlockTime: u64 = TARGET_BLOCK_TIME_MS;
 	pub const TimestampBucketSize: u64 = 2 * TARGET_BLOCK_TIME_MS; // Nyquist frequency
-	/// Initial mining difficulty - low value for development
-	pub const QPoWInitialDifficulty: U512 = U512([1189189, 0, 0, 0, 0, 0, 0, 0]);
-	/// Difficulty adjustment percent clamp
-	pub const DifficultyAdjustPercentClamp: FixedU128 = FixedU128::from_rational(10, 100);
+	/// Initial mining difficulty. Sized to give miners a meaningful warm-up window
+	/// above `MinimumDifficulty` (2^17) while remaining easy enough to bootstrap.
+	pub const QPoWInitialDifficulty: U512 = U512([2_700_000, 0, 0, 0, 0, 0, 0, 0]);
+	/// Ethereum EIP-2 `DIFF_BOUND_DIVISOR`. Per-block unit step is
+	/// `parent_difficulty / 2048`, applied additively in both directions.
+	pub const QPoWDifficultyBoundDivisor: U512 = U512([2048, 0, 0, 0, 0, 0, 0, 0]);
+	/// Bucket for the EIP-2 signed adjustment factor. With `MaxUpAdjFactor = 1`
+	/// the no-change band is `[bucket, 2*bucket)`; `2/3 * target` (8s for a 12s
+	/// target) centres that band on the target block time.
+	pub const QPoWBlockTimeBucketMs: u64 = (2 * TARGET_BLOCK_TIME_MS) / 3;
 }
 
 impl pallet_qpow::Config for Runtime {
-	// Starting difficulty - should be challenging enough to require some work but not too high
 	type InitialDifficulty = QPoWInitialDifficulty;
-	type DifficultyAdjustPercentClamp = DifficultyAdjustPercentClamp;
+	type DifficultyBoundDivisor = QPoWDifficultyBoundDivisor;
+	type BlockTimeBucketMs = QPoWBlockTimeBucketMs;
+	/// Homestead value (Byzantium uses 2 only when the parent has uncles; Quantus
+	/// has no uncles).
+	type MaxUpAdjFactor = ConstI32<1>;
+	/// Ethereum EIP-2 `-99` cap. Triggers only when a single block takes
+	/// `(MaxUp - MaxDown) * BlockTimeBucketMs = 100 * 8s = 800s` (≈13 minutes).
+	type MaxDownAdjFactor = ConstI32<-99>;
 	type TargetBlockTime = TargetBlockTime;
 	type MaxReorgDepth = ConstU32<180>;
-
 	type WeightInfo = ();
-	type EmaAlpha = ConstU32<100>; // out of 1000, last_block_time * alpha + (previous_ema * (1 - alpha)) on moving average
+	/// EMA is exposed via `get_block_time_ema` runtime API for Prometheus
+	/// telemetry only; it does **not** drive the controller (see EIP-2
+	/// §Rationale).
+	type EmaAlpha = ConstU32<100>;
 }
 
 parameter_types! {

--- a/runtime/tests/qpow_difficulty.rs
+++ b/runtime/tests/qpow_difficulty.rs
@@ -1,0 +1,105 @@
+//! Runtime-parameter consistency checks for the QPoW difficulty controller.
+//!
+//! These run against the *actual* `quantus_runtime` constants (not the mock),
+//! so any future re-tuning that breaks the EIP-2 invariants fails CI here.
+
+use frame_support::traits::Get;
+use pallet_qpow::Config;
+use primitive_types::U512;
+use quantus_runtime::Runtime;
+
+fn bucket() -> u64 {
+	<Runtime as Config>::BlockTimeBucketMs::get()
+}
+fn target() -> u64 {
+	<Runtime as Config>::TargetBlockTime::get()
+}
+fn max_up() -> i32 {
+	<Runtime as Config>::MaxUpAdjFactor::get()
+}
+fn max_down() -> i32 {
+	<Runtime as Config>::MaxDownAdjFactor::get()
+}
+fn divisor() -> U512 {
+	<Runtime as Config>::DifficultyBoundDivisor::get()
+}
+fn initial() -> U512 {
+	<Runtime as Config>::InitialDifficulty::get()
+}
+fn min_diff() -> U512 {
+	pallet_qpow::Pallet::<Runtime>::get_min_difficulty()
+}
+
+#[test]
+fn target_sits_inside_no_change_band() {
+	// With `adj_factor = max_up - block_time / bucket` clamped to [max_down, max_up],
+	// the no-change band is [max_up * bucket, (max_up + 1) * bucket). The target
+	// must fall inside it, otherwise every on-target block adjusts difficulty.
+	let band_lo = bucket().saturating_mul(max_up() as u64);
+	let band_hi = bucket().saturating_mul(max_up() as u64 + 1);
+	assert!(
+		target() >= band_lo && target() < band_hi,
+		"target {} not in no-change band [{}, {})",
+		target(),
+		band_lo,
+		band_hi,
+	);
+}
+
+#[test]
+fn floor_is_liftable() {
+	// `step = parent_difficulty / divisor` must be ≥ 1 at the floor, otherwise the
+	// controller cannot escape it (the bug that motivated PR #564's review).
+	assert!(
+		min_diff() >= divisor(),
+		"floor {} < divisor {} — controller cannot escape min",
+		min_diff().low_u64(),
+		divisor().low_u64(),
+	);
+}
+
+#[test]
+fn floor_matches_ethereum_minimum_difficulty() {
+	assert_eq!(min_diff(), U512::from(131_072u64));
+}
+
+#[test]
+fn down_cap_fires_only_on_real_stalls() {
+	// -99 cap should require a single block ≥ 5× target — the EIP-2 §Rationale
+	// "black swan" threshold, not routine slow blocks.
+	let cap_ms = (max_up() - max_down()) as u64 * bucket();
+	assert!(
+		cap_ms > 5 * target(),
+		"-99 cap fires at {}ms, only {}× target — too aggressive",
+		cap_ms,
+		cap_ms / target(),
+	);
+}
+
+#[test]
+fn initial_difficulty_above_floor() {
+	assert!(
+		initial() > min_diff(),
+		"initial {} <= min {} — chain starts at the floor",
+		initial().low_u64(),
+		min_diff().low_u64(),
+	);
+	assert!(
+		initial() >= divisor(),
+		"initial must be ≥ divisor so the per-block step is at least 1 unit",
+	);
+}
+
+#[test]
+fn at_target_block_produces_no_change() {
+	let d = U512::from(1_000_000u64);
+	let r = pallet_qpow::Pallet::<Runtime>::calculate_difficulty(d, target(), target());
+	assert_eq!(r, d, "at-target block must not adjust difficulty");
+}
+
+#[test]
+fn upper_band_edge_still_flat() {
+	let d = U512::from(1_000_000u64);
+	let r = pallet_qpow::Pallet::<Runtime>::calculate_difficulty(d, 2 * bucket() - 1, target());
+	assert_eq!(r, d, "block_time = 2*bucket - 1 must still produce no change");
+}


### PR DESCRIPTION
## Summary

Alternative to #564 that fixes the underlying issues exposed in that PR's review (chronic downward drift, asymmetric hashrate response, `min_difficulty` floor trap) by adopting [EIP-2](https://eips.ethereum.org/EIPS/eip-2)'s **additive** form of difficulty adjustment instead of a multiplicative ratio-clamp.

```text
adj_factor     = clamp(MaxUpAdjFactor - block_time_ms / BlockTimeBucketMs,
                       MaxDownAdjFactor, MaxUpAdjFactor)
step           = parent_difficulty / DifficultyBoundDivisor
new_difficulty = clamp(parent_difficulty + step * adj_factor,
                       min_difficulty, max_difficulty)
```

### What's different from #564

- **Additive, not multiplicative.** No `0.95^N` cumulative-drift problem; the controller's expected per-block change is zero at the right difficulty.
- **Driven by the single-block time, not an EMA.** Matches EIP-2 §Rationale — a single slow block must not keep penalising the chain for ~100 blocks via a slow-decaying state. The EMA storage and `get_block_time_ema` runtime API are **preserved as Prometheus telemetry only**, so `node/src/prometheus.rs` and existing dashboards keep working.
- **`min_difficulty` is now derived** as `max(2^17, DifficultyBoundDivisor)`. Closes the floor trap where `1000 * (1 + 1/2048)` truncated back to `1000` under U512 arithmetic.
- **The `−99` cap fires only on real stalls** — a single block ≥ `(MaxUp − MaxDown) × bucket = 100 × 8 s = 800 s` (≈13 min). Routine slow patches use the linear region (e.g. a 20 s block → −0.0488%, a 30 s block → −0.0977%).
- **Fail-loud guards**: `DifficultyBoundDivisor == 0` or `MaxDown > MaxUp` log an error and return the current difficulty rather than panic.

### Runtime constants (12 s target)

| Constant | Value | Source |
| --- | --- | --- |
| `QPoWDifficultyBoundDivisor` | `2048` | EIP-2 |
| `QPoWBlockTimeBucketMs` | `2 * TARGET_BLOCK_TIME_MS / 3` = **8 000** ms | Centres no-change band `[8 s, 16 s)` on the 12 s target |
| `MaxUpAdjFactor` | `1` | Homestead |
| `MaxDownAdjFactor` | `-99` | EIP-2 |
| `QPoWInitialDifficulty` | `2_700_000` | Kept from #564, well above the new 131 072 floor |
| `EmaAlpha` | `100` (10 %) | Telemetry only |

### Why EIP-2 (Homestead) and not EIP-100 (Byzantium)?

[EIP-100](https://eips.ethereum.org/EIPS/eip-100) added two coupled changes on top of EIP-2:

1. **Uncle bonus**: `adj_factor = (2 if parent_has_uncles else 1) - ...` — an extra `+1` upward boost when the parent block has uncles.
2. **Denominator `// 10 → // 9`**: a ~10% compensation for the upward bias the uncle bonus introduces, so block times stay on target.

Neither applies to Quantus:

| EIP-100 ingredient | Applies here? | Why |
| --- | --- | --- |
| Uncle bonus | **No** | Substrate PoW has a single canonical chain; siblings are discarded, not rewarded as uncles. |
| `// 9` denominator | **No** | The denominator change exists *only* to offset (1). Applying it without the uncle bonus would just bias difficulty upward by ~10% with no offsetting reason. |
| `-99` lower cap | **Yes — kept** | This part is shared with EIP-2 and is what we use. |

The structural property that *does* carry over from both EIPs is `bucket ≈ target / 1.5`, which puts the target block time at the geometric centre of the `[bucket, 2*bucket)` no-change band:

| Era | Effective target | Bucket | target / bucket |
| --- | --- | --- | --- |
| EIP-2 Homestead | ~15 s | 10 s | 1.5 |
| EIP-100 Byzantium | ~13.5 s | 9 s | 1.5 |
| **This PR (Quantus)** | 12 s | 8 s (`2*target/3`) | **1.5** |

So: same structural choice as both Ethereum eras, with the uncle-specific machinery from EIP-100 intentionally omitted.

### Tests

Mock parameters now mirror the runtime structure (bucket = 750 ms for a 1 000 ms target, divisor = 2048, max_up = +1, max_down = -99). New / rewritten:

- `test_min_difficulty_escape_from_floor` — regression for the floor trap.
- `test_adj_factor_table` — exhaustive boundary coverage (every interesting block-time bucket, the `-99` cap, `u64::MAX` saturation).
- `test_overflow_saturation` — `U512::MAX` and floor both saturate cleanly.
- `test_no_change_when_at_target` — at-target blocks produce zero change.
- `test_difficulty_recovers_after_sleep` — rewritten: one outage block drops difficulty by exactly `-99 × step`, then 20 on-target blocks keep it flat (no slow tail — the key EIP-2 property).

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p pallet-qpow` → 24/24 pass
- [x] `cargo test -p quantus-runtime --tests` → 42/42 pass (1 pre-existing `ignored`)
- [ ] Multi-node devnet run to observe difficulty curve under add/remove-GPU stress (the scenario that motivated #564)
- [ ] Sanity-check Prometheus `block_time_ema` continues to populate
