### PR TITLE
Governance settings update

### DIFF
--- a/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
+++ b/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
@@ -6,27 +6,27 @@ Scope: the runtime-upgrade track (`TechReferenda` = `pallet_referenda::Pallet<Ru
 
 All periods are in blocks. `runtime/src/lib.rs:84-89`: `TARGET_BLOCK_TIME_MS = 12_000`, so `MINUTES = 5`, `HOURS = 300`, `DAYS = 7200` blocks.
 
-Track definition: `runtime/src/governance/definitions.rs:165-188` (`TechCollectiveTracksInfo::create_tech_collective_tracks`):
+Track definition: `runtime/src/governance/definitions.rs:165-192` (`TechCollectiveTracksInfo::create_tech_collective_tracks`):
 
 ```rust
 max_deciding: 1,
 decision_deposit: 1000 * UNIT,
 prepare_period: 20,
 decision_period: DAYS,
-confirm_period: 20,
-min_enactment_period: 20,
+confirm_period: DAYS,
+min_enactment_period: DAYS,
 ```
 
 | Parameter | Current (blocks) | Wall clock | Meaning |
 |---|---|---|---|
 | `prepare_period` | 20 | 4 min | Delay between submission and decision start |
 | `decision_period` | 7200 (`DAYS`) | 24 h | Window in which the referendum must reach passing state |
-| `confirm_period` | 20 | 4 min | Must remain continuously passing this long to be approved |
-| `min_enactment_period` | 20 | 4 min | Min delay between approval and dispatch of the upgrade |
+| `confirm_period` | 7200 (`DAYS`) | 24 h | Must remain continuously passing this long to be approved |
+| `min_enactment_period` | 7200 (`DAYS`) | 24 h | Min delay between approval and dispatch of the upgrade |
 
-To change approval duration, edit these four fields in `definitions.rs:170-173`. Any change is a runtime upgrade: bump `spec_version` (`runtime/src/lib.rs:76`, currently 131) and ship via this same track.
+To change approval duration, edit these four fields in `definitions.rs:174-177`. Any change is a runtime upgrade: it only takes effect once shipped via this same track (the release workflow bumps `spec_version`, `runtime/src/lib.rs:76`, currently 131).
 
-Test override: with the `fast-governance` cargo feature, `apply_test_timing` (`definitions.rs:86-95`) forces all four periods to 2 blocks. Production builds never compile it.
+Test override: with the `fast-governance` cargo feature, `apply_test_timing` (`definitions.rs:87-95`) forces all four periods to 2 blocks. Production builds never compile it.
 
 Instance1 `Config` (`runtime/src/configs/mod.rs:335-377`) also uses, from `configs/mod.rs:263-264`:
 
@@ -48,13 +48,13 @@ fn approval(&self, _) -> Perbill { Perbill::from_rational(self.ayes, 1.max(self.
 ```
 
 - **approval** = weighted ayes / (ayes + nays) — abstainers excluded.
-- **support** = `bare_ayes` (head-count of aye voters, unweighted) / total members of the class. `get_max_voters` returns `MemberCount[MinRankOfClass]` (lib.rs:266-271); `MinRankOfClassConverter` always returns rank 0 (`definitions.rs:234-239`), so the denominator is the full membership. Nay votes do not add support; abstention counts against support.
+- **support** = `bare_ayes` (head-count of aye voters, unweighted) / total members of the class. `get_max_voters` returns `MemberCount[MinRankOfClass]` (lib.rs:266-271); `MinRankOfClassConverter` always returns rank 0 (`definitions.rs:238-243`), so the denominator is the full membership. Nay votes do not add support; abstention counts against support.
 - **vote weight**: `type VoteWeight = Linear` (`configs/mod.rs:326`) = `excess_rank + 1` votes (lib.rs:236-241). `PromoteOrigin = NeverEnsureOrigin` (`configs/mod.rs:320`), so every member stays at rank 0 → exactly 1 vote each, and weighted `ayes == bare_ayes`.
 - **passing is inclusive**: `y >= self.threshold(x)` (`pallet-referenda-45.0.0/src/types.rs:637-639`). Therefore a threshold of exactly 60% would let 3 aye / 2 nay pass (60% ≥ 60%). `min_approval` must be strictly above 3/5.
 
-### Proposed curves (constant; `floor == ceil` makes `LinearDecreasing` flat)
+### Current curves (constant; `floor == ceil` makes `LinearDecreasing` flat)
 
-Replace `definitions.rs:174-183` with:
+Implemented at `definitions.rs:178-187`:
 
 ```rust
 min_approval: pallet_referenda::Curve::LinearDecreasing {
@@ -85,7 +85,7 @@ Requirements: (a) 3/5 ayes execute ✓ (rows 1–2); (b) 2 nays block ✓ (row 3
 
 ### Confirm/decision periods are security parameters
 
-A referendum must be *continuously* passing for the whole `confirm_period`; any nay that drops it below threshold aborts confirmation (`ConfirmAborted`, `pallet-referenda-45.0.0/src/lib.rs:1235-1240`) and confirmation must restart. Approval only happens at `lib.rs:1190-1208` after the confirm deadline elapses while still passing. So `confirm_period` is the honest members' reaction window: with the current 20 blocks (4 min), 3 compromised keys could submit 3 ayes and be irreversibly approved before anyone reacts. Recommend ≥ `DAYS` (24 h) for `confirm_period` and keeping `decision_period` ≥ several days on mainnet. `prepare_period` (currently 4 min) similarly bounds advance notice before deciding starts and should be hours at minimum.
+A referendum must be *continuously* passing for the whole `confirm_period`; any nay that drops it below threshold aborts confirmation (`ConfirmAborted`, `pallet-referenda-45.0.0/src/lib.rs:1235-1240`) and confirmation must restart. Approval only happens at `lib.rs:1190-1208` after the confirm deadline elapses while still passing. So `confirm_period` is the honest members' reaction window: at the current 24 h, even if all ayes land in the first block, approval cannot conclude before a full day has passed — dissenting nays always have that window. Worst case (ayes arrive at the end of the decision window) approval takes up to ~48 h; if the referendum is not passing when `decision_period` ends and is not confirming, it is rejected. `prepare_period` (currently 4 min) bounds advance notice before deciding starts and could be raised to hours on mainnet.
 
 ## 3. Vote changing
 
@@ -117,13 +117,13 @@ type KillOrigin = EnsureRoot<AccountId>;
 - `cancel` (`pallet-referenda-45.0.0/src/lib.rs:591-606`): stops an ongoing referendum, **refunds** submission + decision deposits.
 - `kill` (`lib.rs:616-630`): stops it and **slashes** both deposits (`Slash = ()` → burned, `configs/mod.rs:356`).
 
-Both are Root-only. Root is only reachable via a passed referendum, so cancelling a malicious tech referendum requires winning *another* referendum on the same track before the first one enacts — a chicken-and-egg problem, made worse by `max_deciding: 1` (`definitions.rs:168`): a second referendum cannot even enter deciding until the first leaves it. During an attack the practical defense is votes (2 honest nays), not cancellation. Recommendation: give `CancelOrigin` to a smaller quorum (e.g. `EnsureRoot` OR a 2-of-5 ranked-collective origin via `EitherOf<EnsureRoot<...>, EnsureRankedMember<...>>`-style construct, or a dedicated fast cancel track), keep `kill` Root-only.
+Both are Root-only. Root is only reachable via a passed referendum, so cancelling a malicious tech referendum requires winning *another* referendum on the same track before the first one enacts — a chicken-and-egg problem, made worse by `max_deciding: 1` (`definitions.rs:172`): a second referendum cannot even enter deciding until the first leaves it. During an attack the practical defense is votes (2 honest nays), not cancellation. Recommendation: give `CancelOrigin` to a smaller quorum (e.g. `EnsureRoot` OR a 2-of-5 ranked-collective origin via `EitherOf<EnsureRoot<...>, EnsureRankedMember<...>>`-style construct, or a dedicated fast cancel track), keep `kill` Root-only.
 
-Member removal mid-flight: `remove_member` (`pallet-ranked-collective-45.0.0/src/lib.rs:600-617`) requires `RemoveOrigin`, which this runtime sets to `RootOrMemberForCollectiveOrigin` (`configs/mod.rs:319`) — **Root or any single collective member** (`definitions.rs:262-283`). `AddOrigin` (line 318) is the same. This is currently the weakest link: one compromised member can unilaterally remove the other four (all rank 0, so the `max_rank >= rank` check at lib.rs:609 always passes) or stuff the collective up to `MaxMemberCount = 13`, invalidating all threshold math above. For mainnet, membership changes must require Root (i.e. a passed referendum) or an equivalent quorum.
+Member removal mid-flight: `remove_member` (`pallet-ranked-collective-45.0.0/src/lib.rs:600-617`) requires `RemoveOrigin`, which this runtime sets to `RootOrMemberForCollectiveOrigin` (`configs/mod.rs:319`) — **Root or any single collective member** (`definitions.rs:266-287`). `AddOrigin` (line 318) is the same. This is currently the weakest link: one compromised member can unilaterally remove the other four (all rank 0, so the `max_rank >= rank` check at lib.rs:609 always passes) or stuff the collective up to `MaxMemberCount = 13`, invalidating all threshold math above. For mainnet, membership changes must require Root (i.e. a passed referendum) or an equivalent quorum.
 
 Removal does **not** touch ongoing tallies: `do_remove_member_from_rank` (lib.rs:886-892) clears member indices only — cast votes stay counted, but the support denominator `MemberCount[0]` shrinks immediately, *raising* the support percentage of remaining ayes (e.g. after removing 2 of 5 members, 3 ayes = 100% support). Membership changes during a live referendum therefore shift its outcome.
 
-## 5. Security summary (proposed 5-member config: approval 61%, support 60%)
+## 5. Security summary (current 5-member config: approval 61%, support 60%)
 
 Assumes membership management is fixed to Root-only (see §4); with the current any-member `RemoveOrigin`, none of the rows below hold.
 
@@ -134,4 +134,4 @@ Assumes membership management is fixed to Root-only (see §4); with the current 
 | 3 | Yes | **Only if** fewer than 2 honest nays land within decision + confirm window (3a/0n and 3a/1n pass; 3a/2n fails) |
 | 4 | Yes | **Yes, always** (4a/1n = 80% approval) |
 
-Design assumption: at least 2 honest members are online and able to vote nay within `decision_period + confirm_period`. That window is currently 24 h + 4 min — the 4-minute confirm period is the binding constraint and should be raised to hours/days before mainnet.
+Design assumption: at least 2 honest members are online and able to vote nay within `decision_period + confirm_period`. That window is 24 h + 24 h: even in the fastest case (all ayes in the first block of deciding), honest members have a full 24 h confirm window to abort.

--- a/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
+++ b/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
@@ -1,0 +1,137 @@
+# Tech Collective Governance Tuning (Mainnet Parameters)
+
+Scope: the runtime-upgrade track (`TechReferenda` = `pallet_referenda::Pallet<Runtime, Instance1>` + `TechCollective` = `pallet_ranked_collective`). Sources verified against the runtime and crate sources `pallet-referenda-45.0.0` / `pallet-ranked-collective-45.0.0` (cargo registry; not vendored in `pallets/`).
+
+## 1. Timing
+
+All periods are in blocks. `runtime/src/lib.rs:84-89`: `TARGET_BLOCK_TIME_MS = 12_000`, so `MINUTES = 5`, `HOURS = 300`, `DAYS = 7200` blocks.
+
+Track definition: `runtime/src/governance/definitions.rs:165-188` (`TechCollectiveTracksInfo::create_tech_collective_tracks`):
+
+```rust
+max_deciding: 1,
+decision_deposit: 1000 * UNIT,
+prepare_period: 20,
+decision_period: DAYS,
+confirm_period: 20,
+min_enactment_period: 20,
+```
+
+| Parameter | Current (blocks) | Wall clock | Meaning |
+|---|---|---|---|
+| `prepare_period` | 20 | 4 min | Delay between submission and decision start |
+| `decision_period` | 7200 (`DAYS`) | 24 h | Window in which the referendum must reach passing state |
+| `confirm_period` | 20 | 4 min | Must remain continuously passing this long to be approved |
+| `min_enactment_period` | 20 | 4 min | Min delay between approval and dispatch of the upgrade |
+
+To change approval duration, edit these four fields in `definitions.rs:170-173`. Any change is a runtime upgrade: bump `spec_version` (`runtime/src/lib.rs:76`, currently 131) and ship via this same track.
+
+Test override: with the `fast-governance` cargo feature, `apply_test_timing` (`definitions.rs:86-95`) forces all four periods to 2 blocks. Production builds never compile it.
+
+Instance1 `Config` (`runtime/src/configs/mod.rs:335-377`) also uses, from `configs/mod.rs:263-264`:
+
+- `UndecidingTimeout = 45 * DAYS` (note: the comment at line 262 says "90 days" — the value is 45). If a referendum never enters deciding within this window (no decision deposit, or no free `max_deciding` slot), it is rejected as `TimedOut` (`pallet-referenda-45.0.0/src/lib.rs:1164-1177`).
+- `AlarmInterval = 1`: granularity of scheduler wake-ups that re-service referenda state. 1 = state transitions (begin/abort confirmation, approve, reject) can happen on any block.
+
+Both constants are shared with the community-track instance (`impl pallet_referenda::Config for Runtime`, `configs/mod.rs:267-309`; tech track is the `Config<TechReferendaInstance>` impl at 335).
+
+## 2. Thresholds for a 5-member collective
+
+### Verified tally semantics
+
+`pallet-ranked-collective-45.0.0/src/lib.rs:97-136`:
+
+```rust
+pub struct Tally<T, I, M: GetMaxVoters> { bare_ayes: MemberIndex, ayes: Votes, nays: Votes, ... }
+fn support(&self, class) -> Perbill { Perbill::from_rational(self.bare_ayes, M::get_max_voters(class)) }
+fn approval(&self, _) -> Perbill { Perbill::from_rational(self.ayes, 1.max(self.ayes + self.nays)) }
+```
+
+- **approval** = weighted ayes / (ayes + nays) — abstainers excluded.
+- **support** = `bare_ayes` (head-count of aye voters, unweighted) / total members of the class. `get_max_voters` returns `MemberCount[MinRankOfClass]` (lib.rs:266-271); `MinRankOfClassConverter` always returns rank 0 (`definitions.rs:234-239`), so the denominator is the full membership. Nay votes do not add support; abstention counts against support.
+- **vote weight**: `type VoteWeight = Linear` (`configs/mod.rs:326`) = `excess_rank + 1` votes (lib.rs:236-241). `PromoteOrigin = NeverEnsureOrigin` (`configs/mod.rs:320`), so every member stays at rank 0 → exactly 1 vote each, and weighted `ayes == bare_ayes`.
+- **passing is inclusive**: `y >= self.threshold(x)` (`pallet-referenda-45.0.0/src/types.rs:637-639`). Therefore a threshold of exactly 60% would let 3 aye / 2 nay pass (60% ≥ 60%). `min_approval` must be strictly above 3/5.
+
+### Proposed curves (constant; `floor == ceil` makes `LinearDecreasing` flat)
+
+Replace `definitions.rs:174-183` with:
+
+```rust
+min_approval: pallet_referenda::Curve::LinearDecreasing {
+    length: Perbill::from_percent(100),
+    floor: Perbill::from_percent(61),   // strictly above 3/5
+    ceil: Perbill::from_percent(61),
+},
+min_support: pallet_referenda::Curve::LinearDecreasing {
+    length: Perbill::from_percent(100),
+    floor: Perbill::from_percent(60),   // 3 of 5 members must actively vote aye
+    ceil: Perbill::from_percent(60),
+},
+```
+
+(2/3 ≈ 66.7% for `min_approval` works identically for n=5; 61% is the loosest safe value. `Perbill::from_rational(3,5)` is exactly 600,000,000 < 610,000,000, so the comparison is exact, no rounding hazard.)
+
+### Verification, 5 members, all rank 0
+
+| Ayes | Nays | Approval = a/(a+n) | ≥61%? | Support = ayes/5 | ≥60%? | Result |
+|---|---|---|---|---|---|---|
+| 3 | 0 | 100% | yes | 60% | yes (inclusive) | **PASS** |
+| 3 | 1 | 75% | yes | 60% | yes | **PASS** |
+| 3 | 2 | 60% | **no** | 60% | yes | **FAIL** |
+| 4 | 1 | 80% | yes | 80% | yes | **PASS** |
+| 2 | 0 | 100% | yes | 40% | **no** | **FAIL** |
+
+Requirements: (a) 3/5 ayes execute ✓ (rows 1–2); (b) 2 nays block ✓ (row 3); (c) 1 bad member cannot block ✓ (row 2: passes despite 1 nay) nor push through alone (1 aye = 20% support); (d) against 1 honest nay, 3 compromised ayes fail (row 3 generalizes: 3a/2n fails, and 3a/1n passes — so blocking needs 2 honest nays; forcing through 2 honest nays needs 4 ayes, row 4) ✓.
+
+### Confirm/decision periods are security parameters
+
+A referendum must be *continuously* passing for the whole `confirm_period`; any nay that drops it below threshold aborts confirmation (`ConfirmAborted`, `pallet-referenda-45.0.0/src/lib.rs:1235-1240`) and confirmation must restart. Approval only happens at `lib.rs:1190-1208` after the confirm deadline elapses while still passing. So `confirm_period` is the honest members' reaction window: with the current 20 blocks (4 min), 3 compromised keys could submit 3 ayes and be irreversibly approved before anyone reacts. Recommend ≥ `DAYS` (24 h) for `confirm_period` and keeping `decision_period` ≥ several days on mainnet. `prepare_period` (currently 4 min) similarly bounds advance notice before deciding starts and should be hours at minimum.
+
+## 3. Vote changing
+
+**Yes — a member can flip their vote any time while the poll is Ongoing.** `pallet-ranked-collective-45.0.0/src/lib.rs:632-675` (`vote`): an existing vote is first subtracted from the tally, then the new vote is applied and overwrites `Voting`:
+
+```rust
+match Voting::<T, I>::get(&poll, &who) {
+    Some(Aye(votes)) => { tally.bare_ayes.saturating_dec(); tally.ayes.saturating_reduce(votes); },
+    Some(Nay(votes)) => tally.nays.saturating_reduce(votes),
+    None => pays = Pays::No,
+}
+...
+Voting::<T, I>::insert(&poll, &who, &vote);
+```
+
+The first vote on a poll is fee-free (`Pays::No`); changes pay a fee. Voting on `Completed`/missing polls fails with `NotPolling` (lib.rs:646-647). Consequence: an aye cast early can be flipped to nay during confirmation to abort it — this is what makes `confirm_period` an effective defense window.
+
+## 4. Cancellation and incident response
+
+Tech track Instance1 config, `runtime/src/configs/mod.rs:348-351`:
+
+```rust
+type CancelOrigin = EnsureRoot<AccountId>;
+type KillOrigin = EnsureRoot<AccountId>;
+```
+
+(The community instance is identical, `configs/mod.rs:280-283`.)
+
+- `cancel` (`pallet-referenda-45.0.0/src/lib.rs:591-606`): stops an ongoing referendum, **refunds** submission + decision deposits.
+- `kill` (`lib.rs:616-630`): stops it and **slashes** both deposits (`Slash = ()` → burned, `configs/mod.rs:356`).
+
+Both are Root-only. Root is only reachable via a passed referendum, so cancelling a malicious tech referendum requires winning *another* referendum on the same track before the first one enacts — a chicken-and-egg problem, made worse by `max_deciding: 1` (`definitions.rs:168`): a second referendum cannot even enter deciding until the first leaves it. During an attack the practical defense is votes (2 honest nays), not cancellation. Recommendation: give `CancelOrigin` to a smaller quorum (e.g. `EnsureRoot` OR a 2-of-5 ranked-collective origin via `EitherOf<EnsureRoot<...>, EnsureRankedMember<...>>`-style construct, or a dedicated fast cancel track), keep `kill` Root-only.
+
+Member removal mid-flight: `remove_member` (`pallet-ranked-collective-45.0.0/src/lib.rs:600-617`) requires `RemoveOrigin`, which this runtime sets to `RootOrMemberForCollectiveOrigin` (`configs/mod.rs:319`) — **Root or any single collective member** (`definitions.rs:262-283`). `AddOrigin` (line 318) is the same. This is currently the weakest link: one compromised member can unilaterally remove the other four (all rank 0, so the `max_rank >= rank` check at lib.rs:609 always passes) or stuff the collective up to `MaxMemberCount = 13`, invalidating all threshold math above. For mainnet, membership changes must require Root (i.e. a passed referendum) or an equivalent quorum.
+
+Removal does **not** touch ongoing tallies: `do_remove_member_from_rank` (lib.rs:886-892) clears member indices only — cast votes stay counted, but the support denominator `MemberCount[0]` shrinks immediately, *raising* the support percentage of remaining ayes (e.g. after removing 2 of 5 members, 3 ayes = 100% support). Membership changes during a live referendum therefore shift its outcome.
+
+## 5. Security summary (proposed 5-member config: approval 61%, support 60%)
+
+Assumes membership management is fixed to Root-only (see §4); with the current any-member `RemoveOrigin`, none of the rows below hold.
+
+| Compromised members | Can block upgrades? | Can force an upgrade? |
+|---|---|---|
+| 1 | No (3a/1n passes) | No (support 20% < 60%) |
+| 2 | **Yes** — 2 nays hold approval ≤60% < 61% (availability risk only) | No (support 40%) |
+| 3 | Yes | **Only if** fewer than 2 honest nays land within decision + confirm window (3a/0n and 3a/1n pass; 3a/2n fails) |
+| 4 | Yes | **Yes, always** (4a/1n = 80% approval) |
+
+Design assumption: at least 2 honest members are online and able to vote nay within `decision_period + confirm_period`. That window is currently 24 h + 4 min — the 4-minute confirm period is the binding constraint and should be raised to hours/days before mainnet.

--- a/runtime/src/governance/definitions.rs
+++ b/runtime/src/governance/definitions.rs
@@ -163,23 +163,27 @@ pub struct TechCollectiveTracksInfo;
 
 impl TechCollectiveTracksInfo {
 	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
+		// With 5 members: >=3 ayes required (support 60%), and 2 nays always block
+		// (3 ayes / 2 nays = 60% approval < 61%). Constant curves: thresholds don't
+		// decay over the decision period. The 24h confirm period guarantees nays can
+		// arrive for a full day before any approval; enactment is delayed another 24h.
 		let info = pallet_referenda::TrackInfo {
 			name: str_array("tech_collective_members"),
 			max_deciding: 1,
 			decision_deposit: 1000 * UNIT,
 			prepare_period: 20,
 			decision_period: DAYS,
-			confirm_period: 20,
-			min_enactment_period: 20,
+			confirm_period: DAYS,
+			min_enactment_period: DAYS,
 			min_approval: pallet_referenda::Curve::LinearDecreasing {
 				length: Perbill::from_percent(100),
-				floor: Perbill::from_percent(50),
-				ceil: Perbill::from_percent(100),
+				floor: Perbill::from_percent(61),
+				ceil: Perbill::from_percent(61),
 			},
 			min_support: pallet_referenda::Curve::LinearDecreasing {
 				length: Perbill::from_percent(100),
-				floor: Perbill::from_percent(0),
-				ceil: Perbill::from_percent(0),
+				floor: Perbill::from_percent(60),
+				ceil: Perbill::from_percent(60),
 			},
 		};
 		#[cfg(feature = "fast-governance")]

--- a/runtime/tests/governance/tech_collective.rs
+++ b/runtime/tests/governance/tech_collective.rs
@@ -683,8 +683,8 @@ mod tests {
 		// Scenario: Testing voting weights in a flat collective structure.
 		// This test verifies that:
 		// 1. A referendum is rejected when votes are equal (AYE/NAY).
-		// 2. A referendum is approved when 3 of 5 members vote AYE and no one votes against
-		//    (meets the 60% support and 61% approval thresholds).
+		// 2. A referendum is approved when 3 of 5 members vote AYE and no one votes against (meets
+		//    the 60% support and 61% approval thresholds).
 		// 3. A referendum with multiple voters (5 members) shows correct voting patterns:
 		//    - 4 AYE vs 1 NAY should pass
 		//    - 2 AYE vs 3 NAY should fail

--- a/runtime/tests/governance/tech_collective.rs
+++ b/runtime/tests/governance/tech_collective.rs
@@ -71,6 +71,13 @@ mod tests {
 				referendum_index
 			));
 
+			// Both members must vote aye to clear the 60% support threshold (2/2 = 100%)
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(proposer.clone()),
+				referendum_index,
+				true
+			));
+
 			assert_ok!(TechCollective::vote(
 				RuntimeOrigin::signed(voter.clone()),
 				referendum_index,
@@ -191,6 +198,13 @@ mod tests {
 			assert_ok!(TechReferenda::place_decision_deposit(
 				RuntimeOrigin::signed(proposer.clone()),
 				referendum_index
+			));
+
+			// Both members must vote aye to clear the 60% support threshold (2/2 = 100%)
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(proposer.clone()),
+				referendum_index,
+				true
 			));
 
 			assert_ok!(TechCollective::vote(
@@ -669,9 +683,10 @@ mod tests {
 		// Scenario: Testing voting weights in a flat collective structure.
 		// This test verifies that:
 		// 1. A referendum is rejected when votes are equal (AYE/NAY).
-		// 2. A referendum is approved when only one member votes AYE and no one votes against.
+		// 2. A referendum is approved when 3 of 5 members vote AYE and no one votes against
+		//    (meets the 60% support and 61% approval thresholds).
 		// 3. A referendum with multiple voters (5 members) shows correct voting patterns:
-		//    - 3 AYE vs 2 NAY should pass
+		//    - 4 AYE vs 1 NAY should pass
 		//    - 2 AYE vs 3 NAY should fail
 		// The test uses frame_system::Call::remark as a neutral proposal to avoid affecting chain
 		// state. -------------------------------------------------------------
@@ -880,10 +895,22 @@ mod tests {
 				frame_system::Pallet::<Runtime>::block_number()
 			);
 
-			// Only member_one votes (AYE) - by default this should be enough to approve if no one
-			// votes against
+			// Three of five members vote AYE with no NAYs: support 3/5 = 60% and
+			// approval 100% meet the thresholds
 			assert_ok!(TechCollective::vote(
 				RuntimeOrigin::signed(member_one.clone()),
+				second_referendum_index,
+				true // AYE vote
+			));
+
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(member_two.clone()),
+				second_referendum_index,
+				true // AYE vote
+			));
+
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(member_three.clone()),
 				second_referendum_index,
 				true // AYE vote
 			));
@@ -1165,7 +1192,7 @@ mod tests {
 	}
 
 	#[test]
-	fn track0_ignores_token_support_threshold_when_min_support_is_zero() {
+	fn track0_support_counts_members_not_token_amounts() {
 		TestCommons::new_fast_governance_test_ext().execute_with(|| {
 			let proposer = TestCommons::account_id(1);
 			let voter1 = TestCommons::account_id(2);
@@ -1329,6 +1356,13 @@ mod tests {
 			assert_ok!(TechReferenda::place_decision_deposit(
 				RuntimeOrigin::signed(proposer.clone()),
 				referendum_index
+			));
+
+			// Both members must vote aye to clear the 60% support threshold (2/2 = 100%)
+			assert_ok!(TechCollective::vote(
+				RuntimeOrigin::signed(proposer.clone()),
+				referendum_index,
+				true
 			));
 
 			assert_ok!(TechCollective::vote(


### PR DESCRIPTION
Almost — one correction: **support is 60%, not 61%**. That's deliberate: support is measured against all 5 members, so 3/5 = exactly 60%. If you set support to 61%, 3 ayes would fail quorum and you'd need 4/5 to execute. Approval (ayes vs nays among voters) is the one at 61%, which is what makes 2 nays block (3a/2n = 60% < 61%).

Also "1 day minimum confirmation" is the right phrasing — it's 24h of *continuous* passing; if nays abort confirmation, the clock restarts.

Here's a PR description:

---

**Title:** `runtime: tighten tech collective governance track`

## Summary

Tightens the Tech Collective referenda track for a 5-member collective:

| Parameter | Before | After |
|---|---|---|
| `min_support` (quorum) | 0% | **60%** (constant) |
| `min_approval` | 100% → 50% (decaying) | **61%** (constant) |
| `confirm_period` | 20 blocks (~4 min) | **1 day** |
| `min_enactment_period` | 20 blocks (~4 min) | **1 day** |

`decision_period` (1 day) and `prepare_period` (20 blocks) are unchanged. The `fast-governance` test feature still collapses all timings to 2 blocks.

## Security properties (5-member collective)

- **3/5 ayes required to pass** — support quorum of 60% closes the hole where 2 ayes could approve a referendum
- **2 nays always block** — 3 ayes / 2 nays = 60% approval, below the 61% threshold
- **1 nay cannot block** — 3 ayes / 1 nay = 75% approval, passes
- **Compromising 3 members is not enough** — against 2 honest nays, an attacker needs 4 aye votes to clear 61% approval
- **Dissent always has a 24h window** — approval cannot conclude before 24h of continuous passing; any nay that drops approval below threshold aborts confirmation and restarts the clock
- **24h enactment delay** — approved proposals execute no earlier than 1 day after approval

## Notes

- Thresholds are constant over the decision period (no decay)
- Support is computed against the live member count: with 5 members, 60% = 3 ayes
- Takes effect via runtime upgrade in the next release

---

