### PR TITLE
Fix nits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9570,10 +9570,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a21da8370d69fd5c43a2877174de2ef9aba6161131e15854ecbed3f98226f6"
 dependencies = [
- "console",
  "futures 0.3.31",
  "futures-timer",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/quantus-network/chain#"
 members = [
 	"client/cli",
 	"client/consensus/qpow",
+	"client/informant",
 	"client/litep2p",
 	"client/network",
 	"client/network-sync",
@@ -246,6 +247,7 @@ frame-storage-access-test-runtime = { path = "./patches/frame-storage-access-tes
 frame-system = { path = "./pallets/frame-system" }
 litep2p = { path = "./client/litep2p" }
 sc-cli = { path = "./client/cli" }
+sc-informant = { path = "./client/informant" }
 sc-network = { path = "client/network" }
 sc-network-sync = { path = "client/network-sync" }
 sc-network-types = { path = "client/network-types" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "sc-informant"
-version = "0.54.0"
 authors.workspace = true
 description = "Substrate informant (ANSI-free fork)."
 edition.workspace = true
-license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage.workspace = true
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+name = "sc-informant"
 repository.workspace = true
+version = "0.54.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sc-informant"
+version = "0.54.0"
+authors.workspace = true
+description = "Substrate informant (ANSI-free fork)."
+edition.workspace = true
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage.workspace = true
+repository.workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+futures = { workspace = true }
+futures-timer = { workspace = true }
+log = { workspace = true, default-features = true }
+sc-client-api = { workspace = true, default-features = true }
+sc-network = { workspace = true, default-features = true }
+sc-network-sync = { workspace = true, default-features = true }
+sp-blockchain = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }

--- a/client/informant/src/display.rs
+++ b/client/informant/src/display.rs
@@ -1,0 +1,218 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use log::info;
+use sc_client_api::ClientInfo;
+use sc_network::NetworkStatus;
+use sc_network_sync::{SyncState, SyncStatus, WarpSyncPhase, WarpSyncProgress};
+use sp_runtime::traits::{Block as BlockT, CheckedDiv, NumberFor, Saturating, Zero};
+use std::{fmt, time::Instant};
+
+use crate::PrintFullHashOnDebugLogging;
+
+/// State of the informant display system.
+///
+/// This is the system that handles the line that gets regularly printed and that looks something
+/// like:
+///
+/// > Syncing  5.4 bps, target=#531028 (4 peers), best: #90683 (0x4ca8…51b8),
+/// > finalized #360 (0x6f24…a38b), ⬇ 5.5kiB/s ⬆ 0.9kiB/s
+///
+/// # Usage
+///
+/// Call `InformantDisplay::new` to initialize the state, then regularly call `display` with the
+/// information to display.
+pub struct InformantDisplay<B: BlockT> {
+	/// Head of chain block number from the last time `display` has been called.
+	/// `None` if `display` has never been called.
+	last_number: Option<NumberFor<B>>,
+	/// The last time `display` or `new` has been called.
+	last_update: Instant,
+	/// The last seen total of bytes received.
+	last_total_bytes_inbound: u64,
+	/// The last seen total of bytes sent.
+	last_total_bytes_outbound: u64,
+}
+
+impl<B: BlockT> InformantDisplay<B> {
+	/// Builds a new informant display system.
+	pub fn new() -> InformantDisplay<B> {
+		InformantDisplay {
+			last_number: None,
+			last_update: Instant::now(),
+			last_total_bytes_inbound: 0,
+			last_total_bytes_outbound: 0,
+		}
+	}
+
+	/// Displays the informant by calling `info!`.
+	pub fn display(
+		&mut self,
+		info: &ClientInfo<B>,
+		net_status: NetworkStatus,
+		sync_status: SyncStatus<B>,
+		num_connected_peers: usize,
+	) {
+		let best_number = info.chain.best_number;
+		let best_hash = info.chain.best_hash;
+		let finalized_number = info.chain.finalized_number;
+		let speed = speed::<B>(best_number, self.last_number, self.last_update);
+		let total_bytes_inbound = net_status.total_bytes_inbound;
+		let total_bytes_outbound = net_status.total_bytes_outbound;
+
+		let now = Instant::now();
+		let elapsed = (now - self.last_update).as_secs();
+		self.last_update = now;
+		self.last_number = Some(best_number);
+
+		let diff_bytes_inbound = total_bytes_inbound - self.last_total_bytes_inbound;
+		let diff_bytes_outbound = total_bytes_outbound - self.last_total_bytes_outbound;
+		let (avg_bytes_per_sec_inbound, avg_bytes_per_sec_outbound) = if elapsed > 0 {
+			self.last_total_bytes_inbound = total_bytes_inbound;
+			self.last_total_bytes_outbound = total_bytes_outbound;
+			(diff_bytes_inbound / elapsed, diff_bytes_outbound / elapsed)
+		} else {
+			(diff_bytes_inbound, diff_bytes_outbound)
+		};
+
+		let (level, status, target) =
+			match (sync_status.state, sync_status.state_sync, sync_status.warp_sync) {
+				// Do not set status to "Block history" when we are doing a major sync.
+				//
+				// A node could for example have been warp synced to the tip of the chain and
+				// shutdown. At the next start we still need to download the block history, but
+				// first will sync to the tip of the chain.
+				(
+					sync_status,
+					_,
+					Some(WarpSyncProgress { phase: WarpSyncPhase::DownloadingBlocks(n), .. }),
+				) if !sync_status.is_major_syncing() => ("⏩", "Block history".into(), format!(", #{}", n)),
+				// Handle all phases besides the two phases we already handle above.
+				(_, _, Some(warp))
+					if !matches!(warp.phase, WarpSyncPhase::DownloadingBlocks(_)) =>
+					(
+						"⏩",
+						"Warping".into(),
+						format!(
+							", {}, {:.2} Mib",
+							warp.phase,
+							(warp.total_bytes as f32) / (1024f32 * 1024f32)
+						),
+					),
+				(_, Some(state), _) => (
+					"⚙️ ",
+					"State sync".into(),
+					format!(
+						", {}, {}%, {:.2} Mib",
+						state.phase,
+						state.percentage,
+						(state.size as f32) / (1024f32 * 1024f32)
+					),
+				),
+				(SyncState::Idle, _, _) => ("💤", "Idle".into(), "".into()),
+				(SyncState::Downloading { target }, _, _) =>
+					("⚙️ ", format!("Syncing{}", speed), format!(", target=#{target}")),
+				(SyncState::Importing { target }, _, _) =>
+					("⚙️ ", format!("Preparing{}", speed), format!(", target=#{target}")),
+			};
+
+		info!(
+			target: "substrate",
+			"{} {}{} ({} peers), best: #{} ({}), finalized #{} ({}), ⬇ {} ⬆ {}",
+			level,
+			status,
+			target,
+			num_connected_peers,
+			best_number,
+			PrintFullHashOnDebugLogging(&best_hash),
+			finalized_number,
+			PrintFullHashOnDebugLogging(&info.chain.finalized_hash),
+			TransferRateFormat(avg_bytes_per_sec_inbound),
+			TransferRateFormat(avg_bytes_per_sec_outbound),
+		)
+	}
+}
+
+/// Calculates `(best_number - last_number) / (now - last_update)` and returns a `String`
+/// representing the speed of import.
+fn speed<B: BlockT>(
+	best_number: NumberFor<B>,
+	last_number: Option<NumberFor<B>>,
+	last_update: Instant,
+) -> String {
+	// Number of milliseconds elapsed since last time.
+	let elapsed_ms = {
+		let elapsed = last_update.elapsed();
+		let since_last_millis = elapsed.as_secs() * 1000;
+		let since_last_subsec_millis = elapsed.subsec_millis() as u64;
+		since_last_millis + since_last_subsec_millis
+	};
+
+	// Number of blocks that have been imported since last time.
+	let diff = match last_number {
+		None => return String::new(),
+		Some(n) => best_number.saturating_sub(n),
+	};
+
+	if let Ok(diff) = TryInto::<u128>::try_into(diff) {
+		// If the number of blocks can be converted to a regular integer, then it's easy: just
+		// do the math and turn it into a `f64`.
+		let speed = diff
+			.saturating_mul(10_000)
+			.checked_div(u128::from(elapsed_ms))
+			.map_or(0.0, |s| s as f64) /
+			10.0;
+		format!(" {:4.1} bps", speed)
+	} else {
+		// If the number of blocks can't be converted to a regular integer, then we need a more
+		// algebraic approach and we stay within the realm of integers.
+		let one_thousand = NumberFor::<B>::from(1_000u32);
+		let elapsed =
+			NumberFor::<B>::from(<u32 as TryFrom<_>>::try_from(elapsed_ms).unwrap_or(u32::MAX));
+
+		let speed = diff
+			.saturating_mul(one_thousand)
+			.checked_div(&elapsed)
+			.unwrap_or_else(Zero::zero);
+		format!(" {} bps", speed)
+	}
+}
+
+/// Contains a number of bytes per second. Implements `fmt::Display` and shows this number of bytes
+/// per second in a nice way.
+struct TransferRateFormat(u64);
+impl fmt::Display for TransferRateFormat {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		// Special case 0.
+		if self.0 == 0 {
+			return write!(f, "0")
+		}
+
+		// Under 0.1 kiB, display plain bytes.
+		if self.0 < 100 {
+			return write!(f, "{} B/s", self.0)
+		}
+
+		// Under 1.0 MiB/sec, display the value in kiB/sec.
+		if self.0 < 1024 * 1024 {
+			return write!(f, "{:.1}kiB/s", self.0 as f64 / 1024.0)
+		}
+
+		write!(f, "{:.1}MiB/s", self.0 as f64 / (1024.0 * 1024.0))
+	}
+}

--- a/client/informant/src/lib.rs
+++ b/client/informant/src/lib.rs
@@ -1,0 +1,159 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Console informant. Prints sync progress and block events. Runs on the calling thread.
+
+use futures::prelude::*;
+use futures_timer::Delay;
+use log::{debug, info, log_enabled, trace};
+use sc_client_api::{BlockchainEvents, UsageProvider};
+use sc_network::NetworkStatusProvider;
+use sc_network_sync::{SyncStatusProvider, SyncingService};
+use sp_blockchain::HeaderMetadata;
+use sp_runtime::traits::{Block as BlockT, Header};
+use std::{
+	collections::VecDeque,
+	fmt::{Debug, Display},
+	sync::Arc,
+	time::Duration,
+};
+
+mod display;
+
+/// Creates a stream that returns a new value every `duration`.
+fn interval(duration: Duration) -> impl Stream<Item = ()> + Unpin {
+	futures::stream::unfold((), move |_| Delay::new(duration).map(|_| Some(((), ())))).map(drop)
+}
+
+/// Builds the informant and returns a `Future` that drives the informant.
+pub async fn build<B: BlockT, C, N>(client: Arc<C>, network: N, syncing: Arc<SyncingService<B>>)
+where
+	N: NetworkStatusProvider,
+	C: UsageProvider<B> + HeaderMetadata<B> + BlockchainEvents<B>,
+	<C as HeaderMetadata<B>>::Error: Display,
+{
+	let mut display = display::InformantDisplay::new();
+
+	let client_1 = client.clone();
+
+	let display_notifications = interval(Duration::from_millis(5000))
+		.filter_map(|_| async {
+			let net_status = network.status().await;
+			let sync_status = syncing.status().await;
+			let num_connected_peers = syncing.num_connected_peers();
+
+			match (net_status, sync_status) {
+				(Ok(net), Ok(sync)) => Some((net, sync, num_connected_peers)),
+				_ => None,
+			}
+		})
+		.for_each(move |(net_status, sync_status, num_connected_peers)| {
+			let info = client_1.usage_info();
+			if let Some(ref usage) = info.usage {
+				trace!(target: "usage", "Usage statistics: {}", usage);
+			} else {
+				trace!(
+					target: "usage",
+					"Usage statistics not displayed as backend does not provide it",
+				)
+			}
+			display.display(&info, net_status, sync_status, num_connected_peers);
+			future::ready(())
+		});
+
+	futures::select! {
+		() = display_notifications.fuse() => (),
+		() = display_block_import(client).fuse() => (),
+	};
+}
+
+/// Print the full hash when debug logging is enabled.
+struct PrintFullHashOnDebugLogging<'a, H>(&'a H);
+
+impl<H: Debug + Display> Display for PrintFullHashOnDebugLogging<'_, H> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		if log_enabled!(log::Level::Debug) {
+			Debug::fmt(&self.0, f)
+		} else {
+			Display::fmt(&self.0, f)
+		}
+	}
+}
+
+async fn display_block_import<B: BlockT, C>(client: Arc<C>)
+where
+	C: UsageProvider<B> + HeaderMetadata<B> + BlockchainEvents<B>,
+	<C as HeaderMetadata<B>>::Error: Display,
+{
+	let mut last_best = {
+		let info = client.usage_info();
+		Some((info.chain.best_number, info.chain.best_hash))
+	};
+
+	// Hashes of the last blocks we have seen at import.
+	let mut last_blocks = VecDeque::new();
+	let max_blocks_to_track = 100;
+	let mut notifications = client.import_notification_stream();
+
+	while let Some(n) = notifications.next().await {
+		// detect and log reorganizations.
+		if let Some((ref last_num, ref last_hash)) = last_best {
+			if n.header.parent_hash() != last_hash && n.is_new_best {
+				let maybe_ancestor =
+					sp_blockchain::lowest_common_ancestor(&*client, *last_hash, n.hash);
+
+				match maybe_ancestor {
+					Ok(ref ancestor) if ancestor.hash != *last_hash => info!(
+						"♻️  Reorg on #{},{} to #{},{}, common ancestor #{},{}",
+						last_num,
+						PrintFullHashOnDebugLogging(&last_hash),
+						n.header.number(),
+						PrintFullHashOnDebugLogging(&n.hash),
+						ancestor.number,
+						ancestor.hash,
+					),
+					Ok(_) => {},
+					Err(e) => debug!("Error computing tree route: {}", e),
+				}
+			}
+		}
+
+		if n.is_new_best {
+			last_best = Some((*n.header.number(), n.hash));
+		}
+
+		// If we already printed a message for a given block recently,
+		// we should not print it again.
+		if !last_blocks.contains(&n.hash) {
+			last_blocks.push_back(n.hash);
+
+			if last_blocks.len() > max_blocks_to_track {
+				last_blocks.pop_front();
+			}
+
+			let best_indicator = if n.is_new_best { "🏆" } else { "🆕" };
+			info!(
+				target: "substrate",
+				"{best_indicator} Imported #{} ({} → {})",
+				n.header.number(),
+				PrintFullHashOnDebugLogging(n.header.parent_hash()),
+				PrintFullHashOnDebugLogging(&n.hash),
+			);
+		}
+	}
+}

--- a/client/litep2p/src/crypto/dilithium.rs
+++ b/client/litep2p/src/crypto/dilithium.rs
@@ -94,8 +94,8 @@ impl Keypair {
 	pub fn try_from_bytes(kp: &mut [u8]) -> Result<Keypair, Error> {
 		let seed: [u8; SEED_BYTES] = kp.try_into().map_err(|_| {
 			Error::Other(format!(
-				"Invalid Dilithium seed length: expected {} bytes, got {}",
-				SEED_BYTES,
+				"Invalid node key format: expected {SEED_BYTES}-byte seed, got {} bytes. \
+				Please delete or move your old key file and restart to generate a new identity.",
 				kp.len()
 			))
 		})?;

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -50,7 +50,7 @@ use sc_network_types::{
 	PeerId,
 };
 
-use crate::service::signature::Keypair;
+use crate::service::signature::{DecodingError, Keypair};
 
 use crate::service::{ensure_addresses_consistent_with_transport, traits::NetworkBackend};
 use codec::Encode;
@@ -407,7 +407,6 @@ impl NodeKeyConfig {
 						b.to_vec()
 					};
 					litep2p::crypto::dilithium::Keypair::try_from_bytes(&mut bytes)
-						.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:?}")))
 				},
 				|| litep2p::crypto::dilithium::Keypair::generate(),
 				|kp| kp.to_bytes(),
@@ -428,15 +427,14 @@ impl NodeKeyConfig {
 				f,
 				|b| {
 					let bytes = if is_hex_data(b) {
-						array_bytes::hex2bytes(std::str::from_utf8(b).map_err(|_| {
-							io::Error::new(io::ErrorKind::InvalidData, "Failed to decode hex data")
-						})?)
-						.map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid hex"))?
+						array_bytes::hex2bytes(
+							std::str::from_utf8(b).map_err(|_| DecodingError::InvalidKey)?
+						)
+						.map_err(|_| DecodingError::InvalidKey)?
 					} else {
 						b.to_vec()
 					};
 					Keypair::dilithium_from_bytes(&bytes)
-						.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{:?}", e)))
 				},
 				Keypair::generate_dilithium,
 				|kp| kp.dilithium_to_bytes(),
@@ -461,16 +459,20 @@ where
 	E: Error + Send + Sync + 'static,
 	W: Fn(&K) -> Vec<u8>,
 {
-	std::fs::read(&file)
+	let file_path = file.as_ref();
+	std::fs::read(file_path)
 		.and_then(|mut sk_bytes| {
-			parse(&mut sk_bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+			parse(&mut sk_bytes).map_err(|e| io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!("Failed to parse '{}': {}", file_path.display(), e)
+			))
 		})
 		.or_else(|e| {
 			if e.kind() == io::ErrorKind::NotFound {
-				file.as_ref().parent().map_or(Ok(()), fs::create_dir_all)?;
+				file_path.parent().map_or(Ok(()), fs::create_dir_all)?;
 				let sk = generate();
 				let mut sk_vec = serialize(&sk);
-				write_secret_file(file, &sk_vec)?;
+				write_secret_file(file_path, &sk_vec)?;
 				sk_vec.zeroize();
 				Ok(sk)
 			} else {

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -428,7 +428,7 @@ impl NodeKeyConfig {
 				|b| {
 					let bytes = if is_hex_data(b) {
 						array_bytes::hex2bytes(
-							std::str::from_utf8(b).map_err(|_| DecodingError::InvalidKey)?
+							std::str::from_utf8(b).map_err(|_| DecodingError::InvalidKey)?,
 						)
 						.map_err(|_| DecodingError::InvalidKey)?
 					} else {
@@ -462,10 +462,12 @@ where
 	let file_path = file.as_ref();
 	std::fs::read(file_path)
 		.and_then(|mut sk_bytes| {
-			parse(&mut sk_bytes).map_err(|e| io::Error::new(
-				io::ErrorKind::InvalidData,
-				format!("Failed to parse '{}': {}", file_path.display(), e)
-			))
+			parse(&mut sk_bytes).map_err(|e| {
+				io::Error::new(
+					io::ErrorKind::InvalidData,
+					format!("Failed to parse '{}': {}", file_path.display(), e),
+				)
+			})
 		})
 		.or_else(|e| {
 			if e.kind() == io::ErrorKind::NotFound {

--- a/client/network/src/litep2p/discovery.rs
+++ b/client/network/src/litep2p/discovery.rs
@@ -931,8 +931,8 @@ mod tests {
 		}
 
 		// Futures will exit when all peers are discovered.
-		tokio::time::timeout(Duration::from_secs(60), futures.next())
+		tokio::time::timeout(Duration::from_secs(120), futures.next())
 			.await
-			.expect("All peers should finish within 60 seconds");
+			.expect("All peers should finish within 120 seconds");
 	}
 }

--- a/client/network/src/service/signature.rs
+++ b/client/network/src/service/signature.rs
@@ -37,6 +37,9 @@ pub enum DecodingError {
 	/// Invalid key data.
 	#[error("Invalid key data")]
 	InvalidKey,
+	/// Invalid key data with details.
+	#[error("{0}")]
+	InvalidKeyWithMessage(String),
 	/// Unknown key type.
 	#[error("Unknown key type")]
 	UnknownKeyType,
@@ -128,7 +131,7 @@ impl Keypair {
 		let mut bytes_mut = bytes.to_vec();
 		DilithiumKeypair::try_from_bytes(&mut bytes_mut)
 			.map(Keypair::Dilithium)
-			.map_err(|_| DecodingError::InvalidKey)
+			.map_err(|e| DecodingError::InvalidKeyWithMessage(format!("{}", e)))
 	}
 
 	/// Convert to litep2p keypair for the network backend.

--- a/pallets/qpow/src/tests.rs
+++ b/pallets/qpow/src/tests.rs
@@ -70,12 +70,12 @@ fn test_difficulty_validation() {
 }
 
 #[test]
-fn test_poseidon_double_hash() {
+fn test_poseidon_hash_squeeze_twice() {
 	new_test_ext().execute_with(|| {
 		let block_hash = [0x42u8; 32];
 		let nonce = [0x24u8; 64];
 
-		// Manually verify double Poseidon2 hashing
+		// Verify single Poseidon2 hash with double squeeze (512-bit output)
 		let mut input = [0u8; 96];
 		input[..32].copy_from_slice(&block_hash);
 		input[32..96].copy_from_slice(&nonce);


### PR DESCRIPTION
- update inaccurate comments
- fix flaky test
- inline sc-informant so we don't have ANSI in the logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly logging, error messaging, and test timeouts; the informant fork mirrors upstream behavior without altering consensus or networking logic.
> 
> **Overview**
> **Vendors `sc-informant` in-tree** and patches `crates-io` so node sync/import status logs no longer pull in the upstream crate’s `console` dependency (ANSI escape sequences in log output). The fork keeps the same periodic sync line and block-import logging via `log::info!`.
> 
> **Improves Dilithium node identity loading errors**: invalid seed length messages are user-facing (including guidance to remove stale key files), file-based key parsing surfaces the path in I/O errors, and `DecodingError::InvalidKeyWithMessage` preserves the underlying detail from `dilithium_from_bytes`.
> 
> **Test hygiene**: litep2p discovery integration test timeout is raised from 60s to 120s; qPoW test name/comments now describe a single Poseidon2 hash with double squeeze instead of “double hash.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750b06e823c27a7ff525ea6928479beecd5aec72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->