### PR TITLE
vendor sc-network-types v0.20.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -774,7 +774,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -1171,9 +1171,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2-sys"
@@ -1522,7 +1522,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "memchr",
 ]
 
@@ -3739,7 +3739,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -3759,7 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -4043,7 +4043,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "fnv",
  "itoa",
 ]
@@ -4054,7 +4054,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "fnv",
  "itoa",
 ]
@@ -4065,7 +4065,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "http 0.2.12",
  "pin-project-lite 0.2.16",
 ]
@@ -4076,7 +4076,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "http 1.3.1",
 ]
 
@@ -4086,7 +4086,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -4120,7 +4120,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4145,7 +4145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
  "atomic-waker",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "h2 0.4.12",
@@ -4185,7 +4185,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4384,7 +4384,7 @@ checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
  "async-trait",
  "attohttpc",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "http 0.2.12",
  "hyper 0.14.32",
@@ -4756,7 +4756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
 dependencies = [
  "async-trait",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-timer",
  "futures-util",
  "http 1.3.1",
@@ -4964,7 +4964,7 @@ version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "either",
  "futures 0.3.31",
  "futures-timer",
@@ -5110,7 +5110,7 @@ checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
 dependencies = [
  "arrayvec 0.7.6",
  "asynchronous-codec 0.7.0",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "either",
  "fnv",
  "futures 0.3.31",
@@ -5176,7 +5176,7 @@ version = "0.45.10"
 source = "git+https://github.com/Quantus-Network/qp-libp2p-noise?tag=v0.45.10#901f09f30b32f910395270bba3a566191dc2f61f"
 dependencies = [
  "asynchronous-codec 0.6.2",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "clatter",
  "futures 0.3.31",
  "libp2p-core",
@@ -5217,7 +5217,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "futures-timer",
  "if-watch",
@@ -5376,7 +5376,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.8",
+ "yamux 0.13.10",
 ]
 
 [[package]]
@@ -5521,13 +5521,13 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litep2p"
-version = "0.13.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68ba359d7f1a80d18821b46575d5ddb9a9a6672fe0669f5fc9e83cab9abd760"
+checksum = "cbf3924cf539a761465543592b34c4198d60db2cda16594769edd43451e5ab41"
 dependencies = [
  "async-trait",
  "bs58",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "cid 0.11.1",
  "ed25519-dalek",
  "enum-display",
@@ -5535,6 +5535,7 @@ dependencies = [
  "futures-timer",
  "hickory-resolver 0.25.2",
  "indexmap",
+ "ip_network",
  "libc",
  "mockall",
  "multiaddr 0.17.1",
@@ -5563,7 +5564,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.8",
+ "yamux 0.13.10",
  "yasna",
  "zeroize",
 ]
@@ -6012,7 +6013,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "log",
  "pin-project",
@@ -6093,7 +6094,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "log",
  "netlink-packet-core",
@@ -6107,7 +6108,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "libc",
  "log",
@@ -6978,7 +6979,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -7968,7 +7969,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "prost-derive 0.12.6",
 ]
 
@@ -7978,7 +7979,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "prost-derive 0.13.5",
 ]
 
@@ -7988,7 +7989,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "prost-derive 0.14.3",
 ]
 
@@ -8634,7 +8635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
  "asynchronous-codec 0.7.0",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "quick-protobuf",
  "thiserror 1.0.69",
  "unsigned-varint 0.8.0",
@@ -8646,6 +8647,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
+ "env_logger",
+ "log",
  "rand 0.10.0",
 ]
 
@@ -8655,7 +8658,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "pin-project-lite 0.2.16",
  "quinn-proto 0.10.6",
  "quinn-udp 0.4.1",
@@ -8672,7 +8675,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "cfg_aliases 0.2.1",
  "futures-io",
  "pin-project-lite 0.2.16",
@@ -8693,7 +8696,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash 1.1.0",
@@ -8711,7 +8714,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.2",
@@ -8732,7 +8735,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "libc",
  "socket2 0.5.10",
  "tracing",
@@ -9854,7 +9857,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
  "blake2 0.10.6",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "futures-timer",
  "log",
@@ -9883,7 +9886,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec 0.6.2",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "cid 0.9.0",
  "criterion",
  "either",
@@ -10018,12 +10021,10 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11103f2e35999989326ed5be87f0a7d335269bef6d6a1c0ddd543a7d9aed7788"
+version = "0.20.3"
 dependencies = [
  "bs58",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "ed25519-dalek",
  "libp2p-identity",
  "libp2p-kad",
@@ -10031,6 +10032,7 @@ dependencies = [
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
+ "quickcheck",
  "rand 0.8.5",
  "serde",
  "serde_with",
@@ -10044,7 +10046,7 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f774f1db7581702b12e65f55eb6cd95159c5aaaced0fa7bf9c57491d179fc55"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
@@ -11194,7 +11196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures 0.3.31",
  "http 1.3.1",
  "httparse",
@@ -11543,7 +11545,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c3b7db2a4f180e3362e374754983e3ddc844b7a1cd2c2e5b71ab0bd3673dfe"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "docify",
  "ed25519-dalek",
  "libsecp256k1",
@@ -11659,7 +11661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f799c308ab442aa1c80b193db8c76f36dcc5a911408bf8861511987f4e4f2ee"
 dependencies = [
  "binary-merkle-tree",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -11690,7 +11692,7 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22644a2fabb5c246911ecde30fdb7f0801c90f5e611b1147140055ad7b6dabab"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive",
@@ -12758,7 +12760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "io-uring",
  "libc",
  "mio",
@@ -12837,7 +12839,7 @@ version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -12947,7 +12949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.9.4",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -13118,7 +13120,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "data-encoding",
  "http 1.3.1",
  "httparse",
@@ -13258,7 +13260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
  "asynchronous-codec 0.6.2",
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "futures-io",
  "futures-util",
 ]
@@ -13269,7 +13271,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.1",
  "tokio-util",
 ]
 
@@ -14789,9 +14791,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures 0.3.31",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"client/consensus/qpow",
 	"client/network",
 	"client/network-sync",
+	"client/network-types",
 	"miner-api",
 	"node",
 	"pallets/frame-system",
@@ -195,7 +196,7 @@ sc-executor = { version = "0.47.0", default-features = false }
 sc-network = { version = "0.55.1", default-features = false }
 sc-network-common = { version = "0.52.0", default-features = false }
 sc-network-sync = { version = "0.54.0", default-features = false }
-sc-network-types = { version = "0.20.1", default-features = false }
+sc-network-types = { version = "0.20.3", default-features = false }
 sc-offchain = { version = "50.0.0", default-features = false }
 sc-service = { version = "0.56.0", default-features = false }
 sc-telemetry = { version = "30.0.0", default-features = false }
@@ -239,6 +240,7 @@ libp2p-noise = { git = "https://github.com/Quantus-Network/qp-libp2p-noise", tag
 sc-cli = { path = "./client/cli" }
 sc-network = { path = "client/network" }
 sc-network-sync = { path = "client/network-sync" }
+sc-network-types = { path = "client/network-types" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"client/consensus/qpow",
 	"client/network",
 	"client/network-sync",
+	"client/network-types",
 	"miner-api",
 	"node",
 	"pallets/frame-system",
@@ -239,6 +240,7 @@ libp2p-noise = { git = "https://github.com/Quantus-Network/qp-libp2p-noise", tag
 sc-cli = { path = "./client/cli" }
 sc-network = { path = "client/network" }
 sc-network-sync = { path = "client/network-sync" }
+sc-network-types = { path = "client/network-types" }
 
 [profile.release]
 opt-level = 3

--- a/client/network-types/Cargo.toml
+++ b/client/network-types/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "sc-network-types"
+version = "0.20.3"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+description = "Substrate network types"
+homepage = "https://paritytech.github.io/polkadot-sdk/"
+documentation = "https://docs.rs/sc-network-types"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+repository = "https://github.com/paritytech/polkadot-sdk.git"
+
+[lib]
+name = "sc_network_types"
+path = "src/lib.rs"
+
+[dependencies]
+bs58 = "0.5.1"
+bytes = { workspace = true }
+ed25519-dalek = "2.1"
+libp2p-identity = { workspace = true, features = ["ed25519", "peerid", "rand"] }
+libp2p-kad = { version = "0.46.2", default-features = false }
+litep2p = { version = "0.13.3", features = ["rsa", "websocket"] }
+log = { workspace = true }
+multiaddr = "0.18.1"
+multihash = { version = "0.19.1", default-features = false }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_with = { version = "3.12.0", default-features = false, features = ["hex", "macros"] }
+thiserror = { workspace = true }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+quickcheck = "1.0.3"

--- a/client/network-types/Cargo.toml
+++ b/client/network-types/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Substrate network types"
+documentation = "https://docs.rs/sc-network-types"
+edition = "2021"
+homepage = "https://paritytech.github.io/polkadot-sdk/"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+name = "sc-network-types"
+repository = "https://github.com/paritytech/polkadot-sdk.git"
+version = "0.20.3"
+
+[lib]
+name = "sc_network_types"
+path = "src/lib.rs"
+
+[dependencies]
+bs58 = "0.5.1"
+bytes = { workspace = true }
+ed25519-dalek = "2.1"
+libp2p-identity = { workspace = true, features = ["ed25519", "peerid", "rand"] }
+libp2p-kad = { version = "0.46.2", default-features = false }
+litep2p = { version = "0.13.3", features = ["rsa", "websocket"] }
+log = { workspace = true }
+multiaddr = "0.18.1"
+multihash = { version = "0.19.1", default-features = false }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_with = { version = "3.12.0", default-features = false, features = ["hex", "macros"] }
+thiserror = { workspace = true }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+quickcheck = "1.0.3"

--- a/client/network-types/Cargo.toml
+++ b/client/network-types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "sc-network-types"
-version = "0.20.3"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
 description = "Substrate network types"
-homepage = "https://paritytech.github.io/polkadot-sdk/"
 documentation = "https://docs.rs/sc-network-types"
+edition = "2021"
+homepage = "https://paritytech.github.io/polkadot-sdk/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+name = "sc-network-types"
 repository = "https://github.com/paritytech/polkadot-sdk.git"
+version = "0.20.3"
 
 [lib]
 name = "sc_network_types"

--- a/client/network-types/src/ed25519.rs
+++ b/client/network-types/src/ed25519.rs
@@ -1,0 +1,551 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Ed25519 keys.
+
+use crate::PeerId;
+use core::{cmp, fmt, hash};
+use ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
+use libp2p_identity::ed25519 as libp2p_ed25519;
+use litep2p::crypto::ed25519 as litep2p_ed25519;
+use zeroize::Zeroize;
+
+/// An Ed25519 keypair.
+#[derive(Clone)]
+pub struct Keypair(ed25519::SigningKey);
+
+impl Keypair {
+	/// Generate a new random Ed25519 keypair.
+	pub fn generate() -> Keypair {
+		Keypair::from(SecretKey::generate())
+	}
+
+	/// Convert the keypair into a byte array by concatenating the bytes
+	/// of the secret scalar and the compressed public point,
+	/// an informal standard for encoding Ed25519 keypairs.
+	pub fn to_bytes(&self) -> [u8; 64] {
+		self.0.to_keypair_bytes()
+	}
+
+	/// Try to parse a keypair from the [binary format](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5)
+	/// produced by [`Keypair::to_bytes`], zeroing the input on success.
+	///
+	/// Note that this binary format is the same as `ed25519_dalek`'s and `ed25519_zebra`'s.
+	pub fn try_from_bytes(kp: &mut [u8]) -> Result<Keypair, DecodingError> {
+		let bytes = <[u8; 64]>::try_from(&*kp)
+			.map_err(|e| DecodingError::KeypairParseError(Box::new(e)))?;
+
+		ed25519::SigningKey::from_keypair_bytes(&bytes)
+			.map(|k| {
+				kp.zeroize();
+				Keypair(k)
+			})
+			.map_err(|e| DecodingError::KeypairParseError(Box::new(e)))
+	}
+
+	/// Sign a message using the private key of this keypair.
+	pub fn sign(&self, msg: &[u8]) -> Vec<u8> {
+		self.0.sign(msg).to_bytes().to_vec()
+	}
+
+	/// Get the public key of this keypair.
+	pub fn public(&self) -> PublicKey {
+		PublicKey(self.0.verifying_key())
+	}
+
+	/// Get the secret key of this keypair.
+	pub fn secret(&self) -> SecretKey {
+		SecretKey(self.0.to_bytes())
+	}
+}
+
+impl fmt::Debug for Keypair {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("Keypair").field("public", &self.0.verifying_key()).finish()
+	}
+}
+
+impl From<litep2p_ed25519::Keypair> for Keypair {
+	fn from(kp: litep2p_ed25519::Keypair) -> Self {
+		Self::try_from_bytes(&mut kp.to_bytes())
+			.expect("ed25519_dalek in substrate & litep2p to use the same format")
+	}
+}
+
+impl From<Keypair> for litep2p_ed25519::Keypair {
+	fn from(kp: Keypair) -> Self {
+		Self::try_from_bytes(&mut kp.to_bytes())
+			.expect("ed25519_dalek in substrate & litep2p to use the same format")
+	}
+}
+
+impl From<libp2p_ed25519::Keypair> for Keypair {
+	fn from(kp: libp2p_ed25519::Keypair) -> Self {
+		Self::try_from_bytes(&mut kp.to_bytes())
+			.expect("ed25519_dalek in substrate & libp2p to use the same format")
+	}
+}
+
+impl From<Keypair> for libp2p_ed25519::Keypair {
+	fn from(kp: Keypair) -> Self {
+		Self::try_from_bytes(&mut kp.to_bytes())
+			.expect("ed25519_dalek in substrate & libp2p to use the same format")
+	}
+}
+
+/// Demote an Ed25519 keypair to a secret key.
+impl From<Keypair> for SecretKey {
+	fn from(kp: Keypair) -> SecretKey {
+		SecretKey(kp.0.to_bytes())
+	}
+}
+
+/// Promote an Ed25519 secret key into a keypair.
+impl From<SecretKey> for Keypair {
+	fn from(sk: SecretKey) -> Keypair {
+		let signing = ed25519::SigningKey::from_bytes(&sk.0);
+		Keypair(signing)
+	}
+}
+
+/// An Ed25519 public key.
+#[derive(Eq, Clone)]
+pub struct PublicKey(ed25519::VerifyingKey);
+
+impl fmt::Debug for PublicKey {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str("PublicKey(compressed): ")?;
+		for byte in self.0.as_bytes() {
+			write!(f, "{byte:x}")?;
+		}
+		Ok(())
+	}
+}
+
+impl cmp::PartialEq for PublicKey {
+	fn eq(&self, other: &Self) -> bool {
+		self.0.as_bytes().eq(other.0.as_bytes())
+	}
+}
+
+impl hash::Hash for PublicKey {
+	fn hash<H: hash::Hasher>(&self, state: &mut H) {
+		self.0.as_bytes().hash(state);
+	}
+}
+
+impl cmp::PartialOrd for PublicKey {
+	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl cmp::Ord for PublicKey {
+	fn cmp(&self, other: &Self) -> cmp::Ordering {
+		self.0.as_bytes().cmp(other.0.as_bytes())
+	}
+}
+
+impl PublicKey {
+	/// Verify the Ed25519 signature on a message using the public key.
+	pub fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
+		ed25519::Signature::try_from(sig).and_then(|s| self.0.verify(msg, &s)).is_ok()
+	}
+
+	/// Convert the public key to a byte array in compressed form, i.e.
+	/// where one coordinate is represented by a single bit.
+	pub fn to_bytes(&self) -> [u8; 32] {
+		self.0.to_bytes()
+	}
+
+	/// Try to parse a public key from a byte array containing the actual key as produced by
+	/// `to_bytes`.
+	pub fn try_from_bytes(k: &[u8]) -> Result<PublicKey, DecodingError> {
+		let k =
+			<[u8; 32]>::try_from(k).map_err(|e| DecodingError::PublicKeyParseError(Box::new(e)))?;
+		ed25519::VerifyingKey::from_bytes(&k)
+			.map_err(|e| DecodingError::PublicKeyParseError(Box::new(e)))
+			.map(PublicKey)
+	}
+
+	/// Convert public key to `PeerId`.
+	pub fn to_peer_id(&self) -> PeerId {
+		litep2p::PeerId::from(litep2p::crypto::PublicKey::Ed25519(self.clone().into())).into()
+	}
+}
+
+impl From<litep2p_ed25519::PublicKey> for PublicKey {
+	fn from(k: litep2p_ed25519::PublicKey) -> Self {
+		Self::try_from_bytes(&k.to_bytes())
+			.expect("ed25519_dalek in substrate & litep2p to use the same format")
+	}
+}
+
+impl From<PublicKey> for litep2p_ed25519::PublicKey {
+	fn from(k: PublicKey) -> Self {
+		Self::try_from_bytes(&k.to_bytes())
+			.expect("ed25519_dalek in substrate & litep2p to use the same format")
+	}
+}
+
+impl From<libp2p_ed25519::PublicKey> for PublicKey {
+	fn from(k: libp2p_ed25519::PublicKey) -> Self {
+		Self::try_from_bytes(&k.to_bytes())
+			.expect("ed25519_dalek in substrate & libp2p to use the same format")
+	}
+}
+
+impl From<PublicKey> for libp2p_ed25519::PublicKey {
+	fn from(k: PublicKey) -> Self {
+		Self::try_from_bytes(&k.to_bytes())
+			.expect("ed25519_dalek in substrate & libp2p to use the same format")
+	}
+}
+
+/// An Ed25519 secret key.
+#[derive(Clone)]
+pub struct SecretKey(ed25519::SecretKey);
+
+/// View the bytes of the secret key.
+impl AsRef<[u8]> for SecretKey {
+	fn as_ref(&self) -> &[u8] {
+		&self.0[..]
+	}
+}
+
+impl fmt::Debug for SecretKey {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "SecretKey")
+	}
+}
+
+impl SecretKey {
+	/// Generate a new Ed25519 secret key.
+	pub fn generate() -> SecretKey {
+		let signing = ed25519::SigningKey::generate(&mut rand::rngs::OsRng);
+		SecretKey(signing.to_bytes())
+	}
+
+	/// Try to parse an Ed25519 secret key from a byte slice
+	/// containing the actual key, zeroing the input on success.
+	/// If the bytes do not constitute a valid Ed25519 secret key, an error is
+	/// returned.
+	pub fn try_from_bytes(mut sk_bytes: impl AsMut<[u8]>) -> Result<SecretKey, DecodingError> {
+		let sk_bytes = sk_bytes.as_mut();
+		let secret = <[u8; 32]>::try_from(&*sk_bytes)
+			.map_err(|e| DecodingError::SecretKeyParseError(Box::new(e)))?;
+		sk_bytes.zeroize();
+		Ok(SecretKey(secret))
+	}
+
+	pub fn to_bytes(&self) -> [u8; 32] {
+		self.0
+	}
+}
+
+impl Drop for SecretKey {
+	fn drop(&mut self) {
+		self.0.zeroize();
+	}
+}
+
+impl From<litep2p_ed25519::SecretKey> for SecretKey {
+	fn from(sk: litep2p_ed25519::SecretKey) -> Self {
+		Self::try_from_bytes(&mut sk.to_bytes()).expect("Ed25519 key to be 32 bytes length")
+	}
+}
+
+impl From<SecretKey> for litep2p_ed25519::SecretKey {
+	fn from(sk: SecretKey) -> Self {
+		Self::try_from_bytes(&mut sk.to_bytes())
+			.expect("litep2p `SecretKey` to accept 32 bytes as Ed25519 key")
+	}
+}
+
+impl From<libp2p_ed25519::SecretKey> for SecretKey {
+	fn from(sk: libp2p_ed25519::SecretKey) -> Self {
+		Self::try_from_bytes(&mut sk.as_ref().to_owned())
+			.expect("Ed25519 key to be 32 bytes length")
+	}
+}
+
+impl From<SecretKey> for libp2p_ed25519::SecretKey {
+	fn from(sk: SecretKey) -> Self {
+		Self::try_from_bytes(&mut sk.to_bytes())
+			.expect("libp2p `SecretKey` to accept 32 bytes as Ed25519 key")
+	}
+}
+
+/// Error when decoding `ed25519`-related types.
+#[derive(Debug, thiserror::Error)]
+pub enum DecodingError {
+	#[error("failed to parse Ed25519 keypair: {0}")]
+	KeypairParseError(Box<dyn std::error::Error + Send + Sync>),
+	#[error("failed to parse Ed25519 secret key: {0}")]
+	SecretKeyParseError(Box<dyn std::error::Error + Send + Sync>),
+	#[error("failed to parse Ed25519 public key: {0}")]
+	PublicKeyParseError(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use quickcheck::*;
+
+	fn eq_keypairs(kp1: &Keypair, kp2: &Keypair) -> bool {
+		kp1.public() == kp2.public() && kp1.0.to_bytes() == kp2.0.to_bytes()
+	}
+
+	#[test]
+	fn ed25519_keypair_encode_decode() {
+		fn prop() -> bool {
+			let kp1 = Keypair::generate();
+			let mut kp1_enc = kp1.to_bytes();
+			let kp2 = Keypair::try_from_bytes(&mut kp1_enc).unwrap();
+			eq_keypairs(&kp1, &kp2) && kp1_enc.iter().all(|b| *b == 0)
+		}
+		QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
+	}
+
+	#[test]
+	fn ed25519_keypair_from_secret() {
+		fn prop() -> bool {
+			let kp1 = Keypair::generate();
+			let mut sk = kp1.0.to_bytes();
+			let kp2 = Keypair::from(SecretKey::try_from_bytes(&mut sk).unwrap());
+			eq_keypairs(&kp1, &kp2) && sk == [0u8; 32]
+		}
+		QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
+	}
+
+	#[test]
+	fn ed25519_signature() {
+		let kp = Keypair::generate();
+		let pk = kp.public();
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+		assert!(pk.verify(msg, &sig));
+
+		let mut invalid_sig = sig.clone();
+		invalid_sig[3..6].copy_from_slice(&[10, 23, 42]);
+		assert!(!pk.verify(msg, &invalid_sig));
+
+		let invalid_msg = "h3ll0 w0rld".as_bytes();
+		assert!(!pk.verify(invalid_msg, &sig));
+	}
+
+	#[test]
+	fn substrate_kp_to_libs() {
+		let kp = Keypair::generate();
+		let kp_bytes = kp.to_bytes();
+		let kp1: libp2p_ed25519::Keypair = kp.clone().into();
+		let kp2: litep2p_ed25519::Keypair = kp.clone().into();
+		let kp3 = libp2p_ed25519::Keypair::try_from_bytes(&mut kp_bytes.clone()).unwrap();
+		let kp4 = litep2p_ed25519::Keypair::try_from_bytes(&mut kp_bytes.clone()).unwrap();
+
+		assert_eq!(kp_bytes, kp1.to_bytes());
+		assert_eq!(kp_bytes, kp2.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+		let sig1 = kp1.sign(msg);
+		let sig2 = kp2.sign(msg);
+		let sig3 = kp3.sign(msg);
+		let sig4 = kp4.sign(msg);
+
+		assert_eq!(sig, sig1);
+		assert_eq!(sig, sig2);
+		assert_eq!(sig, sig3);
+		assert_eq!(sig, sig4);
+
+		let pk1 = kp1.public();
+		let pk2 = kp2.public();
+		let pk3 = kp3.public();
+		let pk4 = kp4.public();
+
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+		assert!(pk3.verify(msg, &sig));
+		assert!(pk4.verify(msg, &sig));
+	}
+
+	#[test]
+	fn litep2p_kp_to_substrate_kp() {
+		let kp = litep2p_ed25519::Keypair::generate();
+		let kp1: Keypair = kp.clone().into();
+		let kp2 = Keypair::try_from_bytes(&mut kp.to_bytes()).unwrap();
+
+		assert_eq!(kp.to_bytes(), kp1.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+		let sig1 = kp1.sign(msg);
+		let sig2 = kp2.sign(msg);
+
+		assert_eq!(sig, sig1);
+		assert_eq!(sig, sig2);
+
+		let pk1 = kp1.public();
+		let pk2 = kp2.public();
+
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+	}
+
+	#[test]
+	fn libp2p_kp_to_substrate_kp() {
+		let kp = libp2p_ed25519::Keypair::generate();
+		let kp1: Keypair = kp.clone().into();
+		let kp2 = Keypair::try_from_bytes(&mut kp.to_bytes()).unwrap();
+
+		assert_eq!(kp.to_bytes(), kp1.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+		let sig1 = kp1.sign(msg);
+		let sig2 = kp2.sign(msg);
+
+		assert_eq!(sig, sig1);
+		assert_eq!(sig, sig2);
+
+		let pk1 = kp1.public();
+		let pk2 = kp2.public();
+
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+	}
+
+	#[test]
+	fn substrate_pk_to_libs() {
+		let kp = Keypair::generate();
+		let pk = kp.public();
+		let pk_bytes = pk.to_bytes();
+		let pk1: libp2p_ed25519::PublicKey = pk.clone().into();
+		let pk2: litep2p_ed25519::PublicKey = pk.clone().into();
+		let pk3 = libp2p_ed25519::PublicKey::try_from_bytes(&pk_bytes).unwrap();
+		let pk4 = litep2p_ed25519::PublicKey::try_from_bytes(&pk_bytes).unwrap();
+
+		assert_eq!(pk_bytes, pk1.to_bytes());
+		assert_eq!(pk_bytes, pk2.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert!(pk.verify(msg, &sig));
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+		assert!(pk3.verify(msg, &sig));
+		assert!(pk4.verify(msg, &sig));
+	}
+
+	#[test]
+	fn litep2p_pk_to_substrate_pk() {
+		let kp = litep2p_ed25519::Keypair::generate();
+		let pk = kp.public();
+		let pk_bytes = pk.clone().to_bytes();
+		let pk1: PublicKey = pk.clone().into();
+		let pk2 = PublicKey::try_from_bytes(&pk_bytes).unwrap();
+
+		assert_eq!(pk_bytes, pk1.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert!(pk.verify(msg, &sig));
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+	}
+
+	#[test]
+	fn libp2p_pk_to_substrate_pk() {
+		let kp = libp2p_ed25519::Keypair::generate();
+		let pk = kp.public();
+		let pk_bytes = pk.clone().to_bytes();
+		let pk1: PublicKey = pk.clone().into();
+		let pk2 = PublicKey::try_from_bytes(&pk_bytes).unwrap();
+
+		assert_eq!(pk_bytes, pk1.to_bytes());
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert!(pk.verify(msg, &sig));
+		assert!(pk1.verify(msg, &sig));
+		assert!(pk2.verify(msg, &sig));
+	}
+
+	#[test]
+	fn substrate_sk_to_libs() {
+		let sk = SecretKey::generate();
+		let sk_bytes = sk.to_bytes();
+		let sk1: libp2p_ed25519::SecretKey = sk.clone().into();
+		let sk2: litep2p_ed25519::SecretKey = sk.clone().into();
+		let sk3 = libp2p_ed25519::SecretKey::try_from_bytes(&mut sk_bytes.clone()).unwrap();
+		let sk4 = litep2p_ed25519::SecretKey::try_from_bytes(&mut sk_bytes.clone()).unwrap();
+
+		let kp: Keypair = sk.into();
+		let kp1: libp2p_ed25519::Keypair = sk1.into();
+		let kp2: litep2p_ed25519::Keypair = sk2.into();
+		let kp3: libp2p_ed25519::Keypair = sk3.into();
+		let kp4: litep2p_ed25519::Keypair = sk4.into();
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert_eq!(sig, kp1.sign(msg));
+		assert_eq!(sig, kp2.sign(msg));
+		assert_eq!(sig, kp3.sign(msg));
+		assert_eq!(sig, kp4.sign(msg));
+	}
+
+	#[test]
+	fn litep2p_sk_to_substrate_sk() {
+		let sk = litep2p_ed25519::SecretKey::generate();
+		let sk1: SecretKey = sk.clone().into();
+		let sk2 = SecretKey::try_from_bytes(&mut sk.to_bytes()).unwrap();
+
+		let kp: litep2p_ed25519::Keypair = sk.into();
+		let kp1: Keypair = sk1.into();
+		let kp2: Keypair = sk2.into();
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert_eq!(sig, kp1.sign(msg));
+		assert_eq!(sig, kp2.sign(msg));
+	}
+
+	#[test]
+	fn libp2p_sk_to_substrate_sk() {
+		let sk = libp2p_ed25519::SecretKey::generate();
+		let sk_bytes = sk.as_ref().to_owned();
+		let sk1: SecretKey = sk.clone().into();
+		let sk2 = SecretKey::try_from_bytes(sk_bytes).unwrap();
+
+		let kp: libp2p_ed25519::Keypair = sk.into();
+		let kp1: Keypair = sk1.into();
+		let kp2: Keypair = sk2.into();
+
+		let msg = "hello world".as_bytes();
+		let sig = kp.sign(msg);
+
+		assert_eq!(sig, kp1.sign(msg));
+		assert_eq!(sig, kp2.sign(msg));
+	}
+}

--- a/client/network-types/src/kad.rs
+++ b/client/network-types/src/kad.rs
@@ -1,0 +1,185 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{multihash::Multihash, PeerId};
+use bytes::Bytes;
+use libp2p_kad::RecordKey as Libp2pKey;
+use litep2p::protocol::libp2p::kademlia::{Record as Litep2pRecord, RecordKey as Litep2pKey};
+use std::{error::Error, fmt, time::Instant};
+
+/// The (opaque) key of a record.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Key(Bytes);
+
+impl Key {
+	/// Creates a new key from the bytes of the input.
+	pub fn new<K: AsRef<[u8]>>(key: &K) -> Self {
+		Key(Bytes::copy_from_slice(key.as_ref()))
+	}
+
+	/// Copies the bytes of the key into a new vector.
+	pub fn to_vec(&self) -> Vec<u8> {
+		self.0.to_vec()
+	}
+}
+
+impl AsRef<[u8]> for Key {
+	fn as_ref(&self) -> &[u8] {
+		&self.0[..]
+	}
+}
+
+impl From<Vec<u8>> for Key {
+	fn from(v: Vec<u8>) -> Key {
+		Key(Bytes::from(v))
+	}
+}
+
+impl From<Multihash> for Key {
+	fn from(m: Multihash) -> Key {
+		Key::from(m.to_bytes())
+	}
+}
+
+impl From<Litep2pKey> for Key {
+	fn from(key: Litep2pKey) -> Self {
+		Self::from(key.to_vec())
+	}
+}
+
+impl From<Key> for Litep2pKey {
+	fn from(key: Key) -> Self {
+		Self::from(key.to_vec())
+	}
+}
+
+impl From<Libp2pKey> for Key {
+	fn from(key: Libp2pKey) -> Self {
+		Self::from(key.to_vec())
+	}
+}
+
+impl From<Key> for Libp2pKey {
+	fn from(key: Key) -> Self {
+		Self::from(key.to_vec())
+	}
+}
+
+/// A record stored in the DHT.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Record {
+	/// Key of the record.
+	pub key: Key,
+	/// Value of the record.
+	pub value: Vec<u8>,
+	/// The (original) publisher of the record.
+	pub publisher: Option<PeerId>,
+	/// The expiration time as measured by a local, monotonic clock.
+	pub expires: Option<Instant>,
+}
+
+impl Record {
+	/// Creates a new record for insertion into the DHT.
+	pub fn new(key: Key, value: Vec<u8>) -> Self {
+		Record { key, value, publisher: None, expires: None }
+	}
+
+	/// Checks whether the record is expired w.r.t. the given `Instant`.
+	pub fn is_expired(&self, now: Instant) -> bool {
+		self.expires.is_some_and(|t| now >= t)
+	}
+}
+
+impl From<libp2p_kad::Record> for Record {
+	fn from(out: libp2p_kad::Record) -> Self {
+		let vec: Vec<u8> = out.key.to_vec();
+		let key: Key = vec.into();
+		let publisher = out.publisher.map(Into::into);
+		Record { key, value: out.value, publisher, expires: out.expires }
+	}
+}
+
+impl From<Record> for Litep2pRecord {
+	fn from(val: Record) -> Self {
+		let vec: Vec<u8> = val.key.to_vec();
+		let key: Litep2pKey = vec.into();
+		let publisher = val.publisher.map(Into::into);
+		Litep2pRecord { key, value: val.value, publisher, expires: val.expires }
+	}
+}
+
+impl From<Record> for libp2p_kad::Record {
+	fn from(a: Record) -> libp2p_kad::Record {
+		let peer = a.publisher.map(Into::into);
+		libp2p_kad::Record {
+			key: a.key.to_vec().into(),
+			value: a.value,
+			publisher: peer,
+			expires: a.expires,
+		}
+	}
+}
+
+/// A record either received by the given peer or retrieved from the local
+/// record store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerRecord {
+	/// The peer from whom the record was received. `None` if the record was
+	/// retrieved from local storage.
+	pub peer: Option<PeerId>,
+	pub record: Record,
+}
+
+impl From<libp2p_kad::PeerRecord> for PeerRecord {
+	fn from(out: libp2p_kad::PeerRecord) -> Self {
+		let peer = out.peer.map(Into::into);
+		let record = out.record.into();
+		PeerRecord { peer, record }
+	}
+}
+
+/// An error during signing of a message.
+#[derive(Debug)]
+pub struct SigningError {
+	msg: String,
+	source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+/// An error during encoding of key material.
+#[allow(dead_code)]
+impl SigningError {
+	pub(crate) fn new<S: ToString>(msg: S) -> Self {
+		Self { msg: msg.to_string(), source: None }
+	}
+
+	pub(crate) fn source(self, source: impl Error + Send + Sync + 'static) -> Self {
+		Self { source: Some(Box::new(source)), ..self }
+	}
+}
+
+impl fmt::Display for SigningError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "Key signing error: {}", self.msg)
+	}
+}
+
+impl Error for SigningError {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
+		self.source.as_ref().map(|s| &**s as &dyn Error)
+	}
+}

--- a/client/network-types/src/lib.rs
+++ b/client/network-types/src/lib.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub mod ed25519;
+pub mod kad;
+pub mod multiaddr;
+pub mod multihash;
+mod peer_id;
+pub use peer_id::PeerId;

--- a/client/network-types/src/multiaddr.rs
+++ b/client/network-types/src/multiaddr.rs
@@ -1,0 +1,287 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use litep2p::types::multiaddr::{
+	Error as LiteP2pError, Iter as LiteP2pIter, Multiaddr as LiteP2pMultiaddr,
+	Protocol as LiteP2pProtocol,
+};
+use multiaddr::Multiaddr as LibP2pMultiaddr;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::{
+	fmt::{self, Debug, Display},
+	net::{IpAddr, Ipv4Addr, Ipv6Addr},
+	str::FromStr,
+};
+
+mod protocol;
+pub use protocol::Protocol;
+
+// Re-export the macro under shorter name under `multiaddr`.
+pub use crate::build_multiaddr as multiaddr;
+
+/// [`Multiaddr`] type used in Substrate. Converted to libp2p's `Multiaddr`
+/// or litep2p's `Multiaddr` when passed to the corresponding network backend.
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, SerializeDisplay, DeserializeFromStr)]
+pub struct Multiaddr {
+	multiaddr: LiteP2pMultiaddr,
+}
+
+impl Multiaddr {
+	/// Create a new, empty multiaddress.
+	pub fn empty() -> Self {
+		Self { multiaddr: LiteP2pMultiaddr::empty() }
+	}
+
+	/// Adds an address component to the end of this multiaddr.
+	pub fn push(&mut self, p: Protocol<'_>) {
+		self.multiaddr.push(p.into())
+	}
+
+	/// Pops the last `Protocol` of this multiaddr, or `None` if the multiaddr is empty.
+	pub fn pop<'a>(&mut self) -> Option<Protocol<'a>> {
+		self.multiaddr.pop().map(Into::into)
+	}
+
+	/// Like [`Multiaddr::push`] but consumes `self`.
+	pub fn with(self, p: Protocol<'_>) -> Self {
+		self.multiaddr.with(p.into()).into()
+	}
+
+	/// Returns the components of this multiaddress.
+	pub fn iter(&self) -> Iter<'_> {
+		self.multiaddr.iter().into()
+	}
+
+	/// Return a copy of this [`Multiaddr`]'s byte representation.
+	pub fn to_vec(&self) -> Vec<u8> {
+		self.multiaddr.to_vec()
+	}
+}
+
+impl Display for Multiaddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		Display::fmt(&self.multiaddr, f)
+	}
+}
+
+/// Remove an extra layer of nestedness by deferring to the wrapped value's [`Debug`].
+impl Debug for Multiaddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		Debug::fmt(&self.multiaddr, f)
+	}
+}
+
+impl AsRef<[u8]> for Multiaddr {
+	fn as_ref(&self) -> &[u8] {
+		self.multiaddr.as_ref()
+	}
+}
+
+impl From<LiteP2pMultiaddr> for Multiaddr {
+	fn from(multiaddr: LiteP2pMultiaddr) -> Self {
+		Self { multiaddr }
+	}
+}
+
+impl From<Multiaddr> for LiteP2pMultiaddr {
+	fn from(multiaddr: Multiaddr) -> Self {
+		multiaddr.multiaddr
+	}
+}
+
+impl From<LibP2pMultiaddr> for Multiaddr {
+	fn from(multiaddr: LibP2pMultiaddr) -> Self {
+		multiaddr.into_iter().map(Into::into).collect()
+	}
+}
+
+impl From<Multiaddr> for LibP2pMultiaddr {
+	fn from(multiaddr: Multiaddr) -> Self {
+		multiaddr.into_iter().map(Into::into).collect()
+	}
+}
+
+impl From<IpAddr> for Multiaddr {
+	fn from(v: IpAddr) -> Multiaddr {
+		match v {
+			IpAddr::V4(a) => a.into(),
+			IpAddr::V6(a) => a.into(),
+		}
+	}
+}
+
+impl From<Ipv4Addr> for Multiaddr {
+	fn from(v: Ipv4Addr) -> Multiaddr {
+		Protocol::Ip4(v).into()
+	}
+}
+
+impl From<Ipv6Addr> for Multiaddr {
+	fn from(v: Ipv6Addr) -> Multiaddr {
+		Protocol::Ip6(v).into()
+	}
+}
+
+impl TryFrom<Vec<u8>> for Multiaddr {
+	type Error = ParseError;
+
+	fn try_from(v: Vec<u8>) -> Result<Self, ParseError> {
+		let multiaddr = LiteP2pMultiaddr::try_from(v)?;
+		Ok(Self { multiaddr })
+	}
+}
+
+/// Error when parsing a [`Multiaddr`] from string.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+	/// Less data provided than indicated by length.
+	#[error("less data than indicated by length")]
+	DataLessThanLen,
+	/// Invalid multiaddress.
+	#[error("invalid multiaddress")]
+	InvalidMultiaddr,
+	/// Invalid protocol specification.
+	#[error("invalid protocol string")]
+	InvalidProtocolString,
+	/// Unknown protocol string identifier.
+	#[error("unknown protocol '{0}'")]
+	UnknownProtocolString(String),
+	/// Unknown protocol numeric id.
+	#[error("unknown protocol id {0}")]
+	UnknownProtocolId(u32),
+	/// Failed to decode unsigned varint.
+	#[error("failed to decode unsigned varint: {0}")]
+	InvalidUvar(Box<dyn std::error::Error + Send + Sync>),
+	/// Other error emitted when parsing into the wrapped type.
+	#[error("multiaddr parsing error: {0}")]
+	ParsingError(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<LiteP2pError> for ParseError {
+	fn from(error: LiteP2pError) -> Self {
+		match error {
+			LiteP2pError::DataLessThanLen => ParseError::DataLessThanLen,
+			LiteP2pError::InvalidMultiaddr => ParseError::InvalidMultiaddr,
+			LiteP2pError::InvalidProtocolString => ParseError::InvalidProtocolString,
+			LiteP2pError::UnknownProtocolString(s) => ParseError::UnknownProtocolString(s),
+			LiteP2pError::UnknownProtocolId(n) => ParseError::UnknownProtocolId(n),
+			LiteP2pError::InvalidUvar(e) => ParseError::InvalidUvar(Box::new(e)),
+			LiteP2pError::ParsingError(e) => ParseError::ParsingError(e),
+			error => ParseError::ParsingError(Box::new(error)),
+		}
+	}
+}
+
+impl FromStr for Multiaddr {
+	type Err = ParseError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let multiaddr = LiteP2pMultiaddr::from_str(s)?;
+		Ok(Self { multiaddr })
+	}
+}
+
+impl TryFrom<String> for Multiaddr {
+	type Error = ParseError;
+
+	fn try_from(s: String) -> Result<Multiaddr, Self::Error> {
+		Self::from_str(&s)
+	}
+}
+
+impl<'a> TryFrom<&'a str> for Multiaddr {
+	type Error = ParseError;
+
+	fn try_from(s: &'a str) -> Result<Multiaddr, Self::Error> {
+		Self::from_str(s)
+	}
+}
+
+/// Iterator over `Multiaddr` [`Protocol`]s.
+pub struct Iter<'a>(LiteP2pIter<'a>);
+
+impl<'a> Iterator for Iter<'a> {
+	type Item = Protocol<'a>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.0.next().map(Into::into)
+	}
+}
+
+impl<'a> From<LiteP2pIter<'a>> for Iter<'a> {
+	fn from(iter: LiteP2pIter<'a>) -> Self {
+		Self(iter)
+	}
+}
+
+impl<'a> IntoIterator for &'a Multiaddr {
+	type Item = Protocol<'a>;
+	type IntoIter = Iter<'a>;
+
+	fn into_iter(self) -> Iter<'a> {
+		self.multiaddr.into_iter().into()
+	}
+}
+
+impl<'a> FromIterator<Protocol<'a>> for Multiaddr {
+	fn from_iter<T>(iter: T) -> Self
+	where
+		T: IntoIterator<Item = Protocol<'a>>,
+	{
+		LiteP2pMultiaddr::from_iter(iter.into_iter().map(Into::into)).into()
+	}
+}
+
+impl<'a> From<Protocol<'a>> for Multiaddr {
+	fn from(p: Protocol<'a>) -> Multiaddr {
+		let protocol: LiteP2pProtocol = p.into();
+		let multiaddr: LiteP2pMultiaddr = protocol.into();
+		multiaddr.into()
+	}
+}
+
+/// Easy way for a user to create a `Multiaddr`.
+///
+/// Example:
+///
+/// ```rust
+/// use sc_network_types::build_multiaddr;
+/// let addr = build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16));
+/// ```
+///
+/// Each element passed to `multiaddr!` should be a variant of the `Protocol` enum. The
+/// optional parameter is turned into the proper type with the `Into` trait.
+///
+/// For example, `Ip4([127, 0, 0, 1])` works because `Ipv4Addr` implements `From<[u8; 4]>`.
+#[macro_export]
+macro_rules! build_multiaddr {
+    ($($comp:ident $(($param:expr))*),+) => {
+        {
+            use std::iter;
+            let elem = iter::empty::<$crate::multiaddr::Protocol>();
+            $(
+                let elem = {
+                    let cmp = $crate::multiaddr::Protocol::$comp $(( $param.into() ))*;
+                    elem.chain(iter::once(cmp))
+                };
+            )+
+            elem.collect::<$crate::multiaddr::Multiaddr>()
+        }
+    }
+}

--- a/client/network-types/src/multiaddr/protocol.rs
+++ b/client/network-types/src/multiaddr/protocol.rs
@@ -116,9 +116,8 @@ impl<'a> From<LiteP2pProtocol<'a>> for Protocol<'a> {
 			LiteP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
 			LiteP2pProtocol::Memory(port) => Protocol::Memory(port),
 			LiteP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
-			LiteP2pProtocol::Onion3(addr) => {
-				Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port())
-			},
+			LiteP2pProtocol::Onion3(addr) =>
+				Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port()),
 			LiteP2pProtocol::P2p(multihash) => Protocol::P2p(multihash.into()),
 			LiteP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
 			LiteP2pProtocol::Quic => Protocol::Quic,

--- a/client/network-types/src/multiaddr/protocol.rs
+++ b/client/network-types/src/multiaddr/protocol.rs
@@ -1,0 +1,276 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::multihash::Multihash;
+use libp2p_identity::PeerId;
+use litep2p::types::multiaddr::Protocol as LiteP2pProtocol;
+use multiaddr::Protocol as LibP2pProtocol;
+use std::{
+	borrow::Cow,
+	fmt::{self, Debug, Display},
+	net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+// Log target for this file.
+const LOG_TARGET: &str = "sub-libp2p";
+
+/// [`Protocol`] describes all possible multiaddress protocols.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum Protocol<'a> {
+	Dccp(u16),
+	Dns(Cow<'a, str>),
+	Dns4(Cow<'a, str>),
+	Dns6(Cow<'a, str>),
+	Dnsaddr(Cow<'a, str>),
+	Http,
+	Https,
+	Ip4(Ipv4Addr),
+	Ip6(Ipv6Addr),
+	P2pWebRtcDirect,
+	P2pWebRtcStar,
+	WebRTC,
+	Certhash(Multihash),
+	P2pWebSocketStar,
+	/// Contains the "port" to contact. Similar to TCP or UDP, 0 means "assign me a port".
+	Memory(u64),
+	Onion(Cow<'a, [u8; 10]>, u16),
+	Onion3(Cow<'a, [u8; 35]>, u16),
+	P2p(Multihash),
+	P2pCircuit,
+	Quic,
+	QuicV1,
+	Sctp(u16),
+	Tcp(u16),
+	Tls,
+	Noise,
+	Udp(u16),
+	Udt,
+	Unix(Cow<'a, str>),
+	Utp,
+	Ws(Cow<'a, str>),
+	Wss(Cow<'a, str>),
+}
+
+impl Display for Protocol<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let protocol = LiteP2pProtocol::from(self.clone());
+		Display::fmt(&protocol, f)
+	}
+}
+
+impl From<IpAddr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: IpAddr) -> Self {
+		match addr {
+			IpAddr::V4(addr) => Protocol::Ip4(addr),
+			IpAddr::V6(addr) => Protocol::Ip6(addr),
+		}
+	}
+}
+
+impl From<Ipv4Addr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: Ipv4Addr) -> Self {
+		Protocol::Ip4(addr)
+	}
+}
+
+impl From<Ipv6Addr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: Ipv6Addr) -> Self {
+		Protocol::Ip6(addr)
+	}
+}
+
+impl<'a> From<LiteP2pProtocol<'a>> for Protocol<'a> {
+	fn from(protocol: LiteP2pProtocol<'a>) -> Self {
+		match protocol {
+			LiteP2pProtocol::Dccp(port) => Protocol::Dccp(port),
+			LiteP2pProtocol::Dns(str) => Protocol::Dns(str),
+			LiteP2pProtocol::Dns4(str) => Protocol::Dns4(str),
+			LiteP2pProtocol::Dns6(str) => Protocol::Dns6(str),
+			LiteP2pProtocol::Dnsaddr(str) => Protocol::Dnsaddr(str),
+			LiteP2pProtocol::Http => Protocol::Http,
+			LiteP2pProtocol::Https => Protocol::Https,
+			LiteP2pProtocol::Ip4(ipv4_addr) => Protocol::Ip4(ipv4_addr),
+			LiteP2pProtocol::Ip6(ipv6_addr) => Protocol::Ip6(ipv6_addr),
+			LiteP2pProtocol::P2pWebRtcDirect => Protocol::P2pWebRtcDirect,
+			LiteP2pProtocol::P2pWebRtcStar => Protocol::P2pWebRtcStar,
+			LiteP2pProtocol::WebRTC => Protocol::WebRTC,
+			LiteP2pProtocol::Certhash(multihash) => Protocol::Certhash(multihash.into()),
+			LiteP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
+			LiteP2pProtocol::Memory(port) => Protocol::Memory(port),
+			LiteP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
+			LiteP2pProtocol::Onion3(addr) => {
+				Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port())
+			},
+			LiteP2pProtocol::P2p(multihash) => Protocol::P2p(multihash.into()),
+			LiteP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
+			LiteP2pProtocol::Quic => Protocol::Quic,
+			LiteP2pProtocol::QuicV1 => Protocol::QuicV1,
+			LiteP2pProtocol::Sctp(port) => Protocol::Sctp(port),
+			LiteP2pProtocol::Tcp(port) => Protocol::Tcp(port),
+			LiteP2pProtocol::Tls => Protocol::Tls,
+			LiteP2pProtocol::Noise => Protocol::Noise,
+			LiteP2pProtocol::Udp(port) => Protocol::Udp(port),
+			LiteP2pProtocol::Udt => Protocol::Udt,
+			LiteP2pProtocol::Unix(str) => Protocol::Unix(str),
+			LiteP2pProtocol::Utp => Protocol::Utp,
+			LiteP2pProtocol::Ws(str) => Protocol::Ws(str),
+			LiteP2pProtocol::Wss(str) => Protocol::Wss(str),
+		}
+	}
+}
+
+impl<'a> From<Protocol<'a>> for LiteP2pProtocol<'a> {
+	fn from(protocol: Protocol<'a>) -> Self {
+		match protocol {
+			Protocol::Dccp(port) => LiteP2pProtocol::Dccp(port),
+			Protocol::Dns(str) => LiteP2pProtocol::Dns(str),
+			Protocol::Dns4(str) => LiteP2pProtocol::Dns4(str),
+			Protocol::Dns6(str) => LiteP2pProtocol::Dns6(str),
+			Protocol::Dnsaddr(str) => LiteP2pProtocol::Dnsaddr(str),
+			Protocol::Http => LiteP2pProtocol::Http,
+			Protocol::Https => LiteP2pProtocol::Https,
+			Protocol::Ip4(ipv4_addr) => LiteP2pProtocol::Ip4(ipv4_addr),
+			Protocol::Ip6(ipv6_addr) => LiteP2pProtocol::Ip6(ipv6_addr),
+			Protocol::P2pWebRtcDirect => LiteP2pProtocol::P2pWebRtcDirect,
+			Protocol::P2pWebRtcStar => LiteP2pProtocol::P2pWebRtcStar,
+			Protocol::WebRTC => LiteP2pProtocol::WebRTC,
+			Protocol::Certhash(multihash) => LiteP2pProtocol::Certhash(multihash.into()),
+			Protocol::P2pWebSocketStar => LiteP2pProtocol::P2pWebSocketStar,
+			Protocol::Memory(port) => LiteP2pProtocol::Memory(port),
+			Protocol::Onion(str, port) => LiteP2pProtocol::Onion(str, port),
+			Protocol::Onion3(str, port) => LiteP2pProtocol::Onion3((str.into_owned(), port).into()),
+			Protocol::P2p(multihash) => LiteP2pProtocol::P2p(multihash.into()),
+			Protocol::P2pCircuit => LiteP2pProtocol::P2pCircuit,
+			Protocol::Quic => LiteP2pProtocol::Quic,
+			Protocol::QuicV1 => LiteP2pProtocol::QuicV1,
+			Protocol::Sctp(port) => LiteP2pProtocol::Sctp(port),
+			Protocol::Tcp(port) => LiteP2pProtocol::Tcp(port),
+			Protocol::Tls => LiteP2pProtocol::Tls,
+			Protocol::Noise => LiteP2pProtocol::Noise,
+			Protocol::Udp(port) => LiteP2pProtocol::Udp(port),
+			Protocol::Udt => LiteP2pProtocol::Udt,
+			Protocol::Unix(str) => LiteP2pProtocol::Unix(str),
+			Protocol::Utp => LiteP2pProtocol::Utp,
+			Protocol::Ws(str) => LiteP2pProtocol::Ws(str),
+			Protocol::Wss(str) => LiteP2pProtocol::Wss(str),
+		}
+	}
+}
+
+impl<'a> From<LibP2pProtocol<'a>> for Protocol<'a> {
+	fn from(protocol: LibP2pProtocol<'a>) -> Self {
+		match protocol {
+			LibP2pProtocol::Dccp(port) => Protocol::Dccp(port),
+			LibP2pProtocol::Dns(str) => Protocol::Dns(str),
+			LibP2pProtocol::Dns4(str) => Protocol::Dns4(str),
+			LibP2pProtocol::Dns6(str) => Protocol::Dns6(str),
+			LibP2pProtocol::Dnsaddr(str) => Protocol::Dnsaddr(str),
+			LibP2pProtocol::Http => Protocol::Http,
+			LibP2pProtocol::Https => Protocol::Https,
+			LibP2pProtocol::Ip4(ipv4_addr) => Protocol::Ip4(ipv4_addr),
+			LibP2pProtocol::Ip6(ipv6_addr) => Protocol::Ip6(ipv6_addr),
+			LibP2pProtocol::P2pWebRtcDirect => Protocol::P2pWebRtcDirect,
+			LibP2pProtocol::P2pWebRtcStar => Protocol::P2pWebRtcStar,
+			LibP2pProtocol::Certhash(multihash) => Protocol::Certhash(multihash.into()),
+			LibP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
+			LibP2pProtocol::Memory(port) => Protocol::Memory(port),
+			LibP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
+			LibP2pProtocol::Onion3(addr) => Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port()),
+			LibP2pProtocol::P2p(peer_id) => Protocol::P2p((*peer_id.as_ref()).into()),
+			LibP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
+			LibP2pProtocol::Quic => Protocol::Quic,
+			LibP2pProtocol::QuicV1 => Protocol::QuicV1,
+			LibP2pProtocol::Sctp(port) => Protocol::Sctp(port),
+			LibP2pProtocol::Tcp(port) => Protocol::Tcp(port),
+			LibP2pProtocol::Tls => Protocol::Tls,
+			LibP2pProtocol::Noise => Protocol::Noise,
+			LibP2pProtocol::Udp(port) => Protocol::Udp(port),
+			LibP2pProtocol::Udt => Protocol::Udt,
+			LibP2pProtocol::Unix(str) => Protocol::Unix(str),
+			LibP2pProtocol::Utp => Protocol::Utp,
+			LibP2pProtocol::Ws(str) => Protocol::Ws(str),
+			LibP2pProtocol::Wss(str) => Protocol::Wss(str),
+			protocol => {
+				log::error!(
+					target: LOG_TARGET,
+					"Got unsupported multiaddr protocol '{}'",
+					protocol.tag(),
+				);
+				// Strictly speaking, this conversion is incorrect. But making protocol conversion
+				// fallible would significantly complicate the client code. As DCCP transport is not
+				// used by substrate, this conversion should be safe.
+				// Also, as of `multiaddr-18.1`, all enum variants are actually covered.
+				Protocol::Dccp(0)
+			},
+		}
+	}
+}
+
+impl<'a> From<Protocol<'a>> for LibP2pProtocol<'a> {
+	fn from(protocol: Protocol<'a>) -> Self {
+		match protocol {
+			Protocol::Dccp(port) => LibP2pProtocol::Dccp(port),
+			Protocol::Dns(str) => LibP2pProtocol::Dns(str),
+			Protocol::Dns4(str) => LibP2pProtocol::Dns4(str),
+			Protocol::Dns6(str) => LibP2pProtocol::Dns6(str),
+			Protocol::Dnsaddr(str) => LibP2pProtocol::Dnsaddr(str),
+			Protocol::Http => LibP2pProtocol::Http,
+			Protocol::Https => LibP2pProtocol::Https,
+			Protocol::Ip4(ipv4_addr) => LibP2pProtocol::Ip4(ipv4_addr),
+			Protocol::Ip6(ipv6_addr) => LibP2pProtocol::Ip6(ipv6_addr),
+			Protocol::P2pWebRtcDirect => LibP2pProtocol::P2pWebRtcDirect,
+			Protocol::P2pWebRtcStar => LibP2pProtocol::P2pWebRtcStar,
+			// Protocol #280 is called `WebRTC` in multiaddr-17.0 and `WebRTCDirect` in
+			// multiaddr-18.1.
+			Protocol::WebRTC => LibP2pProtocol::WebRTCDirect,
+			Protocol::Certhash(multihash) => LibP2pProtocol::Certhash(multihash.into()),
+			Protocol::P2pWebSocketStar => LibP2pProtocol::P2pWebSocketStar,
+			Protocol::Memory(port) => LibP2pProtocol::Memory(port),
+			Protocol::Onion(str, port) => LibP2pProtocol::Onion(str, port),
+			Protocol::Onion3(str, port) => LibP2pProtocol::Onion3((str.into_owned(), port).into()),
+			Protocol::P2p(multihash) => {
+				LibP2pProtocol::P2p(PeerId::from_multihash(multihash.into()).unwrap_or_else(|_| {
+					// This is better than making conversion fallible and complicating the
+					// client code.
+					log::error!(
+						target: LOG_TARGET,
+						"Received multiaddr with p2p multihash which is not a valid \
+						 peer_id. Replacing with random peer_id."
+					);
+					PeerId::random()
+				}))
+			},
+			Protocol::P2pCircuit => LibP2pProtocol::P2pCircuit,
+			Protocol::Quic => LibP2pProtocol::Quic,
+			Protocol::QuicV1 => LibP2pProtocol::QuicV1,
+			Protocol::Sctp(port) => LibP2pProtocol::Sctp(port),
+			Protocol::Tcp(port) => LibP2pProtocol::Tcp(port),
+			Protocol::Tls => LibP2pProtocol::Tls,
+			Protocol::Noise => LibP2pProtocol::Noise,
+			Protocol::Udp(port) => LibP2pProtocol::Udp(port),
+			Protocol::Udt => LibP2pProtocol::Udt,
+			Protocol::Unix(str) => LibP2pProtocol::Unix(str),
+			Protocol::Utp => LibP2pProtocol::Utp,
+			Protocol::Ws(str) => LibP2pProtocol::Ws(str),
+			Protocol::Wss(str) => LibP2pProtocol::Wss(str),
+		}
+	}
+}

--- a/client/network-types/src/multiaddr/protocol.rs
+++ b/client/network-types/src/multiaddr/protocol.rs
@@ -1,0 +1,275 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::multihash::Multihash;
+use libp2p_identity::PeerId;
+use litep2p::types::multiaddr::Protocol as LiteP2pProtocol;
+use multiaddr::Protocol as LibP2pProtocol;
+use std::{
+	borrow::Cow,
+	fmt::{self, Debug, Display},
+	net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+// Log target for this file.
+const LOG_TARGET: &str = "sub-libp2p";
+
+/// [`Protocol`] describes all possible multiaddress protocols.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum Protocol<'a> {
+	Dccp(u16),
+	Dns(Cow<'a, str>),
+	Dns4(Cow<'a, str>),
+	Dns6(Cow<'a, str>),
+	Dnsaddr(Cow<'a, str>),
+	Http,
+	Https,
+	Ip4(Ipv4Addr),
+	Ip6(Ipv6Addr),
+	P2pWebRtcDirect,
+	P2pWebRtcStar,
+	WebRTC,
+	Certhash(Multihash),
+	P2pWebSocketStar,
+	/// Contains the "port" to contact. Similar to TCP or UDP, 0 means "assign me a port".
+	Memory(u64),
+	Onion(Cow<'a, [u8; 10]>, u16),
+	Onion3(Cow<'a, [u8; 35]>, u16),
+	P2p(Multihash),
+	P2pCircuit,
+	Quic,
+	QuicV1,
+	Sctp(u16),
+	Tcp(u16),
+	Tls,
+	Noise,
+	Udp(u16),
+	Udt,
+	Unix(Cow<'a, str>),
+	Utp,
+	Ws(Cow<'a, str>),
+	Wss(Cow<'a, str>),
+}
+
+impl Display for Protocol<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let protocol = LiteP2pProtocol::from(self.clone());
+		Display::fmt(&protocol, f)
+	}
+}
+
+impl From<IpAddr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: IpAddr) -> Self {
+		match addr {
+			IpAddr::V4(addr) => Protocol::Ip4(addr),
+			IpAddr::V6(addr) => Protocol::Ip6(addr),
+		}
+	}
+}
+
+impl From<Ipv4Addr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: Ipv4Addr) -> Self {
+		Protocol::Ip4(addr)
+	}
+}
+
+impl From<Ipv6Addr> for Protocol<'_> {
+	#[inline]
+	fn from(addr: Ipv6Addr) -> Self {
+		Protocol::Ip6(addr)
+	}
+}
+
+impl<'a> From<LiteP2pProtocol<'a>> for Protocol<'a> {
+	fn from(protocol: LiteP2pProtocol<'a>) -> Self {
+		match protocol {
+			LiteP2pProtocol::Dccp(port) => Protocol::Dccp(port),
+			LiteP2pProtocol::Dns(str) => Protocol::Dns(str),
+			LiteP2pProtocol::Dns4(str) => Protocol::Dns4(str),
+			LiteP2pProtocol::Dns6(str) => Protocol::Dns6(str),
+			LiteP2pProtocol::Dnsaddr(str) => Protocol::Dnsaddr(str),
+			LiteP2pProtocol::Http => Protocol::Http,
+			LiteP2pProtocol::Https => Protocol::Https,
+			LiteP2pProtocol::Ip4(ipv4_addr) => Protocol::Ip4(ipv4_addr),
+			LiteP2pProtocol::Ip6(ipv6_addr) => Protocol::Ip6(ipv6_addr),
+			LiteP2pProtocol::P2pWebRtcDirect => Protocol::P2pWebRtcDirect,
+			LiteP2pProtocol::P2pWebRtcStar => Protocol::P2pWebRtcStar,
+			LiteP2pProtocol::WebRTC => Protocol::WebRTC,
+			LiteP2pProtocol::Certhash(multihash) => Protocol::Certhash(multihash.into()),
+			LiteP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
+			LiteP2pProtocol::Memory(port) => Protocol::Memory(port),
+			LiteP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
+			LiteP2pProtocol::Onion3(addr) =>
+				Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port()),
+			LiteP2pProtocol::P2p(multihash) => Protocol::P2p(multihash.into()),
+			LiteP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
+			LiteP2pProtocol::Quic => Protocol::Quic,
+			LiteP2pProtocol::QuicV1 => Protocol::QuicV1,
+			LiteP2pProtocol::Sctp(port) => Protocol::Sctp(port),
+			LiteP2pProtocol::Tcp(port) => Protocol::Tcp(port),
+			LiteP2pProtocol::Tls => Protocol::Tls,
+			LiteP2pProtocol::Noise => Protocol::Noise,
+			LiteP2pProtocol::Udp(port) => Protocol::Udp(port),
+			LiteP2pProtocol::Udt => Protocol::Udt,
+			LiteP2pProtocol::Unix(str) => Protocol::Unix(str),
+			LiteP2pProtocol::Utp => Protocol::Utp,
+			LiteP2pProtocol::Ws(str) => Protocol::Ws(str),
+			LiteP2pProtocol::Wss(str) => Protocol::Wss(str),
+		}
+	}
+}
+
+impl<'a> From<Protocol<'a>> for LiteP2pProtocol<'a> {
+	fn from(protocol: Protocol<'a>) -> Self {
+		match protocol {
+			Protocol::Dccp(port) => LiteP2pProtocol::Dccp(port),
+			Protocol::Dns(str) => LiteP2pProtocol::Dns(str),
+			Protocol::Dns4(str) => LiteP2pProtocol::Dns4(str),
+			Protocol::Dns6(str) => LiteP2pProtocol::Dns6(str),
+			Protocol::Dnsaddr(str) => LiteP2pProtocol::Dnsaddr(str),
+			Protocol::Http => LiteP2pProtocol::Http,
+			Protocol::Https => LiteP2pProtocol::Https,
+			Protocol::Ip4(ipv4_addr) => LiteP2pProtocol::Ip4(ipv4_addr),
+			Protocol::Ip6(ipv6_addr) => LiteP2pProtocol::Ip6(ipv6_addr),
+			Protocol::P2pWebRtcDirect => LiteP2pProtocol::P2pWebRtcDirect,
+			Protocol::P2pWebRtcStar => LiteP2pProtocol::P2pWebRtcStar,
+			Protocol::WebRTC => LiteP2pProtocol::WebRTC,
+			Protocol::Certhash(multihash) => LiteP2pProtocol::Certhash(multihash.into()),
+			Protocol::P2pWebSocketStar => LiteP2pProtocol::P2pWebSocketStar,
+			Protocol::Memory(port) => LiteP2pProtocol::Memory(port),
+			Protocol::Onion(str, port) => LiteP2pProtocol::Onion(str, port),
+			Protocol::Onion3(str, port) => LiteP2pProtocol::Onion3((str.into_owned(), port).into()),
+			Protocol::P2p(multihash) => LiteP2pProtocol::P2p(multihash.into()),
+			Protocol::P2pCircuit => LiteP2pProtocol::P2pCircuit,
+			Protocol::Quic => LiteP2pProtocol::Quic,
+			Protocol::QuicV1 => LiteP2pProtocol::QuicV1,
+			Protocol::Sctp(port) => LiteP2pProtocol::Sctp(port),
+			Protocol::Tcp(port) => LiteP2pProtocol::Tcp(port),
+			Protocol::Tls => LiteP2pProtocol::Tls,
+			Protocol::Noise => LiteP2pProtocol::Noise,
+			Protocol::Udp(port) => LiteP2pProtocol::Udp(port),
+			Protocol::Udt => LiteP2pProtocol::Udt,
+			Protocol::Unix(str) => LiteP2pProtocol::Unix(str),
+			Protocol::Utp => LiteP2pProtocol::Utp,
+			Protocol::Ws(str) => LiteP2pProtocol::Ws(str),
+			Protocol::Wss(str) => LiteP2pProtocol::Wss(str),
+		}
+	}
+}
+
+impl<'a> From<LibP2pProtocol<'a>> for Protocol<'a> {
+	fn from(protocol: LibP2pProtocol<'a>) -> Self {
+		match protocol {
+			LibP2pProtocol::Dccp(port) => Protocol::Dccp(port),
+			LibP2pProtocol::Dns(str) => Protocol::Dns(str),
+			LibP2pProtocol::Dns4(str) => Protocol::Dns4(str),
+			LibP2pProtocol::Dns6(str) => Protocol::Dns6(str),
+			LibP2pProtocol::Dnsaddr(str) => Protocol::Dnsaddr(str),
+			LibP2pProtocol::Http => Protocol::Http,
+			LibP2pProtocol::Https => Protocol::Https,
+			LibP2pProtocol::Ip4(ipv4_addr) => Protocol::Ip4(ipv4_addr),
+			LibP2pProtocol::Ip6(ipv6_addr) => Protocol::Ip6(ipv6_addr),
+			LibP2pProtocol::P2pWebRtcDirect => Protocol::P2pWebRtcDirect,
+			LibP2pProtocol::P2pWebRtcStar => Protocol::P2pWebRtcStar,
+			LibP2pProtocol::Certhash(multihash) => Protocol::Certhash(multihash.into()),
+			LibP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
+			LibP2pProtocol::Memory(port) => Protocol::Memory(port),
+			LibP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
+			LibP2pProtocol::Onion3(addr) => Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port()),
+			LibP2pProtocol::P2p(peer_id) => Protocol::P2p((*peer_id.as_ref()).into()),
+			LibP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
+			LibP2pProtocol::Quic => Protocol::Quic,
+			LibP2pProtocol::QuicV1 => Protocol::QuicV1,
+			LibP2pProtocol::Sctp(port) => Protocol::Sctp(port),
+			LibP2pProtocol::Tcp(port) => Protocol::Tcp(port),
+			LibP2pProtocol::Tls => Protocol::Tls,
+			LibP2pProtocol::Noise => Protocol::Noise,
+			LibP2pProtocol::Udp(port) => Protocol::Udp(port),
+			LibP2pProtocol::Udt => Protocol::Udt,
+			LibP2pProtocol::Unix(str) => Protocol::Unix(str),
+			LibP2pProtocol::Utp => Protocol::Utp,
+			LibP2pProtocol::Ws(str) => Protocol::Ws(str),
+			LibP2pProtocol::Wss(str) => Protocol::Wss(str),
+			protocol => {
+				log::error!(
+					target: LOG_TARGET,
+					"Got unsupported multiaddr protocol '{}'",
+					protocol.tag(),
+				);
+				// Strictly speaking, this conversion is incorrect. But making protocol conversion
+				// fallible would significantly complicate the client code. As DCCP transport is not
+				// used by substrate, this conversion should be safe.
+				// Also, as of `multiaddr-18.1`, all enum variants are actually covered.
+				Protocol::Dccp(0)
+			},
+		}
+	}
+}
+
+impl<'a> From<Protocol<'a>> for LibP2pProtocol<'a> {
+	fn from(protocol: Protocol<'a>) -> Self {
+		match protocol {
+			Protocol::Dccp(port) => LibP2pProtocol::Dccp(port),
+			Protocol::Dns(str) => LibP2pProtocol::Dns(str),
+			Protocol::Dns4(str) => LibP2pProtocol::Dns4(str),
+			Protocol::Dns6(str) => LibP2pProtocol::Dns6(str),
+			Protocol::Dnsaddr(str) => LibP2pProtocol::Dnsaddr(str),
+			Protocol::Http => LibP2pProtocol::Http,
+			Protocol::Https => LibP2pProtocol::Https,
+			Protocol::Ip4(ipv4_addr) => LibP2pProtocol::Ip4(ipv4_addr),
+			Protocol::Ip6(ipv6_addr) => LibP2pProtocol::Ip6(ipv6_addr),
+			Protocol::P2pWebRtcDirect => LibP2pProtocol::P2pWebRtcDirect,
+			Protocol::P2pWebRtcStar => LibP2pProtocol::P2pWebRtcStar,
+			// Protocol #280 is called `WebRTC` in multiaddr-17.0 and `WebRTCDirect` in
+			// multiaddr-18.1.
+			Protocol::WebRTC => LibP2pProtocol::WebRTCDirect,
+			Protocol::Certhash(multihash) => LibP2pProtocol::Certhash(multihash.into()),
+			Protocol::P2pWebSocketStar => LibP2pProtocol::P2pWebSocketStar,
+			Protocol::Memory(port) => LibP2pProtocol::Memory(port),
+			Protocol::Onion(str, port) => LibP2pProtocol::Onion(str, port),
+			Protocol::Onion3(str, port) => LibP2pProtocol::Onion3((str.into_owned(), port).into()),
+			Protocol::P2p(multihash) => {
+				LibP2pProtocol::P2p(PeerId::from_multihash(multihash.into()).unwrap_or_else(|_| {
+					// This is better than making conversion fallible and complicating the
+					// client code.
+					log::error!(
+						target: LOG_TARGET,
+						"Received multiaddr with p2p multihash which is not a valid \
+						 peer_id. Replacing with random peer_id."
+					);
+					PeerId::random()
+				}))
+			},
+			Protocol::P2pCircuit => LibP2pProtocol::P2pCircuit,
+			Protocol::Quic => LibP2pProtocol::Quic,
+			Protocol::QuicV1 => LibP2pProtocol::QuicV1,
+			Protocol::Sctp(port) => LibP2pProtocol::Sctp(port),
+			Protocol::Tcp(port) => LibP2pProtocol::Tcp(port),
+			Protocol::Tls => LibP2pProtocol::Tls,
+			Protocol::Noise => LibP2pProtocol::Noise,
+			Protocol::Udp(port) => LibP2pProtocol::Udp(port),
+			Protocol::Udt => LibP2pProtocol::Udt,
+			Protocol::Unix(str) => LibP2pProtocol::Unix(str),
+			Protocol::Utp => LibP2pProtocol::Utp,
+			Protocol::Ws(str) => LibP2pProtocol::Ws(str),
+			Protocol::Wss(str) => LibP2pProtocol::Wss(str),
+		}
+	}
+}

--- a/client/network-types/src/multihash.rs
+++ b/client/network-types/src/multihash.rs
@@ -1,0 +1,190 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! [`Multihash`] implemenattion used by substrate. Currently it's a wrapper over
+//! multihash used by litep2p, but it can be switched to other implementation if needed.
+
+use litep2p::types::multihash::{
+	Code as LiteP2pCode, Error as LiteP2pError, Multihash as LiteP2pMultihash, MultihashDigest as _,
+};
+use std::fmt::{self, Debug};
+
+/// Default [`Multihash`] implementations. Only hashes used by substrate are defined.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Code {
+	/// Identity hasher.
+	Identity,
+	/// SHA-256 (32-byte hash size).
+	Sha2_256,
+}
+
+impl Code {
+	/// Calculate digest using this [`Code`]'s hashing algorithm.
+	pub fn digest(&self, input: &[u8]) -> Multihash {
+		LiteP2pCode::from(*self).digest(input).into()
+	}
+}
+
+/// Error generated when converting to [`Code`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// Invalid multihash size.
+	#[error("invalid multihash size '{0}'")]
+	InvalidSize(u64),
+	/// The multihash code is not supported.
+	#[error("unsupported multihash code '{0:x}'")]
+	UnsupportedCode(u64),
+	/// Catch-all for other errors emitted when converting `u64` code to enum or parsing multihash
+	/// from bytes. Never generated as of multihash-0.17.0.
+	#[error("other error: {0}")]
+	Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<LiteP2pError> for Error {
+	fn from(error: LiteP2pError) -> Self {
+		match error {
+			LiteP2pError::InvalidSize(s) => Self::InvalidSize(s),
+			LiteP2pError::UnsupportedCode(c) => Self::UnsupportedCode(c),
+			e => Self::Other(Box::new(e)),
+		}
+	}
+}
+
+impl From<Code> for LiteP2pCode {
+	fn from(code: Code) -> Self {
+		match code {
+			Code::Identity => LiteP2pCode::Identity,
+			Code::Sha2_256 => LiteP2pCode::Sha2_256,
+		}
+	}
+}
+
+impl TryFrom<LiteP2pCode> for Code {
+	type Error = Error;
+
+	fn try_from(code: LiteP2pCode) -> Result<Self, Self::Error> {
+		match code {
+			LiteP2pCode::Identity => Ok(Code::Identity),
+			LiteP2pCode::Sha2_256 => Ok(Code::Sha2_256),
+			_ => Err(Error::UnsupportedCode(code.into())),
+		}
+	}
+}
+
+impl TryFrom<u64> for Code {
+	type Error = Error;
+
+	fn try_from(code: u64) -> Result<Self, Self::Error> {
+		match LiteP2pCode::try_from(code) {
+			Ok(code) => code.try_into(),
+			Err(e) => Err(e.into()),
+		}
+	}
+}
+
+impl From<Code> for u64 {
+	fn from(code: Code) -> Self {
+		LiteP2pCode::from(code).into()
+	}
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
+pub struct Multihash {
+	multihash: LiteP2pMultihash,
+}
+
+impl Multihash {
+	/// Multihash code.
+	pub fn code(&self) -> u64 {
+		self.multihash.code()
+	}
+
+	/// Multihash digest.
+	pub fn digest(&self) -> &[u8] {
+		self.multihash.digest()
+	}
+
+	/// Wraps the digest in a multihash.
+	pub fn wrap(code: u64, input_digest: &[u8]) -> Result<Self, Error> {
+		LiteP2pMultihash::wrap(code, input_digest).map(Into::into).map_err(Into::into)
+	}
+
+	/// Parses a multihash from bytes.
+	///
+	/// You need to make sure the passed in bytes have the length of 64.
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+		LiteP2pMultihash::from_bytes(bytes).map(Into::into).map_err(Into::into)
+	}
+
+	/// Returns the bytes of a multihash.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.multihash.to_bytes()
+	}
+}
+
+/// Remove extra layer of nestedness by deferring to the wrapped value's [`Debug`].
+impl Debug for Multihash {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		Debug::fmt(&self.multihash, f)
+	}
+}
+
+impl From<LiteP2pMultihash> for Multihash {
+	fn from(multihash: LiteP2pMultihash) -> Self {
+		Multihash { multihash }
+	}
+}
+
+impl From<Multihash> for LiteP2pMultihash {
+	fn from(multihash: Multihash) -> Self {
+		multihash.multihash
+	}
+}
+
+impl From<multihash::Multihash<64>> for Multihash {
+	fn from(generic: multihash::Multihash<64>) -> Self {
+		LiteP2pMultihash::wrap(generic.code(), generic.digest())
+			.expect("both have size 64; qed")
+			.into()
+	}
+}
+
+impl From<Multihash> for multihash::Multihash<64> {
+	fn from(multihash: Multihash) -> Self {
+		multihash::Multihash::<64>::wrap(multihash.code(), multihash.digest())
+			.expect("both have size 64; qed")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn code_from_u64() {
+		assert_eq!(Code::try_from(0x00).unwrap(), Code::Identity);
+		assert_eq!(Code::try_from(0x12).unwrap(), Code::Sha2_256);
+		assert!(matches!(Code::try_from(0x01).unwrap_err(), Error::UnsupportedCode(0x01)));
+	}
+
+	#[test]
+	fn code_into_u64() {
+		assert_eq!(u64::from(Code::Identity), 0x00);
+		assert_eq!(u64::from(Code::Sha2_256), 0x12);
+	}
+}

--- a/client/network-types/src/peer_id.rs
+++ b/client/network-types/src/peer_id.rs
@@ -1,0 +1,254 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+	multiaddr::{Multiaddr, Protocol},
+	multihash::{Code, Error, Multihash},
+};
+use rand::Rng;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use std::{fmt, hash::Hash, str::FromStr};
+
+/// Public keys with byte-lengths smaller than `MAX_INLINE_KEY_LENGTH` will be
+/// automatically used as the peer id using an identity multihash.
+const MAX_INLINE_KEY_LENGTH: usize = 42;
+
+/// Identifier of a peer of the network.
+///
+/// The data is a CIDv0 compatible multihash of the protobuf encoded public key of the peer
+/// as specified in [specs/peer-ids](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md).
+#[derive(
+	Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, SerializeDisplay, DeserializeFromStr,
+)]
+pub struct PeerId {
+	multihash: Multihash,
+}
+
+impl fmt::Debug for PeerId {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_tuple("PeerId").field(&self.to_base58()).finish()
+	}
+}
+
+impl fmt::Display for PeerId {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.to_base58().fmt(f)
+	}
+}
+
+impl PeerId {
+	/// Generate random peer ID.
+	pub fn random() -> PeerId {
+		let peer = rand::thread_rng().gen::<[u8; 32]>();
+		PeerId {
+			multihash: Multihash::wrap(0x0, &peer).expect("The digest size is never too large"),
+		}
+	}
+
+	/// Try to extract `PeerId` from `Multiaddr`.
+	pub fn try_from_multiaddr(address: &Multiaddr) -> Option<PeerId> {
+		match address.iter().find(|protocol| std::matches!(protocol, Protocol::P2p(_))) {
+			Some(Protocol::P2p(multihash)) => Some(Self { multihash }),
+			_ => None,
+		}
+	}
+
+	/// Tries to turn a `Multihash` into a `PeerId`.
+	///
+	/// If the multihash does not use a valid hashing algorithm for peer IDs,
+	/// or the hash value does not satisfy the constraints for a hashed
+	/// peer ID, it is returned as an `Err`.
+	pub fn from_multihash(multihash: Multihash) -> Result<PeerId, Multihash> {
+		match Code::try_from(multihash.code()) {
+			Ok(Code::Sha2_256) => Ok(PeerId { multihash }),
+			Ok(Code::Identity) if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH => {
+				Ok(PeerId { multihash })
+			},
+			_ => Err(multihash),
+		}
+	}
+
+	/// Parses a `PeerId` from bytes.
+	pub fn from_bytes(data: &[u8]) -> Result<PeerId, Error> {
+		PeerId::from_multihash(Multihash::from_bytes(data)?)
+			.map_err(|mh| Error::UnsupportedCode(mh.code()))
+	}
+
+	/// Returns a raw bytes representation of this `PeerId`.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.multihash.to_bytes()
+	}
+
+	/// Returns a base-58 encoded string of this `PeerId`.
+	pub fn to_base58(&self) -> String {
+		bs58::encode(self.to_bytes()).into_string()
+	}
+
+	/// Convert `PeerId` into ed25519 public key bytes.
+	pub fn into_ed25519(&self) -> Option<[u8; 32]> {
+		let hash = &self.multihash;
+		// https://www.ietf.org/archive/id/draft-multiformats-multihash-07.html#name-the-multihash-identifier-re
+		if hash.code() != 0 {
+			// Hash is not identity
+			return None;
+		}
+
+		let public = libp2p_identity::PublicKey::try_decode_protobuf(hash.digest()).ok()?;
+		public.try_into_ed25519().ok().map(|public| public.to_bytes())
+	}
+
+	/// Get `PeerId` from ed25519 public key bytes.
+	pub fn from_ed25519(bytes: &[u8; 32]) -> Option<PeerId> {
+		let public = libp2p_identity::ed25519::PublicKey::try_from_bytes(bytes).ok()?;
+		let public: libp2p_identity::PublicKey = public.into();
+		let peer_id: libp2p_identity::PeerId = public.into();
+
+		Some(peer_id.into())
+	}
+}
+
+impl AsRef<Multihash> for PeerId {
+	fn as_ref(&self) -> &Multihash {
+		&self.multihash
+	}
+}
+
+impl From<PeerId> for Multihash {
+	fn from(peer_id: PeerId) -> Self {
+		peer_id.multihash
+	}
+}
+
+impl From<libp2p_identity::PeerId> for PeerId {
+	fn from(peer_id: libp2p_identity::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<PeerId> for libp2p_identity::PeerId {
+	fn from(peer_id: PeerId) -> Self {
+		libp2p_identity::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<&libp2p_identity::PeerId> for PeerId {
+	fn from(peer_id: &libp2p_identity::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<&PeerId> for libp2p_identity::PeerId {
+	fn from(peer_id: &PeerId) -> Self {
+		libp2p_identity::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<litep2p::PeerId> for PeerId {
+	fn from(peer_id: litep2p::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<PeerId> for litep2p::PeerId {
+	fn from(peer_id: PeerId) -> Self {
+		litep2p::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<&litep2p::PeerId> for PeerId {
+	fn from(peer_id: &litep2p::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<&PeerId> for litep2p::PeerId {
+	fn from(peer_id: &PeerId) -> Self {
+		litep2p::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+/// Error when parsing a [`PeerId`] from string or bytes.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+	#[error("base-58 decode error: {0}")]
+	B58(#[from] bs58::decode::Error),
+	#[error("unsupported multihash code '{0}'")]
+	UnsupportedCode(u64),
+	#[error("invalid multihash")]
+	InvalidMultihash(#[from] crate::multihash::Error),
+}
+
+impl FromStr for PeerId {
+	type Err = ParseError;
+
+	#[inline]
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let bytes = bs58::decode(s).into_vec()?;
+		let peer_id = PeerId::from_bytes(&bytes)?;
+
+		Ok(peer_id)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn extract_peer_id_from_multiaddr() {
+		{
+			let peer = PeerId::random();
+			let address = "/ip4/198.51.100.19/tcp/30333"
+				.parse::<Multiaddr>()
+				.unwrap()
+				.with(Protocol::P2p(peer.into()));
+
+			assert_eq!(PeerId::try_from_multiaddr(&address), Some(peer));
+		}
+
+		{
+			let peer = PeerId::random();
+			assert_eq!(
+				PeerId::try_from_multiaddr(&Multiaddr::empty().with(Protocol::P2p(peer.into()))),
+				Some(peer)
+			);
+		}
+
+		{
+			assert!(PeerId::try_from_multiaddr(
+				&"/ip4/198.51.100.19/tcp/30333".parse::<Multiaddr>().unwrap()
+			)
+			.is_none());
+		}
+	}
+
+	#[test]
+	fn from_ed25519() {
+		let keypair = litep2p::crypto::ed25519::Keypair::generate();
+		let original_peer_id = litep2p::PeerId::from_public_key(
+			&litep2p::crypto::PublicKey::Ed25519(keypair.public()),
+		);
+
+		let peer_id: PeerId = original_peer_id.into();
+		assert_eq!(original_peer_id.to_bytes(), peer_id.to_bytes());
+
+		let key = peer_id.into_ed25519().unwrap();
+		assert_eq!(PeerId::from_ed25519(&key).unwrap(), original_peer_id.into());
+	}
+}

--- a/client/network-types/src/peer_id.rs
+++ b/client/network-types/src/peer_id.rs
@@ -77,9 +77,8 @@ impl PeerId {
 	pub fn from_multihash(multihash: Multihash) -> Result<PeerId, Multihash> {
 		match Code::try_from(multihash.code()) {
 			Ok(Code::Sha2_256) => Ok(PeerId { multihash }),
-			Ok(Code::Identity) if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH => {
-				Ok(PeerId { multihash })
-			},
+			Ok(Code::Identity) if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH =>
+				Ok(PeerId { multihash }),
 			_ => Err(multihash),
 		}
 	}

--- a/client/network-types/src/peer_id.rs
+++ b/client/network-types/src/peer_id.rs
@@ -1,0 +1,253 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+	multiaddr::{Multiaddr, Protocol},
+	multihash::{Code, Error, Multihash},
+};
+use rand::Rng;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use std::{fmt, hash::Hash, str::FromStr};
+
+/// Public keys with byte-lengths smaller than `MAX_INLINE_KEY_LENGTH` will be
+/// automatically used as the peer id using an identity multihash.
+const MAX_INLINE_KEY_LENGTH: usize = 42;
+
+/// Identifier of a peer of the network.
+///
+/// The data is a CIDv0 compatible multihash of the protobuf encoded public key of the peer
+/// as specified in [specs/peer-ids](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md).
+#[derive(
+	Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, SerializeDisplay, DeserializeFromStr,
+)]
+pub struct PeerId {
+	multihash: Multihash,
+}
+
+impl fmt::Debug for PeerId {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_tuple("PeerId").field(&self.to_base58()).finish()
+	}
+}
+
+impl fmt::Display for PeerId {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.to_base58().fmt(f)
+	}
+}
+
+impl PeerId {
+	/// Generate random peer ID.
+	pub fn random() -> PeerId {
+		let peer = rand::thread_rng().gen::<[u8; 32]>();
+		PeerId {
+			multihash: Multihash::wrap(0x0, &peer).expect("The digest size is never too large"),
+		}
+	}
+
+	/// Try to extract `PeerId` from `Multiaddr`.
+	pub fn try_from_multiaddr(address: &Multiaddr) -> Option<PeerId> {
+		match address.iter().find(|protocol| std::matches!(protocol, Protocol::P2p(_))) {
+			Some(Protocol::P2p(multihash)) => Some(Self { multihash }),
+			_ => None,
+		}
+	}
+
+	/// Tries to turn a `Multihash` into a `PeerId`.
+	///
+	/// If the multihash does not use a valid hashing algorithm for peer IDs,
+	/// or the hash value does not satisfy the constraints for a hashed
+	/// peer ID, it is returned as an `Err`.
+	pub fn from_multihash(multihash: Multihash) -> Result<PeerId, Multihash> {
+		match Code::try_from(multihash.code()) {
+			Ok(Code::Sha2_256) => Ok(PeerId { multihash }),
+			Ok(Code::Identity) if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH =>
+				Ok(PeerId { multihash }),
+			_ => Err(multihash),
+		}
+	}
+
+	/// Parses a `PeerId` from bytes.
+	pub fn from_bytes(data: &[u8]) -> Result<PeerId, Error> {
+		PeerId::from_multihash(Multihash::from_bytes(data)?)
+			.map_err(|mh| Error::UnsupportedCode(mh.code()))
+	}
+
+	/// Returns a raw bytes representation of this `PeerId`.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.multihash.to_bytes()
+	}
+
+	/// Returns a base-58 encoded string of this `PeerId`.
+	pub fn to_base58(&self) -> String {
+		bs58::encode(self.to_bytes()).into_string()
+	}
+
+	/// Convert `PeerId` into ed25519 public key bytes.
+	pub fn into_ed25519(&self) -> Option<[u8; 32]> {
+		let hash = &self.multihash;
+		// https://www.ietf.org/archive/id/draft-multiformats-multihash-07.html#name-the-multihash-identifier-re
+		if hash.code() != 0 {
+			// Hash is not identity
+			return None;
+		}
+
+		let public = libp2p_identity::PublicKey::try_decode_protobuf(hash.digest()).ok()?;
+		public.try_into_ed25519().ok().map(|public| public.to_bytes())
+	}
+
+	/// Get `PeerId` from ed25519 public key bytes.
+	pub fn from_ed25519(bytes: &[u8; 32]) -> Option<PeerId> {
+		let public = libp2p_identity::ed25519::PublicKey::try_from_bytes(bytes).ok()?;
+		let public: libp2p_identity::PublicKey = public.into();
+		let peer_id: libp2p_identity::PeerId = public.into();
+
+		Some(peer_id.into())
+	}
+}
+
+impl AsRef<Multihash> for PeerId {
+	fn as_ref(&self) -> &Multihash {
+		&self.multihash
+	}
+}
+
+impl From<PeerId> for Multihash {
+	fn from(peer_id: PeerId) -> Self {
+		peer_id.multihash
+	}
+}
+
+impl From<libp2p_identity::PeerId> for PeerId {
+	fn from(peer_id: libp2p_identity::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<PeerId> for libp2p_identity::PeerId {
+	fn from(peer_id: PeerId) -> Self {
+		libp2p_identity::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<&libp2p_identity::PeerId> for PeerId {
+	fn from(peer_id: &libp2p_identity::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<&PeerId> for libp2p_identity::PeerId {
+	fn from(peer_id: &PeerId) -> Self {
+		libp2p_identity::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<litep2p::PeerId> for PeerId {
+	fn from(peer_id: litep2p::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<PeerId> for litep2p::PeerId {
+	fn from(peer_id: PeerId) -> Self {
+		litep2p::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+impl From<&litep2p::PeerId> for PeerId {
+	fn from(peer_id: &litep2p::PeerId) -> Self {
+		PeerId { multihash: Multihash::from_bytes(&peer_id.to_bytes()).expect("to succeed") }
+	}
+}
+
+impl From<&PeerId> for litep2p::PeerId {
+	fn from(peer_id: &PeerId) -> Self {
+		litep2p::PeerId::from_bytes(&peer_id.to_bytes()).expect("to succeed")
+	}
+}
+
+/// Error when parsing a [`PeerId`] from string or bytes.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+	#[error("base-58 decode error: {0}")]
+	B58(#[from] bs58::decode::Error),
+	#[error("unsupported multihash code '{0}'")]
+	UnsupportedCode(u64),
+	#[error("invalid multihash")]
+	InvalidMultihash(#[from] crate::multihash::Error),
+}
+
+impl FromStr for PeerId {
+	type Err = ParseError;
+
+	#[inline]
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let bytes = bs58::decode(s).into_vec()?;
+		let peer_id = PeerId::from_bytes(&bytes)?;
+
+		Ok(peer_id)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn extract_peer_id_from_multiaddr() {
+		{
+			let peer = PeerId::random();
+			let address = "/ip4/198.51.100.19/tcp/30333"
+				.parse::<Multiaddr>()
+				.unwrap()
+				.with(Protocol::P2p(peer.into()));
+
+			assert_eq!(PeerId::try_from_multiaddr(&address), Some(peer));
+		}
+
+		{
+			let peer = PeerId::random();
+			assert_eq!(
+				PeerId::try_from_multiaddr(&Multiaddr::empty().with(Protocol::P2p(peer.into()))),
+				Some(peer)
+			);
+		}
+
+		{
+			assert!(PeerId::try_from_multiaddr(
+				&"/ip4/198.51.100.19/tcp/30333".parse::<Multiaddr>().unwrap()
+			)
+			.is_none());
+		}
+	}
+
+	#[test]
+	fn from_ed25519() {
+		let keypair = litep2p::crypto::ed25519::Keypair::generate();
+		let original_peer_id = litep2p::PeerId::from_public_key(
+			&litep2p::crypto::PublicKey::Ed25519(keypair.public()),
+		);
+
+		let peer_id: PeerId = original_peer_id.into();
+		assert_eq!(original_peer_id.to_bytes(), peer_id.to_bytes());
+
+		let key = peer_id.into_ed25519().unwrap();
+		assert_eq!(PeerId::from_ed25519(&key).unwrap(), original_peer_id.into());
+	}
+}


### PR DESCRIPTION
Inline sc-network-types crate from polkadot-sdk to prepare for post-quantum modifications. This is a direct copy of upstream sc-network-types v0.20.3 with Cargo.toml updated to use workspace dependencies where applicable.

This prepares for replacing Ed25519 identity with Dilithium ML-DSA-87 in a follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core P2P identity and address types used across the node; changes are upstream-equivalent today but expand the surface for future crypto/peer-id edits.
> 
> **Overview**
> This PR **vendors** upstream `sc-network-types` **v0.20.3** as an in-tree crate under `client/network-types`, instead of pulling it only from crates.io.
> 
> **Workspace wiring:** `client/network-types` is added to workspace members; `sc-network-types` is bumped to **0.20.3** and **`[patch.crates-io]`** points the dependency at the local path (alongside existing patches for `sc-network`, `sc-network-sync`, etc.).
> 
> **What the new crate provides:** Shared P2P types with conversions between **libp2p**, **litep2p**, and Substrate—`PeerId`, `Multiaddr`/`Protocol`, `Multihash`, Kademlia `Record`/`Key`, and **Ed25519** key material (including zeroizing secret parsing and interoperability tests). Behavior matches upstream; the intent is a forkable copy before post-quantum identity work.
> 
> **Lockfile:** Transitive updates (e.g. `bytes` **1.11.1**, `litep2p` **0.13.3**, `yamux` **0.13.10**) align the graph with the vendored crate’s dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe51d4afb251a23d9a52410ea00b5e728d55aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->