### PR TITLE
fix: use system DNS resolver in litep2p backend

### DIFF
--- a/client/network/src/litep2p/mod.rs
+++ b/client/network/src/litep2p/mod.rs
@@ -324,6 +324,7 @@ impl Litep2pNetworkBackend {
 			.unzip();
 
 		config_builder
+			.with_system_resolver()
 			.with_websocket(WebSocketTransportConfig {
 				listen_addresses: websocket.into_iter().flatten().map(Into::into).collect(),
 				yamux_config: litep2p::yamux::Config::default(),


### PR DESCRIPTION
hickory-resolver 0.26 (bumped in #581) changed `ResolverConfig::default()` to an empty config with no nameservers, so all `/dns/...` bootnode and telemetry dials fail silently with `NoConnections` (0 peers). Use the system DNS config instead; startup now fails loudly if it can't be read.