### PR TITLE
Automate release for v0.7.1-q-day-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.7.0-qday"
+version = "0.7.1-q-day-2"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.7.0-qday"
+version = "0.7.1-q-day-2"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.7.0-qday"
+version = "0.7.1-q-day-2"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.7.0-qday"
+version = "0.7.1-q-day-2"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 130,
+	spec_version: 131,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.7.1-q-day-2.

https://github.com/Quantus-Network/chain/actions/runs/27258892910

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and spec_version-only changes with no functional code modifications; standard low-risk release metadata bump.
> 
> **Overview**
> Automated **v0.7.1-q-day-2** release bump from the patch workflow.
> 
> **quantus-node** and **quantus-runtime** package versions move from `0.7.0-qday` to `0.7.1-q-day-2` in `node/Cargo.toml`, `runtime/Cargo.toml`, and `Cargo.lock`. On-chain/runtime identity is bumped via **`spec_version` 130 → 131** in `runtime/src/lib.rs`; no pallet or business-logic changes appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b063c28b84d5a4ecbe802c7c6abc8f342c73be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->