### PR TITLE
Automate release for v0.7.0-qday

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.6.5-penestanan"
+version = "0.7.0-qday"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.6.5-penestanan"
+version = "0.7.0-qday"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.6.5-penestanan"
+version = "0.7.0-qday"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.6.5-penestanan"
+version = "0.7.0-qday"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 129,
+	spec_version: 130,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.7.0-qday.

https://github.com/Quantus-Network/chain/actions/runs/27250726689

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and spec_version metadata only; no functional code changes in the diff.
> 
> **Overview**
> Automated **v0.7.0-qday** release bump from `0.6.5-penestanan`, with no application or runtime logic changes in the diff.
> 
> **`quantus-node`** and **`quantus-runtime`** crate versions are updated in their `Cargo.toml` files and reflected in **`Cargo.lock`**. On-chain runtime identity is bumped via **`spec_version`** **129 → 130** in `runtime/src/lib.rs` so nodes and tooling treat this as a new runtime spec for upgrades and compatibility checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75711d21b130f202ff97c7b08b99234ab287606f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->