### PR TITLE
Update rusty crystals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6141,7 +6141,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8518,9 +8518,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes 1.11.1",
  "fastbloom",
@@ -9019,7 +9019,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9098,7 +9098,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.2",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12318,7 +12318,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13835,7 +13835,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4237,7 +4237,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio 1.47.1",
  "tower-service",
  "tracing",
@@ -4834,7 +4834,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.5.3",
+ "rustls-platform-verifier",
  "soketto",
  "thiserror 1.0.69",
  "tokio 1.47.1",
@@ -6141,7 +6141,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8509,7 +8509,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio 1.47.1",
  "tracing",
@@ -8531,7 +8531,6 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -8548,7 +8547,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9019,7 +9018,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -9077,27 +9076,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.6",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -12318,7 +12296,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -13835,7 +13813,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5494,7 +5494,7 @@ dependencies = [
  "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
- "x509-parser 0.17.0",
+ "x509-parser 0.18.1",
  "yamux",
  "yasna",
  "zeroize",
@@ -6179,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -12453,30 +12453,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14516,9 +14516,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs 0.7.1",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,12 +832,6 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -2907,6 +2901,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.3",
+ "libm",
+ "rand 0.9.2",
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,7 +4191,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.32",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.47.1",
  "tokio-rustls",
@@ -4745,14 +4751,14 @@ version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "futures-util",
  "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
  "rustls 0.23.32",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 1.0.69",
  "tokio 1.47.1",
@@ -5120,7 +5126,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "parking_lot 0.12.4",
- "quinn 0.11.9",
+ "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
  "rustls 0.23.32",
@@ -5257,7 +5263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.22.1",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -6523,7 +6529,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "primitive-types 0.13.1",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "qpow-math",
  "scale-info",
  "sp-core",
@@ -6738,7 +6744,7 @@ dependencies = [
  "qp-dilithium-crypto",
  "qp-header",
  "qp-plonky2",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "qp-wormhole",
  "qp-wormhole-aggregator",
  "qp-wormhole-circuit",
@@ -6762,7 +6768,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "scale-info",
  "serde",
  "sp-api",
@@ -6934,7 +6940,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde",
 ]
 
@@ -7931,7 +7937,7 @@ dependencies = [
  "env_logger",
  "log",
  "parity-scale-codec",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "qp-rusty-crystals-dilithium",
  "qp-rusty-crystals-hdwallet",
  "scale-info",
@@ -7947,7 +7953,7 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "scale-info",
  "serde",
  "serde_json",
@@ -7979,7 +7985,7 @@ dependencies = [
  "qp-plonky2-core",
  "qp-plonky2-field",
  "qp-plonky2-verifier",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "rand 0.10.1",
  "serde",
  "static_assertions",
@@ -8043,7 +8049,7 @@ dependencies = [
  "plonky2_util",
  "qp-plonky2-core",
  "qp-plonky2-field",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "serde",
  "static_assertions",
  "unroll",
@@ -8064,45 +8070,31 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51774769a44a1c65f9ad3959ff1497a9c315a16f5718151873721b3c5631413"
-dependencies = [
- "p3-field",
- "p3-goldilocks",
- "p3-poseidon2",
- "p3-symmetric",
- "qp-poseidon-constants",
- "rand_chacha 0.9.0",
-]
-
-[[package]]
-name = "qp-poseidon-core"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78172860cd960773c72e97fba07ead9e5a1c13086c5746283744933e2e4a577b"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223f0218cd3d55a04d96cc9a82415d2edd5e37b5ebd0f466d44a22bf8b34532"
+checksum = "a6c16ed4031406f6d8ff14a4822a35f766b62617324c75931db7df8c3631a701"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbfc888856ab9d7b729d94ada8ddd4916cd3abbe67c1fc6af80c0ed32d17d3d"
+checksum = "e2e068be8021f2bebbabeab77ee9107a359d6e537397323ae92aae8178922fab"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",
  "hex",
  "hex-literal 0.4.1",
  "hmac 0.12.1",
- "qp-poseidon-core 1.4.0",
+ "qp-poseidon-core",
  "qp-rusty-crystals-dilithium",
  "serde",
  "serde_json",
@@ -8126,7 +8118,7 @@ name = "qp-wormhole"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "sp-consensus-qpow",
  "sp-core",
  "sp-runtime",
@@ -8218,7 +8210,7 @@ dependencies = [
  "anyhow",
  "qp-plonky2",
  "qp-poseidon-constants",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "qp-wormhole-inputs",
  "rand 0.8.5",
  "serde",
@@ -8232,7 +8224,7 @@ dependencies = [
  "log",
  "primitive-types 0.13.1",
  "proptest",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
 ]
 
 [[package]]
@@ -8286,7 +8278,7 @@ dependencies = [
  "qpow-math",
  "quantus-miner-api",
  "quantus-runtime",
- "quinn 0.10.2",
+ "quinn",
  "rand 0.8.5",
  "rcgen",
  "rustls 0.21.12",
@@ -8362,7 +8354,7 @@ dependencies = [
  "qp-dilithium-crypto",
  "qp-header",
  "qp-high-security",
- "qp-poseidon-core 2.1.0",
+ "qp-poseidon-core",
  "qp-scheduler",
  "qp-wormhole",
  "scale-info",
@@ -8412,23 +8404,6 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
-dependencies = [
- "bytes 1.11.1",
- "pin-project-lite 0.2.16",
- "quinn-proto 0.10.6",
- "quinn-udp 0.4.1",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "thiserror 1.0.69",
- "tokio 1.47.1",
- "tracing",
-]
-
-[[package]]
-name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
@@ -8437,8 +8412,8 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "futures-io",
  "pin-project-lite 0.2.16",
- "quinn-proto 0.11.13",
- "quinn-udp 0.5.14",
+ "quinn-proto",
+ "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.32",
  "socket2 0.6.0",
@@ -8450,29 +8425,12 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
-dependencies = [
- "bytes 1.11.1",
- "rand 0.8.5",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "slab",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
 version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes 1.11.1",
+ "fastbloom",
  "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.2",
@@ -8480,24 +8438,12 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.32",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
-dependencies = [
- "bytes 1.11.1",
- "libc",
- "socket2 0.5.10",
- "tracing",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8998,18 +8944,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -9017,16 +8951,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework",
 ]
 
 [[package]]
@@ -9051,13 +8976,34 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.32",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.6",
- "security-framework 3.5.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.32",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.6",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10488,19 +10434,6 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.4",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
@@ -10624,7 +10557,7 @@ version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "serde",
@@ -10822,7 +10755,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
- "base64 0.22.1",
+ "base64",
  "bip39",
  "blake2-rfc",
  "bs58",
@@ -10875,7 +10808,7 @@ checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
 dependencies = [
  "async-channel 2.5.0",
  "async-lock",
- "base64 0.22.1",
+ "base64",
  "blake2-rfc",
  "bs58",
  "derive_more 2.0.1",
@@ -10935,7 +10868,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes 1.11.1",
  "futures 0.3.31",
  "http 1.3.1",
@@ -12129,7 +12062,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bip32",
  "bip39",
  "cfg-if",
@@ -12565,7 +12498,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.23.32",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.47.1",
  "tokio-rustls",
@@ -13572,7 +13505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "directories-next",
  "log",
  "postcard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3926,6 +3926,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio 1.47.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,25 +3976,20 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
- "async-trait",
- "cfg-if",
  "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "once_cell",
- "rand 0.9.2",
+ "prefix-trie",
+ "rand 0.10.1",
  "ring 0.17.14",
  "thiserror 2.0.18",
  "tinyvec",
- "tokio 1.47.1",
  "tracing",
  "url",
 ]
@@ -3998,20 +4017,25 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-net",
+ "hickory-proto 0.26.1",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.4",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio 1.47.1",
  "tracing",
@@ -4390,7 +4414,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio 1.47.1",
  "windows 0.53.0",
 ]
@@ -4546,6 +4570,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -4696,7 +4723,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4704,10 +4731,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "jobserver"
@@ -5386,7 +5462,7 @@ dependencies = [
  "futures-timer",
  "futures_ringbuf",
  "hex-literal 1.1.0",
- "hickory-resolver 0.25.2",
+ "hickory-resolver 0.26.1",
  "indexmap",
  "ip_network",
  "libc",
@@ -5907,6 +5983,12 @@ name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netlink-packet-core"
@@ -7604,6 +7686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8974,7 +9067,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -8995,7 +9088,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -10674,6 +10767,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple-dns"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12154,6 +12263,17 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.9.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.16",
+]
+
+[[package]]
 name = "atomic-take"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,17 +1022,6 @@ name = "blake2b_simd"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1355,19 +1357,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cid"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
-dependencies = [
- "core2",
- "multibase",
- "multihash 0.17.0",
- "serde",
- "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -2323,7 +2312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4237,7 +4226,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio 1.47.1",
  "tower-service",
  "tracing",
@@ -5455,7 +5444,7 @@ dependencies = [
  "async-trait",
  "bs58",
  "bytes 1.11.1",
- "cid 0.11.1",
+ "cid",
  "clatter",
  "enum-display",
  "futures 0.3.31",
@@ -5897,15 +5886,11 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive",
  "serde",
  "sha2 0.10.9",
- "sha3",
  "unsigned-varint 0.7.2",
 ]
 
@@ -8036,7 +8021,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8509,7 +8494,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio 1.47.1",
  "tracing",
@@ -8547,7 +8532,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9333,7 +9318,7 @@ dependencies = [
  "sp-tracing",
  "sp-version",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio 1.47.1",
 ]
 
@@ -9492,7 +9477,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9652,9 +9637,9 @@ dependencies = [
  "assert_matches",
  "async-channel 1.9.0",
  "async-trait",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.2",
  "bytes 1.11.1",
- "cid 0.9.0",
+ "cid",
  "criterion",
  "either",
  "fnv",
@@ -9670,8 +9655,8 @@ dependencies = [
  "parking_lot 0.12.4",
  "partial_sort",
  "pin-project",
- "prost 0.12.6",
- "prost-build 0.13.5",
+ "prost 0.13.5",
+ "prost-build 0.14.3",
  "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
@@ -9688,11 +9673,11 @@ dependencies = [
  "sp-tracing",
  "substrate-prometheus-endpoint",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio 1.47.1",
  "tokio-stream",
  "tokio-util",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "void",
  "wasm-timer",
  "zeroize",
@@ -9794,12 +9779,12 @@ dependencies = [
  "bytes 1.11.1",
  "litep2p",
  "log",
- "multiaddr 0.18.2",
- "multihash 0.19.3",
+ "multiaddr 0.17.1",
+ "multihash 0.17.0",
  "quickcheck",
  "rand 0.8.5",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12922,9 +12907,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -13020,12 +13005,6 @@ name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-dependencies = [
- "asynchronous-codec",
- "bytes 1.11.1",
- "futures-io",
- "futures-util",
-]
 
 [[package]]
 name = "unsigned-varint"
@@ -13033,7 +13012,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 dependencies = [
+ "asynchronous-codec 0.7.0",
  "bytes 1.11.1",
+ "futures-io",
+ "futures-util",
  "tokio-util",
 ]
 
@@ -13813,7 +13795,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,9 +844,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "binary-merkle-tree"
-version = "16.1.0"
+version = "16.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c9f6900c9fd344d53fbdfb36e1343429079d73f4168c8ef48884bf15616dbd"
+checksum = "a6d867f1ffee8b07e7bee466f4f33a043b91f868f5c7b1d22d8a02f86e92bee8"
 dependencies = [
  "hash-db",
  "log",
@@ -3518,7 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.32",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -4190,7 +4190,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "log",
- "rustls 0.23.32",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.47.1",
@@ -4756,7 +4756,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.32",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
  "soketto",
@@ -5129,7 +5129,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
- "rustls 0.23.32",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio 1.47.1",
@@ -5186,9 +5186,9 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen",
+ "rcgen 0.11.3",
  "ring 0.17.14",
- "rustls 0.23.32",
+ "rustls",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser 0.16.0",
@@ -8280,8 +8280,8 @@ dependencies = [
  "quantus-runtime",
  "quinn",
  "rand 0.8.5",
- "rcgen",
- "rustls 0.21.12",
+ "rcgen 0.13.2",
+ "rustls",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -8415,7 +8415,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.32",
+ "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio 1.47.1",
@@ -8436,7 +8436,7 @@ dependencies = [
  "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.32",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
  "slab",
@@ -8634,6 +8634,19 @@ checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
  "pem",
  "ring 0.16.20",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring 0.17.14",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -8918,17 +8931,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "ring 0.17.14",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
@@ -8975,7 +8977,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.32",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.6",
@@ -8996,14 +8998,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.32",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.6",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -9748,7 +9750,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "rand 0.8.5",
- "rustls 0.23.32",
+ "rustls",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -10331,16 +10333,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -10931,9 +10923,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "28.0.0"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f4755af7cc57f4a2a830e134b403fc832caa5d93dacb970ffc7ac717f38c40"
+checksum = "4e06588d1c43f60b9bb7f989785689842cc4cc8ce0e19d1c47686b1ff5fe9548"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -11784,9 +11776,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
+checksum = "d93affb0135879b1b67cbcf6370a256e1772f9eaaece3899ec20966d67ad0492"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -12473,7 +12465,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
- "rustls 0.23.32",
+ "rustls",
  "tokio 1.47.1",
 ]
 
@@ -12497,7 +12489,7 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.32",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.47.1",
@@ -12798,7 +12790,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.32",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ primitive-types = { version = "0.13.1", default-features = false }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.12.4" }
 prost-build = { version = "0.13.2" }
-quinn = { version = "0.11.9" }
+quinn = { version = "0.11.9", default-features = false, features = ["log", "runtime-tokio", "rustls-ring", "bloom"] }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.11.24", default-features = false, features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ frame-system = { version = "45.0.0", default-features = false }
 frame-system-benchmarking = { version = "45.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "40.0.0", default-features = false }
 frame-try-runtime = { version = "0.51.0", default-features = false }
-hickory-resolver = { version = "0.25.2" }
+hickory-resolver = { version = "0.26.1" }
 multiaddr = { version = "0.17.0" }
 multihash = { version = "0.17.0", default-features = false }
 pallet-assets = { version = "48.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ unsigned-varint = { version = "0.7.2" }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 void = { version = "1.0.2" }
 wasm-timer = { version = "0.2.5" }
-x509-parser = { version = "0.17.0" }
+x509-parser = { version = "0.18.1" }
 yamux = { version = "0.13.9" }
 yasna = { version = "0.5.0" }
 zeroize = { version = "1.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ primitive-types = { version = "0.13.1", default-features = false }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.12.4" }
 prost-build = { version = "0.13.2" }
+quinn = { version = "0.11.9" }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.11.24", default-features = false, features = ["json"] }
@@ -160,7 +161,7 @@ sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = f
 qp-plonky2 = { version = "1.5.1", default-features = false }
 qp-poseidon-core = { version = "2.1.0", default-features = false }
 qp-rusty-crystals-dilithium = { version = "2.4.0", default-features = false }
-qp-rusty-crystals-hdwallet = { version = "2.3.1" }
+qp-rusty-crystals-hdwallet = { version = "2.4.0" }
 qp-wormhole-aggregator = { version = "3.0.0", default-features = false }
 qp-wormhole-circuit = { version = "3.0.0", default-features = false }
 qp-wormhole-circuit-builder = { version = "3.0.0", default-features = false }
@@ -168,7 +169,6 @@ qp-wormhole-inputs = { version = "3.0.0", default-features = false }
 qp-wormhole-prover = { version = "3.0.0", default-features = false }
 qp-wormhole-verifier = { version = "3.0.0", default-features = false }
 qp-zk-circuits-common = { version = "3.0.0", default-features = false }
-
 
 # polkadot-sdk dependencies
 frame-benchmarking = { version = "45.0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,36 +54,46 @@ async-trait = { version = "0.1.85", default-features = false }
 asynchronous-codec = { version = "0.6" }
 binary-merkle-tree = { version = "16.1.0", default-features = false }
 bip39 = { version = "2.0.1", features = ["rand"], default-features = true, package = "parity-bip39" }
+bs58 = { version = "0.5.1" }
 bytes = { version = "1.4.0", default-features = false }
+cfg-if = { version = "1.0" }
 chrono = { version = "0.4.31" }
-cid = { version = "0.9.0" }
+cid = { version = "0.11.1" }
 clap = { version = "4.5.13" }
+clatter = { version = "=1.1.0" }
 codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
 criterion = { version = "0.5.1", default-features = false }
 docify = { version = "0.2.9", default-features = false }
 either = { version = "1.8.1", default-features = false }
-env_logger = "0.11.5"
+enum-display = { version = "0.1.4" }
+env_logger = { version = "0.11.5" }
 fdlimit = { version = "0.3.0" }
 fnv = { version = "1.0.6" }
 foldhash = { version = "0.1.5", default-features = false }
 futures = { version = "0.3.31" }
 futures-timer = { version = "3.0.2" }
+futures_ringbuf = { version = "0.4.0" }
 hash-db = { version = "0.16.0", default-features = false }
-hashbrown = "0.15.3"
+hashbrown = { version = "0.15.3" }
 hex = { version = "0.4.3", default-features = false }
+hex-literal = { version = "1.0.0" }
+indexmap = { version = "2.9.0", features = ["std"] }
 ip_network = { version = "0.4.1" }
 itertools = { version = "0.11" }
 jsonrpsee = { version = "0.24.3" }
 lazy_static = { version = "1.5.0", default-features = false, features = [
 	"spin_no_std",
 ] }
-
+libc = { version = "0.2.158" }
 linked_hash_set = { version = "0.1.4" }
 log = { version = "0.4.22", default-features = false }
 memory-db = { version = "0.34.0", default-features = false }
 mockall = { version = "0.13.1" }
+multiaddr = { version = "0.17.0" }
+multihash = { version = "0.17.0", default-features = false, features = ["identity", "sha2"] }
 multistream-select = { version = "0.13.0" }
 names = { version = "0.14.0", default-features = false }
+network-interface = { version = "2.0.1" }
 nohash-hasher = { version = "0.2.0" }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 once_cell = { version = "1.21.3" }
@@ -94,41 +104,50 @@ pin-project = { version = "1.1.3" }
 pretty_assertions = { version = "1.3.0" }
 primitive-types = { version = "0.13.1", default-features = false }
 prometheus = { version = "0.13.4", default-features = false }
-prost = { version = "0.12.4" }
-prost-build = { version = "0.13.2" }
-quinn = { version = "0.11.9", default-features = false, features = ["log", "runtime-tokio", "rustls-ring", "bloom"] }
+proptest = { version = "1" }
+prost = { version = "0.13.5" }
+prost-build = { version = "0.14" }
+quickcheck = { version = "1.0.3" }
+quinn = { version = "0.11.9", default-features = false, features = ["bloom", "log", "runtime-tokio", "rustls-ring"] }
 rand = { version = "0.8.5", default-features = false }
+rcgen = { version = "0.13" }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.11.24", default-features = false, features = ["json"] }
 rpassword = { version = "7.0.0" }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 sc-client-db = { version = "0.51.0", default-features = false }
 sc-keystore = { version = "39.0.0", default-features = true }
 sc-mixnet = { version = "0.25.0", default-features = true }
 sc-tracing = { version = "44.0.0" }
-scale-info = { version = "2.11.1", default-features = false }
+scale-info = { version = "2.11.6", default-features = false }
 schnellru = { version = "0.2.3" }
 serde = { version = "1.0.214", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.132", default-features = false }
+serde_millis = { version = "0.1" }
+serde_with = { version = "3.12.0", default-features = false, features = ["hex", "macros"] }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
+simple-dns = { version = "0.11.0" }
 smallvec = { version = "1.11.0", default-features = false }
-
-clatter = { version = "=1.1.0" }
-
+socket2 = { version = "0.5.9", features = ["all"] }
 sp-keystore = { version = "0.45.0", default-features = true }
 sp-state-machine = { version = "0.49.0", default-features = false }
 tempfile = { version = "3.8.1" }
-thiserror = { version = "1.0.64" }
+thiserror = { version = "2.0.12" }
 tokio = { version = "1.45.0", default-features = false }
 tokio-stream = { version = "0.1.14" }
 tokio-test = { version = "0.4.4" }
+tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots", "url"] }
 tokio-util = { version = "0.7.13", default-features = false }
 tracing = { version = "0.1.37", default-features = false }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 trie-bench = { version = "0.42.0" }
 trie-db = { version = "0.30.0", default-features = false }
 trie-root = { version = "0.18.0", default-features = false }
 trie-standardmap = { version = "0.16.0" }
-unsigned-varint = { version = "0.7.2" }
+uint = { version = "0.10.0" }
+unsigned-varint = { version = "0.8.0", features = ["codec"] }
+url = { version = "2.5.4" }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 void = { version = "1.0.2" }
 wasm-timer = { version = "0.2.5" }
@@ -181,8 +200,6 @@ frame-system-benchmarking = { version = "45.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "40.0.0", default-features = false }
 frame-try-runtime = { version = "0.51.0", default-features = false }
 hickory-resolver = { version = "0.26.1" }
-multiaddr = { version = "0.17.0" }
-multihash = { version = "0.17.0", default-features = false }
 pallet-assets = { version = "48.1.0", default-features = false }
 pallet-assets-holder = { version = "0.8.0", default-features = false }
 pallet-conviction-voting = { version = "45.0.0", default-features = false }

--- a/client/litep2p/Cargo.toml
+++ b/client/litep2p/Cargo.toml
@@ -7,44 +7,42 @@ repository = "https://github.com/Quantus-Network/chain"
 version = "0.13.3"
 
 [build-dependencies]
-prost-build = "0.14"
+prost-build = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
-bs58 = "0.5.1"
+bs58 = { workspace = true }
 bytes = { workspace = true }
-cid = "0.11.1"
-
+cid = { workspace = true }
+clatter = { workspace = true }
+enum-display = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 hickory-resolver = { workspace = true }
-indexmap = { version = "2.9.0", features = ["std"] }
+indexmap = { workspace = true }
 ip_network = { workspace = true }
-libc = "0.2.158"
+libc = { workspace = true }
 mockall = { workspace = true }
 multiaddr = { workspace = true }
-multihash = { workspace = true, features = ["blake2b", "identity", "multihash-impl", "sha2", "sha3", "std"] }
-network-interface = "2.0.1"
+multihash = { workspace = true, features = ["identity", "sha2", "std"] }
+network-interface = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }
-prost = "0.13.5"
+prost = { workspace = true }
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
 serde = { workspace = true }
 sha2 = { workspace = true }
-simple-dns = "0.11.0"
+simple-dns = { workspace = true }
 smallvec = { workspace = true }
-# Noise protocol with post-quantum pqxx pattern (ML-KEM 768 / FIPS 203)
-clatter = { workspace = true }
-enum-display = "0.1.4"
-socket2 = { version = "0.5.9", features = ["all"] }
-thiserror = "2.0.12"
+socket2 = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "compat", "io"] }
 tracing = { workspace = true, features = ["log"] }
-uint = "0.10.0"
-unsigned-varint = { version = "0.8.0", features = ["codec"] }
-url = "2.5.4"
+uint = { workspace = true }
+unsigned-varint = { workspace = true }
+url = { workspace = true }
 x509-parser = { workspace = true }
 yamux = { workspace = true }
 yasna = { workspace = true }
@@ -54,17 +52,17 @@ zeroize = { workspace = true }
 qp-rusty-crystals-dilithium = { workspace = true }
 
 # Websocket
-tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots", "url"], optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
 
 # Fuzzing
-serde_millis = { version = "0.1", optional = true }
+serde_millis = { workspace = true, optional = true }
 
 [dev-dependencies]
-futures_ringbuf = "0.4.0"
-hex-literal = "1.0.0"
-quickcheck = "1.0.3"
+futures_ringbuf = { workspace = true }
+hex-literal = { workspace = true }
+quickcheck = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["websocket"]

--- a/client/litep2p/src/error.rs
+++ b/client/litep2p/src/error.rs
@@ -118,7 +118,7 @@ pub enum Error {
 	#[error("Failed to dial peer immediately")]
 	ImmediateDialError(#[from] ImmediateDialError),
 	#[error("Cannot read system DNS config: `{0}`")]
-	CannotReadSystemDnsConfig(hickory_resolver::ResolveError),
+	CannotReadSystemDnsConfig(Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Error type for address parsing.

--- a/client/litep2p/src/lib.rs
+++ b/client/litep2p/src/lib.rs
@@ -50,7 +50,7 @@ use crate::{
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::WebSocketTransport;
 
-use hickory_resolver::{name_server::TokioConnectionProvider, TokioResolver};
+use hickory_resolver::TokioResolver;
 use multiaddr::{Multiaddr, Protocol};
 use transport::Endpoint;
 use types::ConnectionId;
@@ -156,14 +156,15 @@ impl Litep2p {
 
 		let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
 			hickory_resolver::system_conf::read_system_conf()
-				.map_err(Error::CannotReadSystemDnsConfig)?
+				.map_err(|e| Error::CannotReadSystemDnsConfig(e.into()))?
 		} else {
 			(Default::default(), Default::default())
 		};
 		let resolver = Arc::new(
-			TokioResolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
+			TokioResolver::builder_with_config(resolver_config, Default::default())
 				.with_options(resolver_opts)
-				.build(),
+				.build()
+				.map_err(|e| Error::CannotReadSystemDnsConfig(e.into()))?,
 		);
 
 		let supported_transports = Self::supported_transports(&litep2p_config);

--- a/client/litep2p/src/transport/tcp/connection.rs
+++ b/client/litep2p/src/transport/tcp/connection.rs
@@ -779,12 +779,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await
@@ -882,12 +879,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await
@@ -1032,12 +1026,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await
@@ -1086,12 +1077,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await
@@ -1267,12 +1255,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await
@@ -1403,12 +1388,9 @@ mod tests {
 			Duration::from_secs(10),
 			false,
 			Arc::new(
-				TokioResolver::builder_with_config(
-					Default::default(),
-					Default::default(),
-				)
-				.build()
-				.unwrap(),
+				TokioResolver::builder_with_config(Default::default(), Default::default())
+					.build()
+					.unwrap(),
 			),
 		)
 		.await

--- a/client/litep2p/src/transport/tcp/connection.rs
+++ b/client/litep2p/src/transport/tcp/connection.rs
@@ -754,7 +754,7 @@ mod tests {
 	use crate::transport::tcp::TcpTransport;
 
 	use super::*;
-	use hickory_resolver::{name_server::TokioConnectionProvider, TokioResolver};
+	use hickory_resolver::TokioResolver;
 	use tokio::{io::AsyncWriteExt, net::TcpListener};
 
 	#[tokio::test]
@@ -781,9 +781,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await
@@ -883,9 +884,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await
@@ -1032,9 +1034,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await
@@ -1085,9 +1088,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await
@@ -1265,9 +1269,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await
@@ -1400,9 +1405,10 @@ mod tests {
 			Arc::new(
 				TokioResolver::builder_with_config(
 					Default::default(),
-					TokioConnectionProvider::default(),
+					Default::default(),
 				)
-				.build(),
+				.build()
+				.unwrap(),
 			),
 		)
 		.await

--- a/client/litep2p/src/transport/tcp/mod.rs
+++ b/client/litep2p/src/transport/tcp/mod.rs
@@ -757,7 +757,7 @@ mod tests {
 			listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
 			..Default::default()
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
+		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 
 		let (mut transport1, listen_addresses) =
 			TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -847,7 +847,7 @@ mod tests {
 			listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
 			..Default::default()
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
+		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 
 		let (mut transport1, listen_addresses) =
 			TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -931,7 +931,7 @@ mod tests {
 				},
 			)]),
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
+		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 		let (mut transport1, _) =
 			TcpTransport::new(handle1, Default::default(), resolver.clone()).unwrap();
 
@@ -999,7 +999,7 @@ mod tests {
 	async fn dial_error_reported_for_outbound_connections() {
 		let mut manager = TransportManagerBuilder::new().build();
 		let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
-		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
+		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 		manager.register_transport(
 			SupportedTransport::Tcp,
 			Box::new(crate::transport::dummy::DummyTransport::new()),

--- a/client/litep2p/src/transport/tcp/mod.rs
+++ b/client/litep2p/src/transport/tcp/mod.rs
@@ -757,7 +757,7 @@ mod tests {
 			listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
 			..Default::default()
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
 
 		let (mut transport1, listen_addresses) =
 			TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -847,7 +847,7 @@ mod tests {
 			listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
 			..Default::default()
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
 
 		let (mut transport1, listen_addresses) =
 			TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -931,7 +931,7 @@ mod tests {
 				},
 			)]),
 		};
-		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
 		let (mut transport1, _) =
 			TcpTransport::new(handle1, Default::default(), resolver.clone()).unwrap();
 
@@ -999,7 +999,7 @@ mod tests {
 	async fn dial_error_reported_for_outbound_connections() {
 		let mut manager = TransportManagerBuilder::new().build();
 		let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
-		let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+		let resolver = Arc::new(TokioResolver::builder_tokio().build().unwrap());
 		manager.register_transport(
 			SupportedTransport::Tcp,
 			Box::new(crate::transport::dummy::DummyTransport::new()),

--- a/client/litep2p/src/transport/websocket/connection.rs
+++ b/client/litep2p/src/transport/websocket/connection.rs
@@ -665,7 +665,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -781,7 +781,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1221,7 +1221,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1375,7 +1375,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
 		)
 		.await
 		.unwrap();

--- a/client/litep2p/src/transport/websocket/connection.rs
+++ b/client/litep2p/src/transport/websocket/connection.rs
@@ -665,7 +665,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
+			Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -781,7 +781,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
+			Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
+			Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1221,7 +1221,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
+			Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
 		)
 		.await
 		.unwrap();
@@ -1375,7 +1375,7 @@ mod tests {
 			Default::default(),
 			Duration::from_secs(10),
 			false,
-			Arc::new(TokioResolver::builder_tokio().build().unwrap()),
+			Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
 		)
 		.await
 		.unwrap();

--- a/client/network-types/Cargo.toml
+++ b/client/network-types/Cargo.toml
@@ -17,15 +17,15 @@ name = "sc_network_types"
 path = "src/lib.rs"
 
 [dependencies]
-bs58 = "0.5.1"
+bs58 = { workspace = true }
 bytes = { workspace = true }
 litep2p = { workspace = true }
 log = { workspace = true }
-multiaddr = "0.18.1"
-multihash = { version = "0.19.1", default-features = false }
+multiaddr = { workspace = true }
+multihash = { workspace = true }
 rand = { workspace = true }
-serde_with = { version = "3.12.0", default-features = false, features = ["hex", "macros"] }
+serde_with = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-quickcheck = "1.0.3"
+quickcheck = { workspace = true }

--- a/client/network-types/src/multiaddr.rs
+++ b/client/network-types/src/multiaddr.rs
@@ -20,7 +20,8 @@ use litep2p::types::multiaddr::{
 	Error as LiteP2pError, Iter as LiteP2pIter, Multiaddr as LiteP2pMultiaddr,
 	Protocol as LiteP2pProtocol,
 };
-use multiaddr::Multiaddr as LibP2pMultiaddr;
+// Note: With multiaddr 0.17, LiteP2pMultiaddr and multiaddr::Multiaddr are the same type
+// (litep2p re-exports from the multiaddr crate), so we only need impls for one.
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{
 	fmt::{self, Debug, Display},
@@ -102,18 +103,6 @@ impl From<LiteP2pMultiaddr> for Multiaddr {
 impl From<Multiaddr> for LiteP2pMultiaddr {
 	fn from(multiaddr: Multiaddr) -> Self {
 		multiaddr.multiaddr
-	}
-}
-
-impl From<LibP2pMultiaddr> for Multiaddr {
-	fn from(multiaddr: LibP2pMultiaddr) -> Self {
-		multiaddr.into_iter().map(Into::into).collect()
-	}
-}
-
-impl From<Multiaddr> for LibP2pMultiaddr {
-	fn from(multiaddr: Multiaddr) -> Self {
-		multiaddr.into_iter().map(Into::into).collect()
 	}
 }
 

--- a/client/network-types/src/multiaddr/protocol.rs
+++ b/client/network-types/src/multiaddr/protocol.rs
@@ -18,15 +18,13 @@
 
 use crate::multihash::Multihash;
 use litep2p::types::multiaddr::Protocol as LiteP2pProtocol;
-use multiaddr::{PeerId as MultiAddrPeerId, Protocol as LibP2pProtocol};
+// Note: With multiaddr 0.17, LiteP2pProtocol and multiaddr::Protocol are the same type
+// (litep2p re-exports from the multiaddr crate), so we only need impls for one.
 use std::{
 	borrow::Cow,
 	fmt::{self, Debug, Display},
 	net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
-
-// Log target for this file.
-const LOG_TARGET: &str = "sub-libp2p";
 
 /// [`Protocol`] describes all possible multiaddress protocols.
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -169,122 +167,6 @@ impl<'a> From<Protocol<'a>> for LiteP2pProtocol<'a> {
 			Protocol::Utp => LiteP2pProtocol::Utp,
 			Protocol::Ws(str) => LiteP2pProtocol::Ws(str),
 			Protocol::Wss(str) => LiteP2pProtocol::Wss(str),
-		}
-	}
-}
-
-impl<'a> From<LibP2pProtocol<'a>> for Protocol<'a> {
-	fn from(protocol: LibP2pProtocol<'a>) -> Self {
-		match protocol {
-			LibP2pProtocol::Dccp(port) => Protocol::Dccp(port),
-			LibP2pProtocol::Dns(str) => Protocol::Dns(str),
-			LibP2pProtocol::Dns4(str) => Protocol::Dns4(str),
-			LibP2pProtocol::Dns6(str) => Protocol::Dns6(str),
-			LibP2pProtocol::Dnsaddr(str) => Protocol::Dnsaddr(str),
-			LibP2pProtocol::Http => Protocol::Http,
-			LibP2pProtocol::Https => Protocol::Https,
-			LibP2pProtocol::Ip4(ipv4_addr) => Protocol::Ip4(ipv4_addr),
-			LibP2pProtocol::Ip6(ipv6_addr) => Protocol::Ip6(ipv6_addr),
-			LibP2pProtocol::P2pWebRtcDirect => Protocol::P2pWebRtcDirect,
-			LibP2pProtocol::P2pWebRtcStar => Protocol::P2pWebRtcStar,
-			LibP2pProtocol::Certhash(multihash) => Protocol::Certhash(multihash.into()),
-			LibP2pProtocol::P2pWebSocketStar => Protocol::P2pWebSocketStar,
-			LibP2pProtocol::Memory(port) => Protocol::Memory(port),
-			LibP2pProtocol::Onion(str, port) => Protocol::Onion(str, port),
-			LibP2pProtocol::Onion3(addr) => Protocol::Onion3(Cow::Owned(*addr.hash()), addr.port()),
-			LibP2pProtocol::P2p(peer_id) => Protocol::P2p((*peer_id.as_ref()).into()),
-			LibP2pProtocol::P2pCircuit => Protocol::P2pCircuit,
-			LibP2pProtocol::Quic => Protocol::Quic,
-			LibP2pProtocol::QuicV1 => Protocol::QuicV1,
-			LibP2pProtocol::Sctp(port) => Protocol::Sctp(port),
-			LibP2pProtocol::Tcp(port) => Protocol::Tcp(port),
-			LibP2pProtocol::Tls => Protocol::Tls,
-			LibP2pProtocol::Noise => Protocol::Noise,
-			LibP2pProtocol::Udp(port) => Protocol::Udp(port),
-			LibP2pProtocol::Udt => Protocol::Udt,
-			LibP2pProtocol::Unix(str) => Protocol::Unix(str),
-			LibP2pProtocol::Utp => Protocol::Utp,
-			LibP2pProtocol::Ws(str) => Protocol::Ws(str),
-			LibP2pProtocol::Wss(str) => Protocol::Wss(str),
-			protocol => {
-				log::error!(
-					target: LOG_TARGET,
-					"Got unsupported multiaddr protocol '{}'",
-					protocol.tag(),
-				);
-				// Strictly speaking, this conversion is incorrect. But making protocol conversion
-				// fallible would significantly complicate the client code. As DCCP transport is not
-				// used by substrate, this conversion should be safe.
-				// Also, as of `multiaddr-18.1`, all enum variants are actually covered.
-				Protocol::Dccp(0)
-			},
-		}
-	}
-}
-
-impl<'a> From<Protocol<'a>> for LibP2pProtocol<'a> {
-	fn from(protocol: Protocol<'a>) -> Self {
-		match protocol {
-			Protocol::Dccp(port) => LibP2pProtocol::Dccp(port),
-			Protocol::Dns(str) => LibP2pProtocol::Dns(str),
-			Protocol::Dns4(str) => LibP2pProtocol::Dns4(str),
-			Protocol::Dns6(str) => LibP2pProtocol::Dns6(str),
-			Protocol::Dnsaddr(str) => LibP2pProtocol::Dnsaddr(str),
-			Protocol::Http => LibP2pProtocol::Http,
-			Protocol::Https => LibP2pProtocol::Https,
-			Protocol::Ip4(ipv4_addr) => LibP2pProtocol::Ip4(ipv4_addr),
-			Protocol::Ip6(ipv6_addr) => LibP2pProtocol::Ip6(ipv6_addr),
-			Protocol::P2pWebRtcDirect => LibP2pProtocol::P2pWebRtcDirect,
-			Protocol::P2pWebRtcStar => LibP2pProtocol::P2pWebRtcStar,
-			// Protocol #280 is called `WebRTC` in multiaddr-17.0 and `WebRTCDirect` in
-			// multiaddr-18.1.
-			Protocol::WebRTC => LibP2pProtocol::WebRTCDirect,
-			Protocol::Certhash(multihash) => LibP2pProtocol::Certhash(multihash.into()),
-			Protocol::P2pWebSocketStar => LibP2pProtocol::P2pWebSocketStar,
-			Protocol::Memory(port) => LibP2pProtocol::Memory(port),
-			Protocol::Onion(str, port) => LibP2pProtocol::Onion(str, port),
-			Protocol::Onion3(str, port) => LibP2pProtocol::Onion3((str.into_owned(), port).into()),
-			Protocol::P2p(multihash) => {
-				LibP2pProtocol::P2p(
-					MultiAddrPeerId::from_multihash(multihash.into()).unwrap_or_else(|mh| {
-						// This is better than making conversion fallible and complicating the
-						// client code.
-						log::error!(
-							target: LOG_TARGET,
-							"Received multiaddr with p2p multihash which is not a valid \
-							 peer_id. Using the multihash directly as identity."
-						);
-						// Create a peer ID from the invalid multihash - this will at least preserve
-						// some uniqueness for debugging. The underlying multiaddr will be invalid
-						// but this path should rarely be hit in practice.
-						let bytes = mh.to_bytes();
-						MultiAddrPeerId::from_bytes(&bytes).unwrap_or_else(|_| {
-							// Last resort: generate from random bytes using identity hash
-							use rand::RngCore;
-							let mut random_bytes = [0u8; 32];
-							rand::thread_rng().fill_bytes(&mut random_bytes);
-							// Use identity multihash (code 0x00) with 32 random bytes
-							let identity_mh = multihash::Multihash::<64>::wrap(0x00, &random_bytes)
-								.expect("identity hash with 32 bytes always fits");
-							MultiAddrPeerId::from_multihash(identity_mh)
-								.expect("identity multihash is valid peer id")
-						})
-					}),
-				)
-			},
-			Protocol::P2pCircuit => LibP2pProtocol::P2pCircuit,
-			Protocol::Quic => LibP2pProtocol::Quic,
-			Protocol::QuicV1 => LibP2pProtocol::QuicV1,
-			Protocol::Sctp(port) => LibP2pProtocol::Sctp(port),
-			Protocol::Tcp(port) => LibP2pProtocol::Tcp(port),
-			Protocol::Tls => LibP2pProtocol::Tls,
-			Protocol::Noise => LibP2pProtocol::Noise,
-			Protocol::Udp(port) => LibP2pProtocol::Udp(port),
-			Protocol::Udt => LibP2pProtocol::Udt,
-			Protocol::Unix(str) => LibP2pProtocol::Unix(str),
-			Protocol::Utp => LibP2pProtocol::Utp,
-			Protocol::Ws(str) => LibP2pProtocol::Ws(str),
-			Protocol::Wss(str) => LibP2pProtocol::Wss(str),
 		}
 	}
 }

--- a/client/network-types/src/multihash.rs
+++ b/client/network-types/src/multihash.rs
@@ -156,20 +156,8 @@ impl From<Multihash> for LiteP2pMultihash {
 	}
 }
 
-impl From<multihash::Multihash<64>> for Multihash {
-	fn from(generic: multihash::Multihash<64>) -> Self {
-		LiteP2pMultihash::wrap(generic.code(), generic.digest())
-			.expect("both have size 64; qed")
-			.into()
-	}
-}
-
-impl From<Multihash> for multihash::Multihash<64> {
-	fn from(multihash: Multihash) -> Self {
-		multihash::Multihash::<64>::wrap(multihash.code(), multihash.digest())
-			.expect("both have size 64; qed")
-	}
-}
+// Note: In multihash 0.17, LiteP2pMultihash is the same as multihash::Multihash (type alias from
+// Code derive) so these From impls are redundant as both are already handled above.
 
 #[cfg(test)]
 mod tests {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -51,8 +51,8 @@ rand = { workspace = true, default-features = false, features = [
 	"alloc",
 	"getrandom",
 ] }
-rcgen = "0.13"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rcgen = { workspace = true }
+rustls = { workspace = true }
 sc-basic-authorship.default-features = true
 sc-basic-authorship.workspace = true
 sc-cli.default-features = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -51,8 +51,8 @@ rand = { workspace = true, default-features = false, features = [
 	"alloc",
 	"getrandom",
 ] }
-rcgen = "0.11"
-rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "quic"] }
+rcgen = "0.13"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 sc-basic-authorship.default-features = true
 sc-basic-authorship.workspace = true
 sc-cli.default-features = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -46,7 +46,7 @@ qp-wormhole.workspace = true
 qpow-math.workspace = true
 quantus-miner-api = { workspace = true }
 quantus-runtime.workspace = true
-quinn = "0.10"
+quinn.workspace = true
 rand = { workspace = true, default-features = false, features = [
 	"alloc",
 	"getrandom",

--- a/node/src/miner_server.rs
+++ b/node/src/miner_server.rs
@@ -152,25 +152,26 @@ async fn create_server_endpoint(port: u16) -> Result<quinn::Endpoint, String> {
 	let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
 		.map_err(|e| format!("Failed to generate certificate: {}", e))?;
 
-	let cert_der = cert
-		.serialize_der()
-		.map_err(|e| format!("Failed to serialize certificate: {}", e))?;
-	let key_der = cert.serialize_private_key_der();
+	let cert_der = rustls::pki_types::CertificateDer::from(cert.cert);
+	let key_der = rustls::pki_types::PrivateKeyDer::try_from(cert.key_pair.serialize_der())
+		.map_err(|e| format!("Failed to serialize private key: {}", e))?;
 
-	let cert_chain = vec![rustls::Certificate(cert_der)];
-	let key = rustls::PrivateKey(key_der);
+	let cert_chain = vec![cert_der];
 
 	// Create server config
 	let mut server_config = rustls::ServerConfig::builder()
-		.with_safe_defaults()
 		.with_no_client_auth()
-		.with_single_cert(cert_chain, key)
+		.with_single_cert(cert_chain, key_der)
 		.map_err(|e| format!("Failed to create server config: {}", e))?;
 
 	// Set ALPN protocol
 	server_config.alpn_protocols = vec![b"quantus-miner".to_vec()];
 
-	let mut quinn_config = quinn::ServerConfig::with_crypto(Arc::new(server_config));
+	// Wrap in QuicServerConfig for quinn 0.11+
+	let quic_server_config = quinn::crypto::rustls::QuicServerConfig::try_from(server_config)
+		.map_err(|e| format!("Failed to create QUIC server config: {}", e))?;
+
+	let mut quinn_config = quinn::ServerConfig::with_crypto(Arc::new(quic_server_config));
 
 	// Set transport config
 	let mut transport_config = quinn::TransportConfig::default();

--- a/pallets/frame-system/Cargo.toml
+++ b/pallets/frame-system/Cargo.toml
@@ -22,18 +22,18 @@ name = "bench"
 path = "benches/bench.rs"
 
 [dependencies]
-cfg-if = "1.0"
+cfg-if = { workspace = true }
 codec = { workspace = true, default-features = false, features = ["derive"] }
 docify = { workspace = true }
-frame-support = { version = "45.0.0", default-features = false }
+frame-support = { workspace = true }
 log = { workspace = true, default-features = false }
 qp-header = { path = "../../primitives/header", default-features = false, features = ["serde"] }
-scale-info = { version = "2.11.6", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, features = ["derive", "serde"] }
 serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 sp-core = { workspace = true, default-features = false, features = ["serde"] }
 sp-io = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false, features = ["serde"] }
-sp-version = { version = "43.0.0", default-features = false, features = ["serde"] }
+sp-version = { workspace = true, features = ["serde"] }
 sp-weights = { workspace = true, default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -111,6 +111,7 @@ impl pallet_assets::Config for Test {
 	type CallbackHandle = ();
 	type Holder = ();
 	type ReserveData = ();
+	type BenchmarkHelper = ();
 }
 
 parameter_types! {

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -111,6 +111,7 @@ impl pallet_assets::Config for Test {
 	type CallbackHandle = ();
 	type Holder = ();
 	type ReserveData = ();
+	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
 

--- a/patches/frame-storage-access-test-runtime/Cargo.toml
+++ b/patches/frame-storage-access-test-runtime/Cargo.toml
@@ -11,7 +11,8 @@ runtime-benchmarks = []
 std = []
 
 [dependencies]
-codec = { workspace = true, features = ["derive"] }
+# Use actual crate name so derive macros can find it
+parity-scale-codec = { version = "3.6.12", default-features = false, features = ["derive"] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-trie = { workspace = true }

--- a/patches/frame-storage-access-test-runtime/Cargo.toml
+++ b/patches/frame-storage-access-test-runtime/Cargo.toml
@@ -11,7 +11,7 @@ runtime-benchmarks = []
 std = []
 
 [dependencies]
-codec = { version = "3.7.5", features = ["derive"], default-features = false, package = "parity-scale-codec" }
-sp-core = { version = "39.0.0", default-features = false }
-sp-runtime = { version = "45.0.0", default-features = false }
-sp-trie = { version = "42.0.0", default-features = false }
+codec = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-trie = { workspace = true }

--- a/patches/frame-storage-access-test-runtime/src/lib.rs
+++ b/patches/frame-storage-access-test-runtime/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use codec::Decode;
+use parity_scale_codec::Decode;
 use sp_core::storage::ChildInfo;
 use sp_runtime::traits;
 use sp_trie::StorageProof;
@@ -12,7 +12,7 @@ use sp_trie::StorageProof;
 pub const WASM_BINARY: Option<&[u8]> = None;
 
 #[derive(Decode, Clone)]
-#[cfg_attr(feature = "std", derive(codec::Encode))]
+#[cfg_attr(feature = "std", derive(parity_scale_codec::Encode))]
 pub struct StorageAccessParams<B: traits::Block> {
 	pub state_root: B::Hash,
 	pub storage_proof: StorageProof,
@@ -20,7 +20,7 @@ pub struct StorageAccessParams<B: traits::Block> {
 	pub is_dry_run: bool,
 }
 
-#[derive(Debug, Clone, Decode, codec::Encode)]
+#[derive(Debug, Clone, Decode, parity_scale_codec::Encode)]
 pub enum StorageAccessPayload {
 	Read(Vec<(Vec<u8>, Option<ChildInfo>)>),
 	Write((Vec<(Vec<u8>, Vec<u8>)>, Option<ChildInfo>)),

--- a/qpow-math/Cargo.toml
+++ b/qpow-math/Cargo.toml
@@ -5,12 +5,12 @@ version = "0.1.0"
 
 [dependencies]
 hex = { workspace = true, features = ["alloc"] }
-log = { version = "0.4.22", default-features = false }
-primitive-types = { version = "0.13.1", default-features = false }
+log = { workspace = true }
+primitive-types = { workspace = true }
 qp-poseidon-core = { workspace = true }
 
 [dev-dependencies]
-proptest = "1"
+proptest = { workspace = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
upgraded some other packages to reduce (not eliminate) various cargo audit issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P DNS resolution and the miner QUIC/TLS path; dependency major/minor bumps could affect connectivity or certificate handling at runtime.
> 
> **Overview**
> Bumps **Quantus rusty-crystals** crates (`qp-rusty-crystals-hdwallet` 2.4.0, dilithium 2.5.0 in the lockfile) and aligns related crypto/DNS deps (`qp-poseidon-core` 2.1.0 only, `x509-parser` 0.18.1, `hickory-resolver` 0.26.1).
> 
> **litep2p** is updated for Hickory 0.26: resolver construction drops `TokioConnectionProvider`, treats `TokioResolver::build()` as fallible, and broadens `CannotReadSystemDnsConfig` to a boxed error. Tests mirror the same builder pattern.
> 
> The **node miner QUIC server** moves to **quinn 0.11** with **rustls 0.23** and **rcgen 0.13**—self-signed TLS material uses `rustls::pki_types`, and the endpoint is created via `QuicServerConfig::try_from`. Workspace **quinn** is pinned at 0.11.9 and older quinn/rustls 0.21 stacks are removed from the lockfile to reduce `cargo audit` noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c82dcb3536eca16b1d211bf336dc0866a4310ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->