### PR TITLE
fix: report connected peers in litep2p network_state

### DIFF
--- a/client/network/src/litep2p/service.rs
+++ b/client/network/src/litep2p/service.rs
@@ -24,11 +24,14 @@ use crate::{
 		notification::{config::ProtocolControlHandle, peerset::PeersetCommand},
 		request_response::OutboundRequest,
 	},
-	network_state::NetworkState,
+	network_state::{
+		Endpoint as NetworkStateEndpoint, NetworkState, Peer as NetworkStatePeer,
+		PeerEndpoint as NetworkStatePeerEndpoint,
+	},
 	peer_store::PeerStoreProvider,
 	service::{
 		out_events,
-		traits::{IfDisconnected, OutboundFailure, RequestFailure},
+		traits::{Direction, IfDisconnected, OutboundFailure, RequestFailure},
 	},
 	Event, NetworkDHTProvider, NetworkEventStream, NetworkPeers, NetworkRequest, NetworkSigner,
 	NetworkStateInfo, NetworkStatus, NetworkStatusProvider, ProtocolName, Signature,
@@ -343,6 +346,16 @@ impl NetworkStatusProvider for Litep2pNetworkService {
 	}
 
 	async fn network_state(&self) -> Result<NetworkState, ()> {
+		let Some(handle) = self.peerset_handles.get(&self.block_announce_protocol) else {
+			return Err(())
+		};
+		let (tx, rx) = oneshot::channel();
+		handle
+			.tx
+			.unbounded_send(PeersetCommand::GetConnectedPeers { tx })
+			.map_err(|_| ())?;
+		let connected_peers = rx.await.map_err(|_| ())?;
+
 		Ok(NetworkState {
 			peer_id: self.local_peer_id.to_base58(),
 			listened_addresses: self
@@ -358,7 +371,33 @@ impl NetworkStatusProvider for Litep2pNetworkService {
 				.into_iter()
 				.map(|a| Multiaddr::from(a).into())
 				.collect(),
-			connected_peers: HashMap::new(),
+			connected_peers: connected_peers
+				.into_iter()
+				.map(|(peer, direction)| {
+					// Connection-level addresses are not exposed by litep2p, only the
+					// substream direction is known.
+					let endpoint = match direction {
+						Direction::Inbound => NetworkStatePeerEndpoint::Listening {
+							local_addr: Multiaddr::empty(),
+							send_back_addr: Multiaddr::empty(),
+						},
+						Direction::Outbound => NetworkStatePeerEndpoint::Dialing(
+							Multiaddr::empty(),
+							NetworkStateEndpoint::Dialer,
+						),
+					};
+
+					(
+						peer.to_base58(),
+						NetworkStatePeer {
+							endpoint,
+							version_string: None,
+							latest_ping_time: None,
+							known_addresses: HashSet::new(),
+						},
+					)
+				})
+				.collect(),
 			not_connected_peers: HashMap::new(),
 			// TODO: Check what info we can include here.
 			//       Issue reference: https://github.com/paritytech/substrate/issues/14160.

--- a/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/client/network/src/litep2p/shim/notification/peerset.rs
@@ -204,6 +204,12 @@ pub enum PeersetCommand {
 		/// `oneshot::Sender` for sending the current set of reserved peers.
 		tx: oneshot::Sender<Vec<PeerId>>,
 	},
+
+	/// Get connected peers.
+	GetConnectedPeers {
+		/// `oneshot::Sender` for sending the current set of connected peers.
+		tx: oneshot::Sender<Vec<(PeerId, traits::Direction)>>,
+	},
 }
 
 /// Commands emitted by [`Peerset`] to the notification protocol.
@@ -1436,6 +1442,18 @@ impl Stream for Peerset {
 				},
 				PeersetCommand::GetReservedPeers { tx } => {
 					let _ = tx.send(self.reserved_peers.iter().cloned().collect());
+				},
+				PeersetCommand::GetConnectedPeers { tx } => {
+					let _ = tx.send(
+						self.peers
+							.iter()
+							.filter_map(|(peer, state)| match state {
+								PeerState::Connected { direction } =>
+									Some((*peer, (*direction).into())),
+								_ => None,
+							})
+							.collect(),
+					);
 				},
 			}
 		}

--- a/client/network/src/litep2p/shim/notification/tests/peerset.rs
+++ b/client/network/src/litep2p/shim/notification/tests/peerset.rs
@@ -1297,3 +1297,57 @@ async fn reserved_only_rejects_non_reserved_peers() {
 		assert_eq!(connected_peers.load(Ordering::Relaxed), 5usize);
 	}
 }
+
+#[tokio::test]
+async fn get_connected_peers_returns_only_connected_peers() {
+	sp_tracing::try_init_simple();
+
+	let peerstore_handle = Arc::new(peerstore_handle_test());
+	for _ in 0..3 {
+		peerstore_handle.add_known_peer(PeerId::random());
+	}
+
+	let (mut peerset, to_peerset) = Peerset::new(
+		ProtocolName::from("/notif/1"),
+		25,
+		25,
+		false,
+		Default::default(),
+		Default::default(),
+		peerstore_handle,
+	);
+
+	// open substreams to all known peers but report only two of them as connected
+	let connected = match peerset.next().await {
+		Some(PeersetNotificationCommand::OpenSubstream { peers: out_peers }) => {
+			assert_eq!(out_peers.len(), 3usize);
+
+			let connected = out_peers.iter().take(2).copied().collect::<HashSet<_>>();
+			for peer in &connected {
+				assert!(std::matches!(
+					peerset.report_substream_opened(*peer, traits::Direction::Outbound),
+					OpenResult::Accept { .. }
+				));
+			}
+			connected
+		},
+		event => panic!("invalid event: {event:?}"),
+	};
+
+	let (tx, rx) = futures::channel::oneshot::channel();
+	to_peerset.unbounded_send(PeersetCommand::GetConnectedPeers { tx }).unwrap();
+
+	// poll `Peerset` to process the command
+	futures::future::poll_fn(|cx| match peerset.poll_next_unpin(cx) {
+		Poll::Pending => Poll::Ready(()),
+		_ => panic!("unexpected event"),
+	})
+	.await;
+
+	let result = rx.await.unwrap();
+	assert_eq!(result.len(), 2usize);
+	for (peer, direction) in result {
+		assert!(connected.contains(&peer));
+		assert_eq!(direction, traits::Direction::Outbound);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #592 — `peer_getBasicInfo` always returned `peer_count: 0` and an empty `connected_peers` list since v0.7.1-q-day-2, because the litep2p backend's `network_state()` hardcoded `connected_peers` to an empty map (an inherited upstream TODO, surfaced when litep2p became the only backend).

- Add a `PeersetCommand::GetConnectedPeers` command that returns the peers currently in `PeerState::Connected` along with their substream direction.
- `Litep2pNetworkService::network_state()` now queries the block-announce peerset — the same source `system_health`'s peer count is derived from — and populates `connected_peers` with the result. Connection-level addresses are not exposed by litep2p, so endpoint info only reflects substream direction; `peer_id`, peer count, and peer IDs are now correct.
- This also fixes the standard `system_networkState` RPC, which reads the same struct.

## Test plan

- [x] New unit test `get_connected_peers_returns_only_connected_peers` verifying only peers in `Connected` state are returned
- [x] `cargo test -p sc-network peerset` — all 15 tests pass
- [x] Manual check on a syncing planck node: `peer_getBasicInfo` reports `peer_count: 3` with the connected peer IDs listed, matching `system_health`'s `peers: 3` queried moments apart:

```
$ curl -s 127.0.0.1:9933 -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"peer_getBasicInfo"}'
{"jsonrpc":"2.0","id":1,"result":{"peer_id":"QmbBmA…","peer_count":3,
 "connected_peers":["QmbctL…","QmZT5L…","QmczRB…"], ...}}

$ curl -s 127.0.0.1:9933 -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"system_health"}'
{"jsonrpc":"2.0","id":1,"result":{"peers":3,"isSyncing":true,"shouldHavePeers":true}}
```