### PR TITLE
Fix multi arch docker image building

### DIFF
--- a/.github/actions/ubuntu/action.yml
+++ b/.github/actions/ubuntu/action.yml
@@ -13,6 +13,7 @@ runs:
           clang \
           protobuf-compiler \
           gcc-aarch64-linux-gnu \
+          g++-aarch64-linux-gnu \
           libc6-dev-arm64-cross
         rustup update
         rustup target add wasm32-unknown-unknown

--- a/.github/actions/ubuntu/action.yml
+++ b/.github/actions/ubuntu/action.yml
@@ -11,8 +11,9 @@ runs:
         sudo apt-get install -yqq --no-install-recommends \
           libclang-dev \
           clang \
-          protobuf-compiler
-          gcc-aarch64-linux-gnu
+          protobuf-compiler \
+          gcc-aarch64-linux-gnu \
+          libc6-dev-arm64-cross
         rustup update
         rustup target add wasm32-unknown-unknown
         rustup target add aarch64-unknown-linux-gnu

--- a/.github/actions/ubuntu/action.yml
+++ b/.github/actions/ubuntu/action.yml
@@ -12,8 +12,10 @@ runs:
           libclang-dev \
           clang \
           protobuf-compiler
+          gcc-aarch64-linux-gnu
         rustup update
         rustup target add wasm32-unknown-unknown
+        rustup target add aarch64-unknown-linux-gnu
         rustup component add rustfmt --toolchain nightly
         rustup component add clippy rust-src
       shell: bash

--- a/.github/workflows/quantus-docker-image.yml
+++ b/.github/workflows/quantus-docker-image.yml
@@ -103,7 +103,7 @@ jobs:
           path: source_code_for_build
 
       - name: Build and push Docker image from Dockerfile
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./source_code_for_build
           file: ./Dockerfile

--- a/.github/workflows/quantus-hotfix-release.yml
+++ b/.github/workflows/quantus-hotfix-release.yml
@@ -65,6 +65,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
@@ -88,6 +90,10 @@ jobs:
       - name: Setup Windows
         if: runner.os == 'Windows'
         uses: ./.github/actions/windows
+
+      - name: Set ARM64 cross-linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build quantus-node binary
         shell: bash

--- a/.github/workflows/quantus-hotfix-release.yml
+++ b/.github/workflows/quantus-hotfix-release.yml
@@ -93,7 +93,10 @@ jobs:
 
       - name: Set ARM64 cross-linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        run: |
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
 
       - name: Build quantus-node binary
         shell: bash

--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -72,6 +72,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
@@ -95,6 +97,10 @@ jobs:
       - name: Setup Windows
         if: runner.os == 'Windows'
         uses: ./.github/actions/windows
+
+      - name: Set ARM64 cross-linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build quantus-node binary
         shell: bash

--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -100,7 +100,10 @@ jobs:
 
       - name: Set ARM64 cross-linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        run: |
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
 
       - name: Build quantus-node binary
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,17 @@ RUN apt-get update \
 
 # Download the specified pre-built binary from GitHub releases
 ARG VERSION_ARG # Expecting format like vX.Y.Z
-RUN ARCH="x86_64-unknown-linux-gnu" \
- && echo "Attempting to download version: ${VERSION_ARG} for architecture ${ARCH}" \
- && curl -fsSL "https://github.com/Quantus-Network/chain/releases/download/${VERSION_ARG}/quantus-node-${VERSION_ARG}-${ARCH}.tar.gz" \
-    | tar -xzC /usr/local/bin/ \
- && chmod +x /usr/local/bin/quantus-node
+RUN set -eux; \
+    DPKG_ARCH="$(dpkg --print-architecture)"; \
+    case "$DPKG_ARCH" in \
+        amd64)   ARCH="x86_64-unknown-linux-gnu" ;; \
+        arm64)   ARCH="aarch64-unknown-linux-gnu" ;; \
+        *) echo "Unsupported architecture: $DPKG_ARCH" && exit 1 ;; \
+    esac; \
+    echo "Downloading version: ${VERSION_ARG} for architecture: ${ARCH}"; \
+    curl -fsSL "https://github.com/Quantus-Network/chain/releases/download/${VERSION_ARG}/quantus-node-${VERSION_ARG}-${ARCH}.tar.gz" \
+        | tar -xzC /usr/local/bin/; \
+    chmod +x /usr/local/bin/quantus-node
 
 # Expose P2P and public WS/RPC ports
 EXPOSE 30333 9944

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -4,12 +4,13 @@
 FROM rust:bookworm AS builder
 
 # Install dependencies needed for building
-# clang-sys requires libclang - libclang-dev provides libclang-14.so in /usr/lib/x86_64-linux-gnu/
 RUN apt-get update && \
     apt-get install -y cmake clang libclang-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-ENV LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu
+# In Debian Bookworm, libclang-dev places the required .so symlink in the llvm-14 folder.
+# This path is identical for BOTH Intel (x86_64) and Apple Silicon (ARM64) builds.
+ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib
 
 # Add wasm target for runtime compilation
 RUN rustup target add wasm32-unknown-unknown
@@ -50,4 +51,3 @@ USER 10001:10001
 
 # Start the node
 ENTRYPOINT ["quantus-node"]
-


### PR DESCRIPTION
## Summary
- Detect arch on the fly instead of hard coded for x86_64
- Update action version for docker build and push to v6
- Add linker and cross compile to arch64 linux

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small GitHub Actions workflow change limited to the `aarch64-unknown-linux-gnu` hotfix build configuration.
> 
> **Overview**
> Ensures the hotfix release workflow can reliably cross-compile for `aarch64-unknown-linux-gnu` by exporting `CC_aarch64_unknown_linux_gnu` and `CXX_aarch64_unknown_linux_gnu` in addition to `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbfa176e57fe9d04428a43cc4114bfafa58a74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->