### PR TITLE
ci: Dilithium version bump to dilithium-v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "qp-dilithium-crypto"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ pallet-reversible-transfers = { path = "./pallets/reversible-transfers", default
 pallet-scheduler = { path = "./pallets/scheduler", default-features = false }
 pallet-wormhole = { path = "./pallets/wormhole", default-features = false }
 pallet-zk-tree = { path = "./pallets/zk-tree", default-features = false }
-qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.3.1", default-features = false }
+qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.4.0", default-features = false }
 qp-header = { path = "./primitives/header", default-features = false }
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }

--- a/primitives/dilithium-crypto/Cargo.toml
+++ b/primitives/dilithium-crypto/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 name = "qp-dilithium-crypto"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/chain"
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies]
 codec = { workspace = true, default-features = false }


### PR DESCRIPTION
## Dilithium Crypto Release Proposal

This PR proposes releasing **qp-dilithium-crypto** version `0.4.0`.

### Changes
- Updated `primitives/dilithium-crypto/Cargo.toml` version to `0.4.0`
- Updated `Cargo.toml` workspace dependency version to `0.4.0`
- Updated `Cargo.lock`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no cryptographic or runtime code modifications; consumers still resolve the same path dependency until a separate release ships behavioral changes.
> 
> **Overview**
> Bumps **`qp-dilithium-crypto`** from **0.3.1** to **0.4.0** for the upcoming crates.io release.
> 
> The crate version in `primitives/dilithium-crypto/Cargo.toml`, the workspace pin in root `Cargo.toml`, and `Cargo.lock` are updated together. There are **no API or implementation changes** in this diff—only version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3124d7310f18a70234a85dfdd905d50686d86b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->