### PR TITLE
ci: Miner API version bump to quantus-miner-api-v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-miner-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ qp-header = { path = "./primitives/header", default-features = false }
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }
 qpow-math = { path = "./qpow-math", default-features = false }
-quantus-miner-api = { path = "./miner-api", version = "0.1.0", default-features = false }
+quantus-miner-api = { path = "./miner-api", version = "0.2.0", default-features = false }
 quantus-runtime = { path = "./runtime", default-features = false }
 sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
 sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = false }

--- a/miner-api/Cargo.toml
+++ b/miner-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 license.workspace = true
 name = "quantus-miner-api"
 repository.workspace = true
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 serde = { workspace = true, features = ["alloc", "derive"] }


### PR DESCRIPTION
## Miner API Release Proposal

This PR proposes releasing **quantus-miner-api** version `0.2.0`.

### Changes
- Updated `miner-api/Cargo.toml` version to `0.2.0`
- Updated `Cargo.toml` workspace dependency version to `0.2.0`
- Updated `Cargo.lock`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no runtime or API code modifications; main risk is consumers pinning the new crate version after publish.
> 
> **Overview**
> Bumps **`quantus-miner-api`** from **0.1.0** to **0.2.0** for a miner API crate release.
> 
> The package version in `miner-api/Cargo.toml`, the workspace `quantus-miner-api` dependency in the root `Cargo.toml`, and `Cargo.lock` are updated together so the workspace stays aligned for tagging and crates.io publish (per the miner-api release workflow). **No library source or API changes** appear in this diff—only versioning metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2791a718be82beef3c0e8a3d42bf34073a4548. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->