### PR TITLE
Associate classical keys with quantus keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6606,6 +6606,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-key-association"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-mining-rewards"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 	"miner-api",
 	"node",
 	"pallets/frame-system",
+	"pallets/key-association",
 	"pallets/mining-rewards",
 	"pallets/multisig",
 	"pallets/qpow",
@@ -132,6 +133,7 @@ zeroize = { version = "1.7.0", default-features = false }
 
 # Own dependencies
 pallet-balances = { version = "46.0.0", default-features = false }
+pallet-key-association = { path = "./pallets/key-association", default-features = false }
 pallet-mining-rewards = { path = "./pallets/mining-rewards", default-features = false }
 pallet-multisig = { path = "./pallets/multisig", default-features = false }
 pallet-qpow = { path = "./pallets/qpow", default-features = false }

--- a/pallets/key-association/Cargo.toml
+++ b/pallets/key-association/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+authors.workspace = true
+description = "Pallet for associating classical cryptographic keys (ECDSA/Ed25519) with ML-DSA-87 accounts"
+edition.workspace = true
+homepage.workspace = true
+license = "MIT-0"
+name = "pallet-key-association"
+repository.workspace = true
+version = "1.0.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = ["derive", "max-encoded-len"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+
+[dev-dependencies]
+pallet-balances = { workspace = true, features = ["std"] }
+sp-core = { workspace = true, features = ["std"] }
+sp-io = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+]

--- a/pallets/key-association/src/lib.rs
+++ b/pallets/key-association/src/lib.rs
@@ -1,0 +1,285 @@
+//! # Key Association Pallet
+//!
+//! This pallet allows users to associate classical cryptographic keys (ECDSA secp256k1, Ed25519)
+//! with their post-quantum ML-DSA-87 accounts on Quantus.
+//!
+//! ## Purpose
+//!
+//! Forward migration: Users with existing classical key wallets (Ethereum, Polkadot, etc.)
+//! can cryptographically prove ownership and link those identities to their Quantus account.
+//!
+//! ## Features
+//!
+//! - Associate multiple classical keys with a single ML-DSA-87 account
+//! - On-chain signature verification using sp-core primitives
+//! - Block-hash-based replay protection (unpredictable challenge)
+//! - Reverse index for looking up which ML-DSA account owns a classical key
+//!
+//! ## Design Notes
+//!
+//! - Associations are permanent (no disassociation by design)
+//! - Each classical key can only be associated with one ML-DSA account
+//! - Signature validity window derived from `frame_system::BlockHashCount`
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod types;
+pub mod weights;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+pub use types::*;
+pub use weights::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use sp_io::hashing::blake2_128;
+	use sp_runtime::{traits::Verify, Saturating};
+
+	/// The in-code storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Maximum number of classical keys that can be associated with a single ML-DSA account.
+		#[pallet::constant]
+		type MaxAssociations: Get<u32>;
+
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	/// ML-DSA account -> list of associated classical keys with metadata.
+	#[pallet::storage]
+	#[pallet::getter(fn associations)]
+	pub type Associations<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		BoundedVec<(ClassicalKey, AssociationRecord<BlockNumberFor<T>>), T::MaxAssociations>,
+		ValueQuery,
+	>;
+
+	/// Reverse index: Blake2-128 hash of ClassicalKey -> ML-DSA account.
+	///
+	/// This enables efficient lookups of which ML-DSA account owns a given classical key.
+	#[pallet::storage]
+	#[pallet::getter(fn key_index)]
+	pub type KeyIndex<T: Config> = StorageMap<_, Blake2_128Concat, [u8; 16], T::AccountId, OptionQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A classical key was associated with an ML-DSA-87 account.
+		KeyAssociated {
+			/// The ML-DSA-87 account that now owns this classical key association.
+			account: T::AccountId,
+			/// The type of classical key (ECDSA or Ed25519).
+			key_type: KeyType,
+			/// Blake2-128 hash of the classical key (for indexing).
+			key_hash: [u8; 16],
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The signature type does not match the key type.
+		SignatureKeyMismatch,
+		/// Signature verification failed.
+		InvalidSignature,
+		/// The block hash does not match the hash at the given block number.
+		BlockHashMismatch,
+		/// The signed block is too old (outside validity window).
+		SignatureExpired,
+		/// This classical key is already associated with an account.
+		KeyAlreadyAssociated,
+		/// The account has reached the maximum number of key associations.
+		TooManyAssociations,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Associate a classical key with the caller's ML-DSA-87 account.
+		///
+		/// The caller must provide:
+		/// - `classical_key`: The public key to associate
+		/// - `signature`: A signature from that key over the challenge message
+		/// - `signed_block_number`: The block number whose hash was signed
+		/// - `signed_block_hash`: The block hash that was included in the signed message
+		///
+		/// ## Challenge Message Format
+		///
+		/// The message that must be signed is:
+		/// ```text
+		/// Quantus Key Association
+		/// Account: <scale-encoded account>
+		/// Key: <scale-encoded classical key>
+		/// Block: <block hash bytes>
+		/// ```
+		///
+		/// ## Replay Protection
+		///
+		/// The signed block must be within `BlockHashCount` blocks of the current block.
+		/// The provided block hash must match the on-chain hash at that block number.
+		///
+		/// ## Errors
+		///
+		/// - `BlockHashMismatch`: The hash doesn't match the on-chain hash at that block
+		/// - `SignatureExpired`: The block is older than the validity window
+		/// - `SignatureKeyMismatch`: Signature type doesn't match key type
+		/// - `InvalidSignature`: Signature verification failed
+		/// - `KeyAlreadyAssociated`: This classical key is already linked to an account
+		/// - `TooManyAssociations`: Account has reached `MaxAssociations` limit
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::WeightInfo::associate())]
+		pub fn associate(
+			origin: OriginFor<T>,
+			classical_key: ClassicalKey,
+			signature: ClassicalSignature,
+			signed_block_number: BlockNumberFor<T>,
+			signed_block_hash: T::Hash,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			// 1. Verify block hash matches the on-chain hash at the given block number
+			let actual_hash = frame_system::Pallet::<T>::block_hash(signed_block_number);
+			ensure!(actual_hash == signed_block_hash, Error::<T>::BlockHashMismatch);
+
+			// 2. Verify block is within validity window (derived from BlockHashCount)
+			let current_block = frame_system::Pallet::<T>::block_number();
+			let validity_window = T::BlockHashCount::get();
+
+			ensure!(
+				current_block.saturating_sub(signed_block_number) < validity_window,
+				Error::<T>::SignatureExpired
+			);
+
+			// 3. Build challenge message
+			let message = Self::challenge_message(&who, &classical_key, &signed_block_hash);
+
+			// 4. Verify signature
+			Self::verify_signature(&classical_key, &signature, &message)?;
+
+			// 5. Check key is not already associated
+			let key_hash = Self::hash_key(&classical_key);
+			ensure!(!KeyIndex::<T>::contains_key(key_hash), Error::<T>::KeyAlreadyAssociated);
+
+			// 6. Add to associations (enforces MaxAssociations bound)
+			Associations::<T>::try_mutate(&who, |associations| {
+				associations
+					.try_push((
+						classical_key.clone(),
+						AssociationRecord { created_at: current_block },
+					))
+					.map_err(|_| Error::<T>::TooManyAssociations)
+			})?;
+
+			// 7. Add reverse index
+			KeyIndex::<T>::insert(key_hash, &who);
+
+			// 8. Emit event
+			Self::deposit_event(Event::KeyAssociated {
+				account: who,
+				key_type: classical_key.key_type(),
+				key_hash,
+			});
+
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Build the challenge message that must be signed by the classical key.
+		///
+		/// Format is human-readable for hardware wallet compatibility:
+		/// ```text
+		/// Quantus Key Association
+		/// Account: <scale-encoded account>
+		/// Key: <scale-encoded classical key>
+		/// Block: <block hash bytes>
+		/// ```
+		fn challenge_message(
+			account: &T::AccountId,
+			classical_key: &ClassicalKey,
+			block_hash: &T::Hash,
+		) -> alloc::vec::Vec<u8> {
+			use codec::Encode;
+
+			let mut msg = b"Quantus Key Association\n".to_vec();
+			msg.extend_from_slice(b"Account: ");
+			msg.extend_from_slice(&account.encode());
+			msg.extend_from_slice(b"\nKey: ");
+			msg.extend_from_slice(&classical_key.encode());
+			msg.extend_from_slice(b"\nBlock: ");
+			msg.extend_from_slice(block_hash.as_ref());
+			msg
+		}
+
+		/// Verify a classical signature over a message.
+		fn verify_signature(
+			key: &ClassicalKey,
+			signature: &ClassicalSignature,
+			message: &[u8],
+		) -> Result<(), Error<T>> {
+			match (key, signature) {
+				(ClassicalKey::Ecdsa(pub_key), ClassicalSignature::Ecdsa(sig)) => {
+					ensure!(sig.verify(message, pub_key), Error::<T>::InvalidSignature);
+				}
+				(ClassicalKey::Ed25519(pub_key), ClassicalSignature::Ed25519(sig)) => {
+					ensure!(sig.verify(message, pub_key), Error::<T>::InvalidSignature);
+				}
+				_ => return Err(Error::<T>::SignatureKeyMismatch),
+			}
+			Ok(())
+		}
+
+		/// Compute Blake2-128 hash of a classical key for indexing.
+		fn hash_key(key: &ClassicalKey) -> [u8; 16] {
+			use codec::Encode;
+			blake2_128(&key.encode())
+		}
+
+		// ==================== Public Read APIs ====================
+
+		/// Get all classical keys associated with an ML-DSA account.
+		pub fn associations_for(
+			account: &T::AccountId,
+		) -> alloc::vec::Vec<(ClassicalKey, AssociationRecord<BlockNumberFor<T>>)> {
+			Associations::<T>::get(account).into_inner()
+		}
+
+		/// Look up which ML-DSA account owns a classical key.
+		pub fn account_for_key(key: &ClassicalKey) -> Option<T::AccountId> {
+			let key_hash = Self::hash_key(key);
+			KeyIndex::<T>::get(key_hash)
+		}
+
+		/// Check if a classical key is already associated with any account.
+		pub fn is_key_associated(key: &ClassicalKey) -> bool {
+			let key_hash = Self::hash_key(key);
+			KeyIndex::<T>::contains_key(key_hash)
+		}
+
+		/// Compute the key hash for a given classical key (useful for clients).
+		pub fn compute_key_hash(key: &ClassicalKey) -> [u8; 16] {
+			Self::hash_key(key)
+		}
+	}
+}

--- a/pallets/key-association/src/mock.rs
+++ b/pallets/key-association/src/mock.rs
@@ -1,0 +1,63 @@
+//! Mock runtime for testing pallet-key-association.
+
+use crate as pallet_key_association;
+use frame_support::{derive_impl, parameter_types};
+use sp_runtime::BuildStorage;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+pub type AccountId = sp_core::crypto::AccountId32;
+
+/// Create an AccountId from a u64 (for test convenience).
+pub fn account_id(id: u64) -> AccountId {
+	let mut data = [0u8; 32];
+	data[0..8].copy_from_slice(&id.to_le_bytes());
+	AccountId::new(data)
+}
+
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type KeyAssociation = pallet_key_association::Pallet<Test>;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+	type AccountId = AccountId;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+}
+
+parameter_types! {
+	pub const MaxAssociationsParam: u32 = 8;
+}
+
+impl pallet_key_association::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxAssociations = MaxAssociationsParam;
+	type WeightInfo = ();
+}
+
+/// Build test externalities with default genesis.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.expect("Genesis build should succeed");
+	t.into()
+}

--- a/pallets/key-association/src/tests.rs
+++ b/pallets/key-association/src/tests.rs
@@ -1,0 +1,417 @@
+//! Unit tests for pallet-key-association.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use crate::{mock::*, Error, Event, KeyIndex, Associations, ClassicalKey, ClassicalSignature, KeyType};
+use codec::Encode;
+use frame_support::{assert_noop, assert_ok};
+use sp_core::{ecdsa, ed25519, Pair, H256};
+
+/// Build the challenge message (mirrors the pallet's internal function).
+fn build_challenge_message(
+	account: &AccountId,
+	classical_key: &ClassicalKey,
+	block_hash: &<Test as frame_system::Config>::Hash,
+) -> Vec<u8> {
+	let mut msg = b"Quantus Key Association\n".to_vec();
+	msg.extend_from_slice(b"Account: ");
+	msg.extend_from_slice(&account.encode());
+	msg.extend_from_slice(b"\nKey: ");
+	msg.extend_from_slice(&classical_key.encode());
+	msg.extend_from_slice(b"\nBlock: ");
+	msg.extend_from_slice(block_hash.as_ref());
+	msg
+}
+
+/// Set up test environment with a known block hash at block 5.
+/// Returns the block hash that can be used in tests.
+fn setup_test_blocks() -> H256 {
+	// Set current block to 10 so block 5 is within the validity window
+	System::set_block_number(10);
+	
+	// Manually insert a known block hash at block 5
+	let test_block_hash = H256::from([0x42u8; 32]);
+	frame_system::BlockHash::<Test>::insert(5u64, test_block_hash);
+	
+	test_block_hash
+}
+
+// ==================== ECDSA TESTS ====================
+
+#[test]
+fn associate_ecdsa_key_works() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+		
+		// Generate ECDSA keypair
+		let ecdsa_pair = ecdsa::Pair::generate().0;
+		let ecdsa_public = ecdsa_pair.public();
+		let classical_key = ClassicalKey::Ecdsa(ecdsa_public);
+
+		// Build and sign the challenge message
+		let message = build_challenge_message(&quantus_account, &classical_key, &block_hash);
+		let signature = ecdsa_pair.sign(&message);
+		let classical_sig = ClassicalSignature::Ecdsa(signature);
+
+		// Associate the key
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(quantus_account.clone()),
+			classical_key.clone(),
+			classical_sig,
+			block_number,
+			block_hash,
+		));
+
+		// Verify storage
+		let associations = Associations::<Test>::get(&quantus_account);
+		assert_eq!(associations.len(), 1);
+		assert_eq!(associations[0].0, classical_key);
+		assert_eq!(associations[0].1.created_at, 10); // Current block
+
+		// Verify reverse index
+		let key_hash = KeyAssociation::compute_key_hash(&classical_key);
+		assert_eq!(KeyIndex::<Test>::get(key_hash), Some(quantus_account.clone()));
+
+		// Verify event
+		System::assert_last_event(
+			Event::KeyAssociated {
+				account: quantus_account,
+				key_type: KeyType::Ecdsa,
+				key_hash,
+			}
+			.into(),
+		);
+	});
+}
+
+// ==================== ED25519 TESTS ====================
+
+#[test]
+fn associate_ed25519_key_works() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(2);
+		
+		// Generate Ed25519 keypair
+		let ed_pair = ed25519::Pair::generate().0;
+		let ed_public = ed_pair.public();
+		let classical_key = ClassicalKey::Ed25519(ed_public);
+
+		let message = build_challenge_message(&quantus_account, &classical_key, &block_hash);
+		let signature = ed_pair.sign(&message);
+		let classical_sig = ClassicalSignature::Ed25519(signature);
+
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(quantus_account.clone()),
+			classical_key.clone(),
+			classical_sig,
+			block_number,
+			block_hash,
+		));
+
+		// Verify storage
+		let associations = Associations::<Test>::get(&quantus_account);
+		assert_eq!(associations.len(), 1);
+		assert_eq!(associations[0].0, classical_key);
+
+		// Verify event
+		let key_hash = KeyAssociation::compute_key_hash(&classical_key);
+		System::assert_last_event(
+			Event::KeyAssociated {
+				account: quantus_account,
+				key_type: KeyType::Ed25519,
+				key_hash,
+			}
+			.into(),
+		);
+	});
+}
+
+// ==================== MULTIPLE KEYS TESTS ====================
+
+#[test]
+fn associate_multiple_keys_works() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+
+		// Associate an ECDSA key
+		let ecdsa_pair = ecdsa::Pair::generate().0;
+		let ecdsa_key = ClassicalKey::Ecdsa(ecdsa_pair.public());
+		let msg1 = build_challenge_message(&quantus_account, &ecdsa_key, &block_hash);
+		let sig1 = ClassicalSignature::Ecdsa(ecdsa_pair.sign(&msg1));
+
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(quantus_account.clone()),
+			ecdsa_key.clone(),
+			sig1,
+			block_number,
+			block_hash,
+		));
+
+		// Associate an Ed25519 key
+		let ed_pair = ed25519::Pair::generate().0;
+		let ed_key = ClassicalKey::Ed25519(ed_pair.public());
+		let msg2 = build_challenge_message(&quantus_account, &ed_key, &block_hash);
+		let sig2 = ClassicalSignature::Ed25519(ed_pair.sign(&msg2));
+
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(quantus_account.clone()),
+			ed_key.clone(),
+			sig2,
+			block_number,
+			block_hash,
+		));
+
+		// Verify both are stored
+		let associations = Associations::<Test>::get(&quantus_account);
+		assert_eq!(associations.len(), 2);
+	});
+}
+
+#[test]
+fn max_associations_enforced() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+
+		// Associate MaxAssociations (8) keys
+		for _ in 0..8u8 {
+			// Use generate() with a seed to get deterministic but unique keys
+			let pair = ecdsa::Pair::generate().0;
+			let key = ClassicalKey::Ecdsa(pair.public());
+			let msg = build_challenge_message(&quantus_account, &key, &block_hash);
+			let sig = ClassicalSignature::Ecdsa(pair.sign(&msg));
+
+			assert_ok!(KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account.clone()),
+				key,
+				sig,
+				block_number,
+				block_hash,
+			));
+		}
+
+		// 9th key should fail
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let msg = build_challenge_message(&quantus_account, &key, &block_hash);
+		let sig = ClassicalSignature::Ecdsa(pair.sign(&msg));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account),
+				key,
+				sig,
+				block_number,
+				block_hash,
+			),
+			Error::<Test>::TooManyAssociations
+		);
+	});
+}
+
+// ==================== ERROR CASES ====================
+
+#[test]
+fn invalid_signature_rejected() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+
+		// Generate key but sign wrong message
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let wrong_message = b"wrong message";
+		let sig = ClassicalSignature::Ecdsa(pair.sign(wrong_message));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account),
+				key,
+				sig,
+				block_number,
+				block_hash,
+			),
+			Error::<Test>::InvalidSignature
+		);
+	});
+}
+
+#[test]
+fn signature_key_mismatch_rejected() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+
+		// ECDSA key with Ed25519 signature
+		let ecdsa_pair = ecdsa::Pair::generate().0;
+		let ecdsa_key = ClassicalKey::Ecdsa(ecdsa_pair.public());
+
+		let ed_pair = ed25519::Pair::generate().0;
+		let msg = build_challenge_message(&quantus_account, &ecdsa_key, &block_hash);
+		let wrong_sig = ClassicalSignature::Ed25519(ed_pair.sign(&msg));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account),
+				ecdsa_key,
+				wrong_sig,
+				block_number,
+				block_hash,
+			),
+			Error::<Test>::SignatureKeyMismatch
+		);
+	});
+}
+
+#[test]
+fn key_already_associated_rejected() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let account1 = account_id(1);
+		let account2 = account_id(2);
+
+		// Account 1 associates a key
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let msg1 = build_challenge_message(&account1, &key, &block_hash);
+		let sig1 = ClassicalSignature::Ecdsa(pair.sign(&msg1));
+
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(account1),
+			key.clone(),
+			sig1,
+			block_number,
+			block_hash,
+		));
+
+		// Account 2 tries to associate the same key
+		let msg2 = build_challenge_message(&account2, &key, &block_hash);
+		let sig2 = ClassicalSignature::Ecdsa(pair.sign(&msg2));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(account2),
+				key,
+				sig2,
+				block_number,
+				block_hash,
+			),
+			Error::<Test>::KeyAlreadyAssociated
+		);
+	});
+}
+
+#[test]
+fn block_hash_mismatch_rejected() {
+	new_test_ext().execute_with(|| {
+		let _correct_hash = setup_test_blocks();
+		let block_number = 5u64;
+		
+		// Use a fake block hash that doesn't match block 5
+		let fake_block_hash = H256::from([0xffu8; 32]);
+
+		let quantus_account = account_id(1);
+
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let msg = build_challenge_message(&quantus_account, &key, &fake_block_hash);
+		let sig = ClassicalSignature::Ecdsa(pair.sign(&msg));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account),
+				key,
+				sig,
+				block_number,
+				fake_block_hash,
+			),
+			Error::<Test>::BlockHashMismatch
+		);
+	});
+}
+
+#[test]
+fn signature_expired_rejected() {
+	new_test_ext().execute_with(|| {
+		// Set up block hash at block 5, but set current block very far ahead
+		let test_block_hash = H256::from([0x42u8; 32]);
+		frame_system::BlockHash::<Test>::insert(5u64, test_block_hash);
+		
+		// Set current block to 1000 (way past the 256 block validity window)
+		System::set_block_number(1000);
+
+		let quantus_account = account_id(1);
+
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let msg = build_challenge_message(&quantus_account, &key, &test_block_hash);
+		let sig = ClassicalSignature::Ecdsa(pair.sign(&msg));
+
+		assert_noop!(
+			KeyAssociation::associate(
+				RuntimeOrigin::signed(quantus_account),
+				key,
+				sig,
+				5u64,
+				test_block_hash,
+			),
+			Error::<Test>::SignatureExpired
+		);
+	});
+}
+
+// ==================== READ API TESTS ====================
+
+#[test]
+fn read_apis_work() {
+	new_test_ext().execute_with(|| {
+		let block_hash = setup_test_blocks();
+		let block_number = 5u64;
+
+		let quantus_account = account_id(1);
+
+		let pair = ecdsa::Pair::generate().0;
+		let key = ClassicalKey::Ecdsa(pair.public());
+		let msg = build_challenge_message(&quantus_account, &key, &block_hash);
+		let sig = ClassicalSignature::Ecdsa(pair.sign(&msg));
+
+		// Before association
+		assert!(!KeyAssociation::is_key_associated(&key));
+		assert_eq!(KeyAssociation::account_for_key(&key), None);
+		assert!(KeyAssociation::associations_for(&quantus_account).is_empty());
+
+		// Associate
+		assert_ok!(KeyAssociation::associate(
+			RuntimeOrigin::signed(quantus_account.clone()),
+			key.clone(),
+			sig,
+			block_number,
+			block_hash,
+		));
+
+		// After association
+		assert!(KeyAssociation::is_key_associated(&key));
+		assert_eq!(KeyAssociation::account_for_key(&key), Some(quantus_account.clone()));
+		
+		let associations = KeyAssociation::associations_for(&quantus_account);
+		assert_eq!(associations.len(), 1);
+		assert_eq!(associations[0].0, key);
+	});
+}

--- a/pallets/key-association/src/types.rs
+++ b/pallets/key-association/src/types.rs
@@ -1,0 +1,63 @@
+//! Types for the key-association pallet.
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::{ecdsa, ed25519};
+use sp_runtime::RuntimeDebug;
+
+/// Supported classical key types.
+///
+/// These are the pre-quantum cryptographic keys that users may want to
+/// associate with their post-quantum ML-DSA-87 accounts for migration purposes.
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, RuntimeDebug,
+)]
+pub enum ClassicalKey {
+	/// ECDSA secp256k1 compressed public key (33 bytes).
+	/// Compatible with Ethereum, Bitcoin, and other secp256k1-based chains.
+	Ecdsa(ecdsa::Public),
+	/// Ed25519 public key (32 bytes).
+	/// Compatible with Polkadot (Sr25519 uses the same curve), Solana, etc.
+	Ed25519(ed25519::Public),
+}
+
+impl ClassicalKey {
+	/// Returns the key type discriminant.
+	pub fn key_type(&self) -> KeyType {
+		match self {
+			ClassicalKey::Ecdsa(_) => KeyType::Ecdsa,
+			ClassicalKey::Ed25519(_) => KeyType::Ed25519,
+		}
+	}
+}
+
+/// Signature types matching the classical keys.
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, RuntimeDebug,
+)]
+pub enum ClassicalSignature {
+	/// ECDSA signature (65 bytes: r + s + recovery byte).
+	Ecdsa(ecdsa::Signature),
+	/// Ed25519 signature (64 bytes).
+	Ed25519(ed25519::Signature),
+}
+
+/// Key type discriminant for events.
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Clone, Copy, PartialEq, Eq, TypeInfo, MaxEncodedLen, RuntimeDebug,
+)]
+pub enum KeyType {
+	/// ECDSA secp256k1
+	Ecdsa,
+	/// Ed25519
+	Ed25519,
+}
+
+/// Metadata stored with each key association.
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, RuntimeDebug,
+)]
+pub struct AssociationRecord<BlockNumber> {
+	/// Block number when the association was created.
+	pub created_at: BlockNumber,
+}

--- a/pallets/key-association/src/weights.rs
+++ b/pallets/key-association/src/weights.rs
@@ -1,0 +1,47 @@
+//! Placeholder weights for pallet-key-association.
+//!
+//! These are temporary weights that should be replaced with benchmarked values.
+//! Run `cargo run --release -p quantus-node benchmark pallet` to generate real weights.
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+#![allow(missing_docs)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use core::marker::PhantomData;
+
+/// Weight functions needed for `pallet_key_association`.
+pub trait WeightInfo {
+	fn associate() -> Weight;
+}
+
+/// Placeholder weights for `pallet_key_association`.
+///
+/// These are conservative estimates. Real benchmarks should be run for production.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	/// Weight for the `associate` extrinsic.
+	///
+	/// Storage: `System::BlockHash` (r:1 for block hash lookup)
+	/// Storage: `KeyAssociation::KeyIndex` (r:1 w:1)
+	/// Storage: `KeyAssociation::Associations` (r:1 w:1)
+	///
+	/// Computation: Signature verification (ECDSA ~50µs, Ed25519 ~30µs)
+	fn associate() -> Weight {
+		// Conservative placeholder: 100ms execution + storage ops
+		// ECDSA verification is more expensive than Ed25519
+		Weight::from_parts(100_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+}
+
+/// Default implementation for tests.
+impl WeightInfo for () {
+	fn associate() -> Weight {
+		Weight::from_parts(100_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+}


### PR DESCRIPTION
Not sure if this makes sense but kind of interesting. 

It's not hooked up to the runtime yet, just starting a conversation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New on-chain identity/crypto surface with permanent bindings and signature verification, but it is isolated from the live runtime until integrated and benchmarked.
> 
> **Overview**
> Adds a new **`pallet-key-association`** workspace crate (registered in root `Cargo.toml` / lockfile) that is **not wired into `quantus-runtime` yet**.
> 
> The pallet exposes **`associate`**: a signed ML-DSA account can link **ECDSA (secp256k1)** or **Ed25519** public keys after the classical key signs a fixed challenge (`Quantus Key Association` + SCALE-encoded account/key + block hash). Replay protection checks the signed block hash against on-chain `frame_system` history and enforces a window from **`BlockHashCount`**.
> 
> On success it stores a per-account bounded list (`MaxAssociations`), a **Blake2-128 reverse index** (one classical key → one account, no unlink), emits **`KeyAssociated`**, and ships **placeholder weights** plus broad unit tests (valid paths, limits, and error cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d320fc228a7975402c2ede6047f6c66c65495a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->