### PR TITLE
Turn off external scheduler access

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -212,7 +212,11 @@ mod runtime {
 	#[runtime::pallet_index(7)]
 	pub type Preimage = pallet_preimage;
 
+	// The scheduler is used internally for reversible transfers and governance via the
+	// `Scheduler`/`ScheduleNamed` trait. Its extrinsics are disabled so users cannot place
+	// arbitrary transactions onto the scheduler.
 	#[runtime::pallet_index(8)]
+	#[runtime::disable_call]
 	pub type Scheduler = pallet_scheduler;
 
 	#[runtime::pallet_index(9)]


### PR DESCRIPTION
Scheduler is very complex, this prevents shenanigans until we have time to rewrite it

No outside RPC access to scheduler