### PR TITLE
Implement turnstile and migration

### DIFF
--- a/docs/wormhole-soundness-detection-plan.md
+++ b/docs/wormhole-soundness-detection-plan.md
@@ -23,6 +23,13 @@ On-chain, wormhole addresses are indistinguishable from regular dilithium addres
 
 When an address signs its first transaction, it "reveals" itself as a regular dilithium address (not a wormhole address), and its balance should be subtracted from the potential wormhole pool.
 
+### Accounts that never reveal
+
+The `nonce == 0` heuristic over-counts two kinds of accounts that have a zero nonce but are known *not* to be wormhole deposits. These are excluded via the `NonWormholeAccounts: Contains<AccountId>` config (so they never add to the pool), and the runtime populates it as follows:
+
+- **Multisig accounts** spend through their signatories, so the multisig account itself never signs and never reveals. The runtime excludes any address registered in `pallet_multisig` (`is_multisig`). Because funds can be sent to a *pre-computed* multisig address before it is created, the multisig pallet also calls `TransferProofRecorder::reveal_address` on creation, which subtracts the address's balance from the pool (the multisig analog of a normal account's first-signature reveal). Together these make a multisig net zero into the pool over its lifetime.
+- **Keyless accounts** that can never sign at all: the treasury account (a keyless governance account that receives a block reward every block), the `PalletId`-derived pallet accounts, and the sentinel minting addresses used as the `from` side of minted transfers.
+
 ## Storage Items
 
 Add to `pallets/wormhole/src/lib.rs`:
@@ -219,7 +226,8 @@ Wormhole exits are unsigned (`ensure_none`). They don't have a signer and won't 
 1. **`pallets/wormhole/src/lib.rs`**
    - Bumped `STORAGE_VERSION` to 1 (`#[pallet::storage_version]`)
    - Added `PotentialWormholeBalance` and `TotalWormholeExits` storage items (with getters)
-   - Added `is_ambiguous_account()` helper (single source of truth for the `nonce == 0` heuristic)
+   - Added `is_ambiguous_account()` helper (single source of truth for the `nonce == 0` heuristic), now also excluding `NonWormholeAccounts`
+   - Added `NonWormholeAccounts: Contains<AccountId>` config and `reveal_account()` helper (the deduction side, shared by the first-signature reveal and multisig creation)
    - Added `SoundnessInvariantViolation` error variant
    - Updated `record_transfer()` to track deposits to ambiguous addresses
    - Updated `verify_aggregated_proof()` to check the invariant and update `TotalWormholeExits`
@@ -227,10 +235,20 @@ Wormhole exits are unsigned (`ensure_none`). They don't have a signer and won't 
 2. **`pallets/wormhole/src/migrations.rs`** (new)
    - `v1::InitSoundnessCounters` + `MigrateV0ToV1` versioned migration to seed the pool
 
-3. **`runtime/src/transaction_extensions.rs`**
-   - Updated `WormholeProofRecorderExtension::validate()` to detect first-time signers and subtract their balance (and accounted for it in `weight()`)
+3. **`primitives/wormhole/src/lib.rs`**
+   - Added `reveal_address()` to the `TransferProofRecorder` trait (the cross-pallet wormhole hook), implemented by the wormhole pallet
 
-4. **`runtime/src/lib.rs`**
+4. **`pallets/multisig/src/lib.rs`**
+   - Added `is_multisig()` helper (registry lookup)
+   - Added a `ProofRecorder: TransferProofRecorder` config and a `reveal_address` call on multisig creation, so a multisig is revealed to the soundness counter when created
+
+5. **`runtime/src/transaction_extensions.rs`**
+   - Updated `WormholeProofRecorderExtension::validate()` to detect first-time signers and reveal them (and accounted for it in `weight()`)
+
+6. **`runtime/src/configs/mod.rs`**
+   - Implemented `NonWormholeAccounts` (registered multisigs + treasury + `PalletId`/sentinel keyless accounts) and wired multisig's `ProofRecorder = Wormhole`
+
+7. **`runtime/src/lib.rs`**
    - Added the `Migrations` tuple (`MigrateV0ToV1`) to `Executive` and bumped `spec_version` to 132
 
 ## Testing
@@ -238,11 +256,18 @@ Wormhole exits are unsigned (`ensure_none`). They don't have a signer and won't 
 1. **Unit tests in wormhole pallet:**
    - Test that transfers to nonce-0 addresses increment `PotentialWormholeBalance`
    - Test that transfers to nonce>0 addresses don't affect `PotentialWormholeBalance`
+   - Test that transfers to `NonWormholeAccounts` don't affect `PotentialWormholeBalance`
+   - Test that `reveal_account()` subtracts an account's balance from the pool
    - Test that exits increment `TotalWormholeExits`
    - Test that exits fail with `SoundnessInvariantViolation` when invariant would be violated
 
-2. **Integration tests in runtime:**
+2. **Multisig pallet test:**
+   - Test that creating a multisig reveals its address to the wormhole soundness counter
+
+3. **Integration tests in runtime:**
    - Test that signing a first transaction subtracts balance from `PotentialWormholeBalance`
+   - Test that creating a multisig deducts a pre-funded (pre-computed) address's balance and excludes it afterward
+   - Test that mining rewards count only the miner's (ambiguous) portion, not the excluded treasury portion
    - Test full flow: deposit -> exit -> verify counters
    - Test reveal flow: deposit -> sign transaction -> verify balance subtracted
 

--- a/docs/wormhole-soundness-detection-plan.md
+++ b/docs/wormhole-soundness-detection-plan.md
@@ -1,0 +1,253 @@
+# Wormhole Soundness Bug Detection Plan
+
+## Overview
+
+This document describes a mechanism to detect potential soundness bugs in the wormhole system (ZK proof-of-burn minting). The core invariant we want to enforce:
+
+```
+total_wormhole_exits <= potential_wormhole_balance
+```
+
+Where:
+- `potential_wormhole_balance` = sum of balances held by "ambiguous" addresses (addresses that have never signed a dilithium transaction)
+- `total_wormhole_exits` = sum of all tokens minted via wormhole exits
+
+If this invariant is ever violated, it indicates a soundness bug — more tokens are being exited than could possibly have been deposited into wormhole addresses.
+
+## Key Insight: Nonce-Based Address Classification
+
+On-chain, wormhole addresses are indistinguishable from regular dilithium addresses. However, we can use a heuristic:
+
+- **Ambiguous address**: `account_nonce == 0` (has never signed a transaction)
+- **Revealed address**: `account_nonce > 0` (has signed at least one transaction with dilithium)
+
+When an address signs its first transaction, it "reveals" itself as a regular dilithium address (not a wormhole address), and its balance should be subtracted from the potential wormhole pool.
+
+## Storage Items
+
+Add to `pallets/wormhole/src/lib.rs`:
+
+```rust
+/// Sum of balances held by ambiguous addresses (nonce == 0, might be wormhole).
+/// This represents the maximum possible value that could be legitimately exited.
+#[pallet::storage]
+pub type PotentialWormholeBalance<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+/// Total value of all successful wormhole exits (mints to exit accounts).
+#[pallet::storage]
+pub type TotalWormholeExits<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+```
+
+## Implementation
+
+### 1. Track Deposits on Every Transfer
+
+Location: `record_transfer()` in `pallets/wormhole/src/lib.rs` (around line 603)
+
+After recording the transfer in the ZK tree, check if the recipient is ambiguous:
+
+```rust
+pub fn record_transfer(
+    asset_id: T::AssetId,
+    from: &<T as Config>::WormholeAccountId,
+    to: &<T as Config>::WormholeAccountId,
+    amount: BalanceOf<T>,
+) {
+    // ... existing ZK tree recording code ...
+
+    // Soundness tracking: if recipient has never signed (nonce == 0),
+    // they might be a wormhole address, so add to potential balance
+    if asset_id == T::AssetId::default() {
+        // Native token only for now
+        let to_account: <T as frame_system::Config>::AccountId = to.clone().into();
+        let recipient_nonce = frame_system::Pallet::<T>::account_nonce(&to_account);
+        
+        if recipient_nonce.is_zero() {
+            PotentialWormholeBalance::<T>::mutate(|total| {
+                *total = total.saturating_add(amount);
+            });
+        }
+    }
+    
+    // TODO: Add similar tracking for asset transfers when asset wormhole is enabled
+
+    // ... existing event emission code ...
+}
+```
+
+### 2. Subtract Balance on First Signature (Reveal)
+
+Location: `WormholeProofRecorderExtension::validate()` in `runtime/src/transaction_extensions.rs` (around line 231)
+
+When an address signs its first transaction, subtract its balance from the potential pool:
+
+```rust
+fn validate(
+    &self,
+    origin: sp_runtime::traits::DispatchOriginOf<RuntimeCall>,
+    _call: &RuntimeCall,
+    _info: &DispatchInfoOf<RuntimeCall>,
+    _len: usize,
+    _self_implicit: Self::Implicit,
+    _inherited_implication: &impl sp_runtime::traits::Implication,
+    _source: frame_support::pallet_prelude::TransactionSource,
+) -> sp_runtime::traits::ValidateResult<Self::Val, RuntimeCall> {
+    // Soundness tracking: detect first-time signers and subtract their balance
+    // Note: We're in validate(), so nonce has NOT been incremented yet by CheckNonce
+    if let Ok(signer) = frame_system::ensure_signed(origin.clone()) {
+        let nonce = frame_system::Pallet::<Runtime>::account_nonce(&signer);
+        
+        if nonce.is_zero() {
+            // First transaction from this address — they're revealing as dilithium signer
+            // Subtract their current balance from potential wormhole balance
+            let balance = <Runtime as pallet_wormhole::Config>::Currency::free_balance(&signer);
+            
+            pallet_wormhole::PotentialWormholeBalance::<Runtime>::mutate(|total| {
+                *total = total.saturating_sub(balance);
+            });
+        }
+    }
+    
+    Ok((ValidTransaction::default(), (), origin))
+}
+```
+
+**Important timing note:** This runs in `validate()`, which executes *before* `CheckNonce::prepare()` increments the nonce. So `nonce == 0` correctly identifies first-time signers.
+
+### 3. Enforce Invariant on Wormhole Exit
+
+Location: `verify_aggregated_proof()` in `pallets/wormhole/src/lib.rs` (around line 394, after computing `total_exit_amount`)
+
+Add the soundness check before processing exits:
+
+```rust
+// After computing total_exit_amount (around line 394-396):
+
+// SOUNDNESS CHECK: Verify invariant before allowing exit
+let potential_balance = PotentialWormholeBalance::<T>::get();
+let current_exits = TotalWormholeExits::<T>::get();
+let exits_after = current_exits.saturating_add(total_exit_amount);
+
+ensure!(
+    exits_after <= potential_balance,
+    Error::<T>::SoundnessInvariantViolation
+);
+
+// ... existing exit processing (minting, fee handling, etc.) ...
+
+// After successful exit processing (near end of function, before Ok):
+TotalWormholeExits::<T>::put(exits_after);
+```
+
+### 4. Add Error Variant
+
+Location: `pallets/wormhole/src/lib.rs`, in the `Error` enum (around line 264)
+
+```rust
+#[pallet::error]
+pub enum Error<T> {
+    // ... existing errors ...
+    
+    /// Soundness invariant violated: total exits would exceed potential wormhole deposits.
+    /// This indicates a potential bug in the ZK proof system.
+    SoundnessInvariantViolation,
+}
+```
+
+## Status: IMPLEMENTED
+
+This plan has been implemented. A few decisions were made during implementation that refine
+the original plan; they are documented inline below.
+
+### Seeding an already-running testnet (the key ambiguity)
+
+The original plan only handled fresh chains (where genesis endowments seed the pool at block 1).
+On a chain that is **already running**, wormhole deposits made before this tracking existed are
+not reflected in `PotentialWormholeBalance`, which would default to `0`. The first legitimate
+exit would then trip `SoundnessInvariantViolation` and effectively brick the wormhole.
+
+To fix this we added a versioned storage migration (`migrations::v1::InitSoundnessCounters`, wired
+as `MigrateV0ToV1` in the runtime `Migrations` tuple) that runs once on the v0 -> v1 upgrade and
+seeds:
+
+```
+PotentialWormholeBalance = total_issuance()
+```
+
+Every balance held by an ambiguous address is necessarily backed by issued tokens, so
+`total_issuance()` is an upper bound on the value that could legitimately be exited. Seeding to it
+therefore guarantees the upgrade can never brick a valid exit (including value held by un-revealed
+miner-reward accounts). As accounts reveal themselves, the counter tightens toward the true
+ambiguous sum. We deliberately avoid an extra configurable buffer: it could only ever loosen the
+invariant (total issuance is already a safe ceiling), so it would add no safety and reduce
+sensitivity.
+
+The pallet now declares `STORAGE_VERSION = 1`, and `VersionedMigration<0, 1, ...>` runs the seed
+only when the on-chain version is 0, then bumps it to 1 (so it executes exactly once). On a fresh
+chain the migration is skipped (genesis sets the on-chain version to 1) and the pool is seeded by
+the block-1 `record_transfer` calls for genesis endowments instead.
+
+## Edge Cases
+
+### Genesis Endowments
+
+Genesis addresses that receive funds via `GenesisConfig` will have `nonce == 0`, so their balances are correctly counted in `PotentialWormholeBalance`. If they later sign a transaction, they'll be subtracted.
+
+The existing `on_initialize` hook at block 1 calls `record_transfer` for genesis endowments, which will add to `PotentialWormholeBalance`.
+
+### Exit to Revealed Address
+
+When someone exits from wormhole to a revealed address (nonce > 0):
+- The exit minting increases `TotalWormholeExits`
+- The `record_transfer` call for the exit does NOT add to `PotentialWormholeBalance` (recipient nonce > 0)
+- This is correct — tokens exited to a revealed address can't be re-exited via wormhole
+
+### Fees
+
+The current implementation mints `exit_amount` (post-fee) to users. Fees are partially burned and partially paid to miners. The invariant tracks:
+- Deposits: full amount transferred to ambiguous addresses
+- Exits: amount minted to users (post-fee)
+
+So `exits < deposits` is expected (the gap is fees). The invariant `exits <= deposits` should always hold unless there's a soundness bug.
+
+### Unsigned Transactions
+
+Wormhole exits are unsigned (`ensure_none`). They don't have a signer and won't trigger the reveal logic. This is correct — exits don't reveal anything about the exit destination address.
+
+## Files Modified
+
+1. **`pallets/wormhole/src/lib.rs`**
+   - Bumped `STORAGE_VERSION` to 1 (`#[pallet::storage_version]`)
+   - Added `PotentialWormholeBalance` and `TotalWormholeExits` storage items (with getters)
+   - Added `is_ambiguous_account()` helper (single source of truth for the `nonce == 0` heuristic)
+   - Added `SoundnessInvariantViolation` error variant
+   - Updated `record_transfer()` to track deposits to ambiguous addresses
+   - Updated `verify_aggregated_proof()` to check the invariant and update `TotalWormholeExits`
+
+2. **`pallets/wormhole/src/migrations.rs`** (new)
+   - `v1::InitSoundnessCounters` + `MigrateV0ToV1` versioned migration to seed the pool
+
+3. **`runtime/src/transaction_extensions.rs`**
+   - Updated `WormholeProofRecorderExtension::validate()` to detect first-time signers and subtract their balance (and accounted for it in `weight()`)
+
+4. **`runtime/src/lib.rs`**
+   - Added the `Migrations` tuple (`MigrateV0ToV1`) to `Executive` and bumped `spec_version` to 132
+
+## Testing
+
+1. **Unit tests in wormhole pallet:**
+   - Test that transfers to nonce-0 addresses increment `PotentialWormholeBalance`
+   - Test that transfers to nonce>0 addresses don't affect `PotentialWormholeBalance`
+   - Test that exits increment `TotalWormholeExits`
+   - Test that exits fail with `SoundnessInvariantViolation` when invariant would be violated
+
+2. **Integration tests in runtime:**
+   - Test that signing a first transaction subtracts balance from `PotentialWormholeBalance`
+   - Test full flow: deposit -> exit -> verify counters
+   - Test reveal flow: deposit -> sign transaction -> verify balance subtracted
+
+## Future Considerations
+
+- **Asset support:** When asset wormhole is enabled, add similar tracking for asset balances. Comments are left in the code indicating where to add this.
+- **Monitoring:** Consider adding RPC methods to query `PotentialWormholeBalance` and `TotalWormholeExits` for external monitoring dashboards.
+- **Graceful degradation:** If a false positive ever occurs (e.g., due to a bug in the tracking itself), consider adding a sudo call to adjust the counters or temporarily disable the check.

--- a/pallets/mining-rewards/src/mock.rs
+++ b/pallets/mining-rewards/src/mock.rs
@@ -161,6 +161,8 @@ impl qp_wormhole::TransferProofRecorder<sp_core::crypto::AccountId32, u32, u128>
 			proofs.borrow_mut().push(RecordedTransferProof { asset_id, from, to, amount });
 		});
 	}
+
+	fn reveal_address(_account: sp_core::crypto::AccountId32) {}
 }
 
 impl pallet_mining_rewards::Config for Test {

--- a/pallets/multisig/Cargo.toml
+++ b/pallets/multisig/Cargo.toml
@@ -20,6 +20,7 @@ pallet-balances.workspace = true
 pallet-reversible-transfers = { path = "../reversible-transfers", default-features = false, optional = true }
 qp-high-security = { path = "../../primitives/high-security", default-features = false }
 qp-scheduler = { workspace = true, optional = true }
+qp-wormhole = { workspace = true, default-features = false }
 scale-info = { features = ["derive"], workspace = true }
 sp-arithmetic.workspace = true
 sp-core.workspace = true
@@ -66,6 +67,7 @@ std = [
 	"pallet-timestamp/std",
 	"qp-high-security/std",
 	"qp-scheduler?/std",
+	"qp-wormhole/std",
 	"scale-info/std",
 	"sp-arithmetic/std",
 	"sp-core/std",

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -45,6 +45,7 @@ pub mod weights;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{traits::Get, BoundedBTreeMap, BoundedVec};
+use qp_wormhole::TransferProofRecorder;
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
@@ -236,6 +237,11 @@ pub mod pallet {
 			Self::AccountId,
 			<Self as pallet::Config>::RuntimeCall,
 		>;
+
+		/// Handle into the wormhole pallet. On creation, a multisig is revealed to the wormhole
+		/// soundness counter (a multisig never signs, so it never reveals itself otherwise), which
+		/// deducts any balance sent to the pre-computed address before it was created.
+		type ProofRecorder: TransferProofRecorder<Self::AccountId, u32, BalanceOf<Self>>;
 	}
 
 	/// Type alias for bounded signers vector
@@ -478,6 +484,11 @@ pub mod pallet {
 					proposals_per_signer: BoundedProposalsPerSignerOf::<T>::default(),
 				},
 			);
+
+			// Reveal the multisig to the wormhole soundness counter now that the address is known
+			// to be a multisig (it will never sign and reveal itself). This deducts any balance
+			// sent to the pre-computed address before creation.
+			T::ProofRecorder::reveal_address(multisig_address.clone());
 
 			// Emit event with sorted signers
 			Self::deposit_event(Event::MultisigCreated {
@@ -1208,6 +1219,16 @@ pub mod pallet {
 			let hash = T::Hashing::hash(&data);
 			T::AccountId::decode(&mut TrailingZeroInput::new(hash.as_ref()))
 				.expect("TrailingZeroInput provides sufficient bytes; qed")
+		}
+
+		/// Check if an account is a (permanently registered) multisig address.
+		///
+		/// Multisigs are recorded in [`Multisigs`] when created and never removed, so this is an
+		/// exact test. It is used by other pallets (e.g. the wormhole soundness counter) that need
+		/// to know an account spends via signatories and therefore never "reveals" itself by
+		/// signing a transaction directly.
+		pub fn is_multisig(account: &T::AccountId) -> bool {
+			Multisigs::<T>::contains_key(account)
 		}
 
 		/// Check if an account is a signer for a given multisig

--- a/pallets/multisig/src/mock.rs
+++ b/pallets/multisig/src/mock.rs
@@ -194,6 +194,13 @@ impl pallet_multisig::Config for Test {
 	type PalletId = MultisigPalletId;
 	type WeightInfo = ();
 	type HighSecurity = crate::tests::MockHighSecurity;
+	type ProofRecorder = MockProofRecorder;
+}
+
+thread_local! {
+	/// Records addresses passed to `TransferProofRecorder::reveal_address`, so tests can assert a
+	/// multisig is revealed to the wormhole soundness counter on creation.
+	pub static REVEALED_ADDRESSES: RefCell<Vec<AccountId>> = const { RefCell::new(Vec::new()) };
 }
 
 impl mock_heavy_call::Config for Test {}
@@ -243,6 +250,10 @@ impl qp_wormhole::TransferProofRecorder<AccountId, u32, Balance> for MockProofRe
 		_to: AccountId,
 		_amount: Balance,
 	) {
+	}
+
+	fn reveal_address(account: AccountId) {
+		REVEALED_ADDRESSES.with(|a| a.borrow_mut().push(account));
 	}
 }
 

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -162,6 +162,34 @@ fn create_multisig_works() {
 }
 
 #[test]
+fn create_multisig_reveals_address_to_wormhole() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		crate::mock::REVEALED_ADDRESSES.with(|a| a.borrow_mut().clear());
+
+		let creator = alice();
+		let signers = vec![bob(), charlie(), dave()];
+		let threshold = 2;
+
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			threshold,
+			0,
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, threshold, 0);
+		crate::mock::REVEALED_ADDRESSES.with(|a| {
+			assert_eq!(
+				a.borrow().as_slice(),
+				&[multisig_address],
+				"creating a multisig must reveal its address to the wormhole soundness counter"
+			);
+		});
+	});
+}
+
+#[test]
 fn create_multisig_fails_with_threshold_zero() {
 	new_test_ext().execute_with(|| {
 		let creator = alice();

--- a/pallets/reversible-transfers/src/tests/mock.rs
+++ b/pallets/reversible-transfers/src/tests/mock.rs
@@ -244,6 +244,8 @@ impl qp_wormhole::TransferProofRecorder<AccountId, u32, Balance> for MockProofRe
 			proofs.borrow_mut().push(RecordedTransferProof { asset_id, from, to, amount });
 		});
 	}
+
+	fn reveal_address(_account: AccountId) {}
 }
 
 impl pallet_reversible_transfers::Config for Test {

--- a/pallets/wormhole/Cargo.toml
+++ b/pallets/wormhole/Cargo.toml
@@ -74,3 +74,10 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 ]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-zk-tree/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -670,15 +670,16 @@ pub mod pallet {
 				!T::NonWormholeAccounts::contains(account)
 		}
 
-		/// Reveal `account`: remove its current free balance from `PotentialWormholeBalance`.
+		/// Reveal `account`: remove its current total balance from `PotentialWormholeBalance`.
 		///
 		/// This is the deduction side of the soundness counter. It runs when an account stops
 		/// being indistinguishable from a wormhole deposit address:
 		///
 		/// - a regular account the first time it signs a transaction (see
 		///   `WormholeProofRecorderExtension::validate` in the runtime), and
-		/// - a multisig address at creation time (see `OnMultisigCreated`), which covers the case
-		///   where funds were sent to a pre-computed multisig address before it was created.
+		/// - a multisig address at creation time (the multisig pallet calls `reveal_address`), which
+		///   covers the case where funds were sent to a pre-computed multisig address before it was
+		///   created.
 		///
 		/// Idempotent in practice: once revealed, an account is excluded from
 		/// `is_ambiguous_account`, so its later receipts are never re-added to the pool.
@@ -694,13 +695,25 @@ pub mod pallet {
 		/// post-fee balance.
 		///
 		/// Soundness caveat: the reveal subtracts an account's whole balance on the assumption that
-		/// every credit it received while ambiguous was added to the pool (via `record_transfer`).
-		/// This holds for all normal credit paths (transfers and mints), but NOT for an untracked
-		/// balance increase such as a root `Balances::force_set_balance` (emits `BalanceSet`, which
-		/// is not recorded). Such an increase is never added to the pool, so revealing the account
-		/// would over-subtract here. This is root-gated and the conservative migration seed keeps
-		/// the pool well above the true ambiguous sum, but operators should avoid raising the
-		/// balance of a never-signed account via `force_set_balance`.
+		/// every credit it received while ambiguous was added to the pool. The pool is only
+		/// incremented by `record_transfer`, which is driven by the runtime's event-scanning
+		/// transaction extension, so the assumption holds for every *unprivileged* credit path
+		/// (ordinary transfers and mints inside a signed extrinsic). It does NOT hold for
+		/// privileged credit paths that bypass that extension, including:
+		///   - root `Balances::force_set_balance` (emits `BalanceSet`, which is not a transfer/mint
+		///     event and is therefore never recorded),
+		///   - Root/scheduler-dispatched transfers (the scheduler runs in `on_initialize`/`on_idle`
+		///     with no transaction extension, so their `Transfer`/`Minted` events are never
+		///     scanned), and
+		///   - any future pallet-internal credit that does not flow through `record_transfer`.
+		/// Each such credit raises an ambiguous account's balance without adding to the pool, so a
+		/// later reveal over-subtracts here. All of these paths are privileged (Root/governance)
+		/// today, and the error is in the safe direction: it under-counts the pool, so the worst
+		/// case is a liveness false-positive (`SoundnessInvariantViolation` wrongly blocking a
+		/// legitimate exit), never a forged exit. The conservative migration seed (`total_issuance`)
+		/// keeps the pool far above the true ambiguous sum, masking this in practice. For true
+		/// robustness, track a per-account contributed amount and subtract that here instead of the
+		/// account's total balance.
 		pub fn reduce_potential_balance(amount: BalanceOf<T>) {
 			if !amount.is_zero() {
 				PotentialWormholeBalance::<T>::mutate(|total| {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -683,10 +683,19 @@ pub mod pallet {
 		/// Idempotent in practice: once revealed, an account is excluded from
 		/// `is_ambiguous_account`, so its later receipts are never re-added to the pool.
 		pub fn reveal_account(account: &<T as frame_system::Config>::AccountId) {
-			let balance = <T::Currency as Currency<_>>::free_balance(account);
-			if !balance.is_zero() {
+			Self::reduce_potential_balance(<T::Currency as Currency<_>>::free_balance(account));
+		}
+
+		/// Remove `amount` from `PotentialWormholeBalance` (saturating).
+		///
+		/// This is the low-level deduction used by the reveal paths. It is exposed so the runtime's
+		/// transaction extension can capture a signer's balance during `validate` (a side-effect
+		/// free phase) and commit the subtraction later in `prepare`, rather than re-reading a
+		/// post-fee balance.
+		pub fn reduce_potential_balance(amount: BalanceOf<T>) {
+			if !amount.is_zero() {
 				PotentialWormholeBalance::<T>::mutate(|total| {
-					*total = total.saturating_sub(balance);
+					*total = total.saturating_sub(amount);
 				});
 			}
 		}

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -677,9 +677,9 @@ pub mod pallet {
 		///
 		/// - a regular account the first time it signs a transaction (see
 		///   `WormholeProofRecorderExtension::validate` in the runtime), and
-		/// - a multisig address at creation time (the multisig pallet calls `reveal_address`), which
-		///   covers the case where funds were sent to a pre-computed multisig address before it was
-		///   created.
+		/// - a multisig address at creation time (the multisig pallet calls `reveal_address`),
+		///   which covers the case where funds were sent to a pre-computed multisig address before
+		///   it was created.
 		///
 		/// Idempotent in practice: once revealed, an account is excluded from
 		/// `is_ambiguous_account`, so its later receipts are never re-added to the pool.
@@ -710,10 +710,10 @@ pub mod pallet {
 		/// later reveal over-subtracts here. All of these paths are privileged (Root/governance)
 		/// today, and the error is in the safe direction: it under-counts the pool, so the worst
 		/// case is a liveness false-positive (`SoundnessInvariantViolation` wrongly blocking a
-		/// legitimate exit), never a forged exit. The conservative migration seed (`total_issuance`)
-		/// keeps the pool far above the true ambiguous sum, masking this in practice. For true
-		/// robustness, track a per-account contributed amount and subtract that here instead of the
-		/// account's total balance.
+		/// legitimate exit), never a forged exit. The conservative migration seed
+		/// (`total_issuance`) keeps the pool far above the true ambiguous sum, masking this in
+		/// practice. For true robustness, track a per-account contributed amount and subtract
+		/// that here instead of the account's total balance.
 		pub fn reduce_potential_balance(amount: BalanceOf<T>) {
 			if !amount.is_zero() {
 				PotentialWormholeBalance::<T>::mutate(|total| {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -8,6 +8,7 @@ use qp_wormhole_verifier::WormholeVerifier;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+pub mod migrations;
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
@@ -65,7 +66,16 @@ pub mod pallet {
 	pub type BalanceOf<T> = <T as Config>::NativeBalance;
 	pub type AssetBalanceOf<T> = <T as Config>::AssetBalance;
 
+	/// Current storage version of the pallet.
+	///
+	/// v1 introduces the wormhole soundness counters (`PotentialWormholeBalance` and
+	/// `TotalWormholeExits`). The v0 -> v1 migration seeds `PotentialWormholeBalance` so
+	/// that wormhole deposits made before the soundness tracking existed can still be
+	/// exited (see `migrations::v1`).
+	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// Genesis configuration for recording transfer proofs.
@@ -227,6 +237,27 @@ pub mod pallet {
 	pub type GenesisEndowmentsPending<T: Config> =
 		StorageValue<_, Vec<(T::WormholeAccountId, BalanceOf<T>)>, ValueQuery>;
 
+	/// Sum of balances held by "ambiguous" addresses (accounts that have never signed a
+	/// dilithium transaction, i.e. `nonce == 0`). These addresses are indistinguishable from
+	/// wormhole deposit addresses, so this is the maximum value that could legitimately be
+	/// exited via the wormhole.
+	///
+	/// Maintained incrementally: transfers to ambiguous addresses add to it (see
+	/// `record_transfer`), and an address revealing itself by signing its first transaction
+	/// subtracts its balance (see `WormholeProofRecorderExtension::validate` in the runtime).
+	#[pallet::storage]
+	#[pallet::getter(fn potential_wormhole_balance)]
+	pub type PotentialWormholeBalance<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	/// Total value of all successful wormhole exits (tokens minted to exit accounts).
+	///
+	/// The core soundness invariant enforced on every exit is
+	/// `TotalWormholeExits <= PotentialWormholeBalance`. A violation indicates that more value
+	/// is being exited than could possibly have been deposited — i.e. a ZK soundness bug.
+	#[pallet::storage]
+	#[pallet::getter(fn total_wormhole_exits)]
+	pub type TotalWormholeExits<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -276,6 +307,10 @@ pub mod pallet {
 		TransferAmountBelowMinimum,
 		/// Only native asset (asset_id = 0) is supported in this version
 		NonNativeAssetNotSupported,
+		/// Soundness invariant violated: total wormhole exits would exceed the value that could
+		/// possibly have been deposited into wormhole addresses. This indicates a potential
+		/// soundness bug in the ZK proof system, so the exit is rejected.
+		SoundnessInvariantViolation,
 	}
 
 	#[pallet::hooks]
@@ -401,6 +436,14 @@ pub mod pallet {
 				Error::<T>::TransferAmountBelowMinimum
 			);
 
+			// SOUNDNESS CHECK: never allow the cumulative wormhole exits to exceed the value
+			// that could possibly have been deposited into wormhole (ambiguous) addresses.
+			// A violation means the ZK system is letting more value out than went in, so we
+			// reject the exit rather than mint unbacked tokens.
+			let potential_balance = PotentialWormholeBalance::<T>::get();
+			let exits_after = TotalWormholeExits::<T>::get().saturating_add(total_exit_amount);
+			ensure!(exits_after <= potential_balance, Error::<T>::SoundnessInvariantViolation);
+
 			// Emit event for each exit account
 			Self::deposit_event(Event::ProofVerified {
 				exit_amount: total_exit_amount,
@@ -498,6 +541,10 @@ pub mod pallet {
 				);
 			}
 
+			// Commit the new cumulative exit total now that all exits succeeded. The invariant
+			// `exits_after <= potential_balance` was checked above before any minting.
+			TotalWormholeExits::<T>::put(exits_after);
+
 			// Success - use declared weight (actual_weight: None means use declared weight)
 			Ok(PostDispatchInfo { actual_weight: None, pays_fee: Pays::No })
 		}
@@ -593,6 +640,18 @@ pub mod pallet {
 			Ok((proof, inputs))
 		}
 
+		/// Whether `account` is "ambiguous": it has never signed a transaction (`nonce == 0`) and
+		/// is therefore indistinguishable from a wormhole deposit address. Signing any transaction
+		/// reveals an account as a regular dilithium account, after which it is no longer
+		/// ambiguous.
+		///
+		/// This is the single source of truth for the soundness heuristic. Both the deposit-side
+		/// tracking in `record_transfer` (recipient) and the reveal-side tracking in the runtime's
+		/// `WormholeProofRecorderExtension` (signer) classify addresses through this function.
+		pub fn is_ambiguous_account(account: &<T as frame_system::Config>::AccountId) -> bool {
+			frame_system::Pallet::<T>::account_nonce(account).is_zero()
+		}
+
 		/// Record a transfer in the ZK tree and emit events.
 		///
 		/// This inserts the transfer data into the 4-ary Poseidon Merkle tree
@@ -619,6 +678,20 @@ pub mod pallet {
 				asset_id.clone(),
 				amount,
 			);
+
+			// Soundness tracking (native asset only): if the recipient has never signed a
+			// transaction (nonce == 0) it is "ambiguous" and might be a wormhole deposit address,
+			// so it adds to the pool of value that could later be exited via the wormhole.
+			//
+			// TODO: Add equivalent tracking for asset transfers once the asset wormhole is enabled.
+			if asset_id == T::AssetId::default() {
+				let to_account: <T as frame_system::Config>::AccountId = to.clone().into();
+				if Self::is_ambiguous_account(&to_account) {
+					PotentialWormholeBalance::<T>::mutate(|total| {
+						*total = total.saturating_add(amount);
+					});
+				}
+			}
 
 			if asset_id == T::AssetId::default() {
 				Self::deposit_event(Event::<T>::NativeTransferred {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -683,7 +683,7 @@ pub mod pallet {
 		/// Idempotent in practice: once revealed, an account is excluded from
 		/// `is_ambiguous_account`, so its later receipts are never re-added to the pool.
 		pub fn reveal_account(account: &<T as frame_system::Config>::AccountId) {
-			Self::reduce_potential_balance(<T::Currency as Currency<_>>::free_balance(account));
+			Self::reduce_potential_balance(<T::Currency as Currency<_>>::total_balance(account));
 		}
 
 		/// Remove `amount` from `PotentialWormholeBalance` (saturating).
@@ -692,6 +692,15 @@ pub mod pallet {
 		/// transaction extension can capture a signer's balance during `validate` (a side-effect
 		/// free phase) and commit the subtraction later in `prepare`, rather than re-reading a
 		/// post-fee balance.
+		///
+		/// Soundness caveat: the reveal subtracts an account's whole balance on the assumption that
+		/// every credit it received while ambiguous was added to the pool (via `record_transfer`).
+		/// This holds for all normal credit paths (transfers and mints), but NOT for an untracked
+		/// balance increase such as a root `Balances::force_set_balance` (emits `BalanceSet`, which
+		/// is not recorded). Such an increase is never added to the pool, so revealing the account
+		/// would over-subtract here. This is root-gated and the conservative migration seed keeps
+		/// the pool well above the true ambiguous sum, but operators should avoid raising the
+		/// balance of a never-signed account via `force_set_balance`.
 		pub fn reduce_potential_balance(amount: BalanceOf<T>) {
 			if !amount.is_zero() {
 				PotentialWormholeBalance::<T>::mutate(|total| {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -46,7 +46,7 @@ pub mod pallet {
 		traits::{
 			fungible::{Inspect as FungibleInspect, Mutate, Unbalanced},
 			fungibles::{self},
-			BuildGenesisConfig, Currency,
+			BuildGenesisConfig, Contains, Currency,
 		},
 	};
 	use frame_system::pallet_prelude::*;
@@ -181,6 +181,23 @@ pub mod pallet {
 		/// This prevents dust transfers that waste storage.
 		#[pallet::constant]
 		type MinimumTransferAmount: Get<BalanceOf<Self>>;
+
+		/// Accounts that must never be treated as "ambiguous" wormhole-deposit addresses, even
+		/// though their nonce is zero.
+		///
+		/// The soundness counter assumes an ambiguous (`nonce == 0`) address either holds a
+		/// wormhole deposit or will eventually "reveal" itself by signing a transaction (at which
+		/// point its balance is removed from the pool). Some accounts break that assumption:
+		///
+		/// - **Multisig accounts** spend via their signatories, so the multisig account itself
+		///   never signs and never reveals. Its received funds would otherwise stay counted in
+		///   `PotentialWormholeBalance` forever, and its outflows would never be subtracted.
+		/// - **Keyless accounts** (e.g. pallet/`PalletId` accounts) can never sign at all, so they
+		///   are known not to be wormhole deposits.
+		///
+		/// Counting either kind only inflates the pool (the unsafe direction for the soundness
+		/// bound), so they are excluded here.
+		type NonWormholeAccounts: Contains<<Self as frame_system::Config>::AccountId>;
 
 		/// Volume fee rate in basis points (1 basis point = 0.01%).
 		/// This must match the fee rate used in proof generation.
@@ -649,7 +666,29 @@ pub mod pallet {
 		/// tracking in `record_transfer` (recipient) and the reveal-side tracking in the runtime's
 		/// `WormholeProofRecorderExtension` (signer) classify addresses through this function.
 		pub fn is_ambiguous_account(account: &<T as frame_system::Config>::AccountId) -> bool {
-			frame_system::Pallet::<T>::account_nonce(account).is_zero()
+			frame_system::Pallet::<T>::account_nonce(account).is_zero() &&
+				!T::NonWormholeAccounts::contains(account)
+		}
+
+		/// Reveal `account`: remove its current free balance from `PotentialWormholeBalance`.
+		///
+		/// This is the deduction side of the soundness counter. It runs when an account stops
+		/// being indistinguishable from a wormhole deposit address:
+		///
+		/// - a regular account the first time it signs a transaction (see
+		///   `WormholeProofRecorderExtension::validate` in the runtime), and
+		/// - a multisig address at creation time (see `OnMultisigCreated`), which covers the case
+		///   where funds were sent to a pre-computed multisig address before it was created.
+		///
+		/// Idempotent in practice: once revealed, an account is excluded from
+		/// `is_ambiguous_account`, so its later receipts are never re-added to the pool.
+		pub fn reveal_account(account: &<T as frame_system::Config>::AccountId) {
+			let balance = <T::Currency as Currency<_>>::free_balance(account);
+			if !balance.is_zero() {
+				PotentialWormholeBalance::<T>::mutate(|total| {
+					*total = total.saturating_sub(balance);
+				});
+			}
 		}
 
 		/// Record a transfer in the ZK tree and emit events.
@@ -730,6 +769,10 @@ pub mod pallet {
 		) {
 			let asset_id_value = asset_id.unwrap_or_default();
 			Self::record_transfer(asset_id_value, &from, &to, amount);
+		}
+
+		fn reveal_address(account: <T as Config>::WormholeAccountId) {
+			Self::reveal_account(&account.into());
 		}
 	}
 }

--- a/pallets/wormhole/src/migrations.rs
+++ b/pallets/wormhole/src/migrations.rs
@@ -1,0 +1,73 @@
+//! Storage migrations for `pallet-wormhole`.
+
+extern crate alloc;
+
+use crate::{Config, Pallet, PotentialWormholeBalance};
+use core::marker::PhantomData;
+use frame_support::{
+	traits::{Currency, Get, UncheckedOnRuntimeUpgrade},
+	weights::Weight,
+};
+
+#[cfg(feature = "try-runtime")]
+use alloc::vec::Vec;
+
+/// v0 -> v1: introduce the wormhole soundness counters.
+pub mod v1 {
+	use super::*;
+
+	/// Seeds [`PotentialWormholeBalance`] on an already-running chain so that wormhole deposits
+	/// made before the soundness tracking existed remain exitable.
+	///
+	/// The seed is `total_issuance()`. Every balance held by an ambiguous (never-signed) address
+	/// is necessarily backed by issued tokens, so total issuance is an upper bound on the value
+	/// that could legitimately be exited. Seeding to it therefore guarantees the upgrade can never
+	/// accidentally trip the soundness invariant on the first post-upgrade exit and brick the
+	/// wormhole. As accounts reveal themselves the counter tightens toward the true ambiguous sum.
+	///
+	/// On a fresh chain this migration does not run (genesis sets the storage version to the
+	/// current value), so `PotentialWormholeBalance` is instead seeded by the block-1
+	/// `record_transfer` calls for genesis endowments.
+	pub struct InitSoundnessCounters<T>(PhantomData<T>);
+
+	impl<T: Config> UncheckedOnRuntimeUpgrade for InitSoundnessCounters<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let seed = T::Currency::total_issuance();
+
+			PotentialWormholeBalance::<T>::put(seed);
+
+			log::info!(
+				target: "runtime::wormhole",
+				"Seeded PotentialWormholeBalance to total issuance: {:?}",
+				seed,
+			);
+
+			// 1 read (total issuance) + 1 write (PotentialWormholeBalance).
+			T::DbWeight::get().reads_writes(1, 1)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+			Ok(Vec::new())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			frame_support::ensure!(
+				PotentialWormholeBalance::<T>::get() >= T::Currency::total_issuance(),
+				"PotentialWormholeBalance must be seeded to at least total issuance"
+			);
+			Ok(())
+		}
+	}
+}
+
+/// Versioned v0 -> v1 migration. Runs [`v1::InitSoundnessCounters`] only when the on-chain
+/// storage version is 0, then bumps the on-chain storage version to 1.
+pub type MigrateV0ToV1<T> = frame_support::migrations::VersionedMigration<
+	0,
+	1,
+	v1::InitSoundnessCounters<T>,
+	Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -127,6 +127,20 @@ parameter_types! {
 	pub const VolumeFeesBurnRate: Permill = Permill::from_percent(50);
 }
 
+/// Sentinel account used in tests to exercise the `NonWormholeAccounts` exclusion path (stands in
+/// for a multisig / keyless account that must never be counted as ambiguous).
+pub fn excluded_account() -> AccountId {
+	account_id(424242)
+}
+
+/// Test exclusion set: excludes [`excluded_account`] from the ambiguous-address heuristic.
+pub struct ExcludedAccounts;
+impl frame_support::traits::Contains<AccountId> for ExcludedAccounts {
+	fn contains(account: &AccountId) -> bool {
+		*account == excluded_account()
+	}
+}
+
 impl pallet_wormhole::Config for Test {
 	type NativeBalance = Balance;
 	type Currency = Balances;
@@ -136,6 +150,7 @@ impl pallet_wormhole::Config for Test {
 	type TransferCount = u64;
 	type MintingAccount = MintingAccount;
 	type MinimumTransferAmount = MinimumTransferAmount;
+	type NonWormholeAccounts = ExcludedAccounts;
 	type VolumeFeeRateBps = VolumeFeeRateBps;
 	type VolumeFeesBurnRate = VolumeFeesBurnRate;
 	type WormholeAccountId = AccountId;

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -316,6 +316,48 @@ mod wormhole_tests {
 	}
 
 	#[test]
+	fn record_transfer_to_non_wormhole_account_does_not_change_potential_balance() {
+		new_test_ext().execute_with(|| {
+			let from = account_id(1);
+			let to = crate::mock::excluded_account();
+			let amount = 25 * UNIT;
+
+			// `to` has nonce == 0 but is in the NonWormholeAccounts set (e.g. a multisig or known
+			// keyless account), so it must not be treated as an ambiguous wormhole deposit.
+			assert!(!Wormhole::is_ambiguous_account(&to));
+			Wormhole::record_transfer(0u32, &from, &to, amount);
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				0,
+				"Transfers to excluded (non-wormhole) addresses must not add to the pool"
+			);
+		});
+	}
+
+	#[test]
+	fn reveal_account_subtracts_free_balance_from_potential_balance() {
+		new_test_ext_with_endowments(vec![(account_id(7), 500 * UNIT)]).execute_with(|| {
+			let revealed = account_id(7);
+			let seeded = 1_000 * UNIT;
+			crate::PotentialWormholeBalance::<Test>::put(seeded);
+
+			// Mirrors funds being sent to a pre-computed multisig address before creation: when
+			// the address is later revealed, its balance is removed from the pool.
+			Wormhole::reveal_account(&revealed);
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				seeded - 500 * UNIT,
+				"reveal_account must subtract the account's free balance from the pool"
+			);
+
+			// Idempotent against over-subtraction: revealing an empty account is a no-op.
+			let before = Wormhole::potential_wormhole_balance();
+			Wormhole::reveal_account(&account_id(99));
+			assert_eq!(Wormhole::potential_wormhole_balance(), before);
+		});
+	}
+
+	#[test]
 	fn migration_seeds_potential_balance_to_total_issuance() {
 		use frame_support::traits::UncheckedOnRuntimeUpgrade;
 

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -272,6 +272,73 @@ mod wormhole_tests {
 			assert_eq!(Wormhole::transfer_count(&address), 1); // Still 1, not 2
 		});
 	}
+
+	// =========================================================================
+	// Soundness counter tracking
+	// =========================================================================
+
+	#[test]
+	fn record_transfer_to_ambiguous_address_increases_potential_balance() {
+		new_test_ext().execute_with(|| {
+			let from = account_id(1);
+			let to = account_id(2);
+			let amount = 25 * UNIT;
+
+			// `to` has never signed (nonce == 0), so it's ambiguous.
+			assert_eq!(Wormhole::potential_wormhole_balance(), 0);
+			Wormhole::record_transfer(0u32, &from, &to, amount);
+			assert_eq!(Wormhole::potential_wormhole_balance(), amount);
+
+			// A second deposit to another ambiguous address accumulates.
+			let to2 = account_id(3);
+			Wormhole::record_transfer(0u32, &from, &to2, amount);
+			assert_eq!(Wormhole::potential_wormhole_balance(), amount * 2);
+		});
+	}
+
+	#[test]
+	fn record_transfer_to_revealed_address_does_not_change_potential_balance() {
+		new_test_ext().execute_with(|| {
+			let from = account_id(1);
+			let to = account_id(2);
+			let amount = 25 * UNIT;
+
+			// Reveal `to` by bumping its nonce above zero.
+			frame_system::Pallet::<Test>::inc_account_nonce(&to);
+
+			Wormhole::record_transfer(0u32, &from, &to, amount);
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				0,
+				"Transfers to revealed (nonce > 0) addresses must not add to the pool"
+			);
+		});
+	}
+
+	#[test]
+	fn migration_seeds_potential_balance_to_total_issuance() {
+		use frame_support::traits::UncheckedOnRuntimeUpgrade;
+
+		new_test_ext().execute_with(|| {
+			// The migration seeds the pool to current total issuance, a safe upper bound on the
+			// value that could be sitting in ambiguous addresses.
+			let alice = account_id(1);
+			let minted = 750 * UNIT;
+			assert_ok!(Balances::mint_into(&alice, minted));
+
+			let issuance = <Balances as Inspect<AccountId>>::total_issuance();
+			assert_eq!(issuance, minted);
+			assert_eq!(Wormhole::potential_wormhole_balance(), 0);
+
+			crate::migrations::v1::InitSoundnessCounters::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				issuance,
+				"Migration must seed PotentialWormholeBalance to total issuance"
+			);
+		});
+	}
 }
 
 /// Tests for aggregated proof verification
@@ -279,7 +346,7 @@ mod wormhole_tests {
 mod aggregated_proof_tests {
 	use crate::{
 		mock::*,
-		pallet::{Error, UsedNullifiers},
+		pallet::{Error, PotentialWormholeBalance, TotalWormholeExits, UsedNullifiers},
 	};
 	use frame_support::{assert_noop, assert_ok};
 	use frame_system::RawOrigin;
@@ -444,10 +511,24 @@ mod aggregated_proof_tests {
 			// Set current block number higher than the proof's block
 			System::set_block_number(block_number + 10);
 
+			// Seed the soundness pool so the exit doesn't trip the invariant.
+			PotentialWormholeBalance::<Test>::put(1_000_000 * UNIT);
+
 			let proof_bytes = get_test_proof_bytes();
+
+			// Expected exit total from the proof's public inputs.
+			let expected_exit: u128 = inputs
+				.account_data
+				.iter()
+				.filter(|a| a.summed_output_amount > 0)
+				.map(|a| (a.summed_output_amount as u128) * crate::SCALE_DOWN_FACTOR)
+				.sum();
 
 			// This should succeed - proof is valid and state matches
 			assert_ok!(Wormhole::verify_aggregated_proof(RawOrigin::None.into(), proof_bytes));
+
+			// TotalWormholeExits should now reflect the exit amount.
+			assert_eq!(TotalWormholeExits::<Test>::get(), expected_exit);
 
 			// Verify nullifiers are now marked as used
 			for nullifier in &inputs.nullifiers {
@@ -484,6 +565,48 @@ mod aggregated_proof_tests {
 	}
 
 	#[test]
+	fn exit_to_ambiguous_address_rejected_when_margin_exhausted() {
+		new_test_ext().execute_with(|| {
+			let proof = deserialize_test_proof();
+			let inputs = parse_aggregated_public_inputs(&proof).expect("Should parse");
+
+			let block_number = inputs.block_data.block_number as u64;
+			let block_hash_bytes: [u8; 32] =
+				inputs.block_data.block_hash.as_ref().try_into().unwrap();
+			frame_system::BlockHash::<Test>::insert(block_number, H256::from(block_hash_bytes));
+			System::set_block_number(block_number + 10);
+
+			let expected_exit: u128 = inputs
+				.account_data
+				.iter()
+				.filter(|a| a.summed_output_amount > 0)
+				.map(|a| (a.summed_output_amount as u128) * crate::SCALE_DOWN_FACTOR)
+				.sum();
+
+			// Margin is exactly zero: the pool has already been fully consumed by prior exits
+			// (potential_balance == total_exits). Exiting into another wormhole (an ambiguous
+			// address) is itself valid, but it must NOT be possible when there is no margin left,
+			// regardless of where the exit lands. The exit account in the fixture is ambiguous.
+			PotentialWormholeBalance::<Test>::put(expected_exit);
+			TotalWormholeExits::<Test>::put(expected_exit);
+
+			let proof_bytes = get_test_proof_bytes();
+			let result = Wormhole::verify_aggregated_proof(RawOrigin::None.into(), proof_bytes);
+
+			assert!(result.is_err());
+			assert_eq!(
+				result.unwrap_err().error,
+				Error::<Test>::SoundnessInvariantViolation.into(),
+				"exit must be rejected when margin is zero, even to an ambiguous address"
+			);
+
+			// State is unchanged: no tokens minted, no counters moved.
+			assert_eq!(TotalWormholeExits::<Test>::get(), expected_exit);
+			assert_eq!(PotentialWormholeBalance::<Test>::get(), expected_exit);
+		});
+	}
+
+	#[test]
 	fn test_verify_aggregated_proof_cannot_replay() {
 		new_test_ext().execute_with(|| {
 			let proof = deserialize_test_proof();
@@ -498,6 +621,9 @@ mod aggregated_proof_tests {
 			frame_system::BlockHash::<Test>::insert(block_number, block_hash);
 			System::set_block_number(block_number + 10);
 
+			// Seed the soundness pool so the exit doesn't trip the invariant.
+			PotentialWormholeBalance::<Test>::put(1_000_000 * UNIT);
+
 			let proof_bytes = get_test_proof_bytes();
 
 			// First submission should succeed
@@ -511,6 +637,35 @@ mod aggregated_proof_tests {
 			assert!(result.is_err());
 			let err = result.unwrap_err();
 			assert_eq!(err.error, Error::<Test>::NullifierAlreadyUsed.into());
+		});
+	}
+
+	#[test]
+	fn test_verify_aggregated_proof_fails_when_soundness_invariant_violated() {
+		new_test_ext().execute_with(|| {
+			let proof = deserialize_test_proof();
+			let inputs = parse_aggregated_public_inputs(&proof).expect("Should parse");
+
+			let block_number = inputs.block_data.block_number as u64;
+			let block_hash_bytes: [u8; 32] =
+				inputs.block_data.block_hash.as_ref().try_into().unwrap();
+			let block_hash = H256::from(block_hash_bytes);
+
+			frame_system::BlockHash::<Test>::insert(block_number, block_hash);
+			System::set_block_number(block_number + 10);
+
+			// PotentialWormholeBalance defaults to 0, so any exit must be rejected: the proof is
+			// valid but there is no recorded deposit backing it.
+			let proof_bytes = get_test_proof_bytes();
+			let result = Wormhole::verify_aggregated_proof(RawOrigin::None.into(), proof_bytes);
+			assert!(result.is_err());
+			assert_eq!(
+				result.unwrap_err().error,
+				Error::<Test>::SoundnessInvariantViolation.into()
+			);
+
+			// Nothing should have been exited.
+			assert_eq!(TotalWormholeExits::<Test>::get(), 0);
 		});
 	}
 

--- a/primitives/wormhole/src/lib.rs
+++ b/primitives/wormhole/src/lib.rs
@@ -71,8 +71,8 @@ pub fn account_id(id: u64) -> sp_core::crypto::AccountId32 {
 pub const MINTING_ACCOUNT: sp_core::crypto::AccountId32 =
 	sp_core::crypto::AccountId32::new([3u8; 32]);
 
-/// Trait for recording transfer proofs in the wormhole pallet.
-/// Other pallets can use this to record proofs when they mint/transfer tokens.
+/// Trait giving other pallets a handle into the wormhole pallet's bookkeeping, without taking a
+/// hard dependency on `pallet-wormhole` itself.
 pub trait TransferProofRecorder<AccountId, AssetId, Balance> {
 	/// Record a transfer proof for native or asset tokens
 	/// - `None` for native tokens (asset_id = 0)
@@ -83,6 +83,15 @@ pub trait TransferProofRecorder<AccountId, AssetId, Balance> {
 		to: AccountId,
 		amount: Balance,
 	);
+
+	/// Reveal `account` to the wormhole soundness counter, removing its current balance from the
+	/// pool of value that could be exited via the wormhole.
+	///
+	/// Used when an account becomes known to be a regular (non-deposit) account. Most accounts
+	/// reveal themselves by signing their first transaction; a multisig never signs, so it is
+	/// revealed at creation time instead (covering funds sent to a pre-computed address before the
+	/// multisig existed).
+	fn reveal_address(account: AccountId);
 }
 
 /// Derive a wormhole address from a 32-byte inner_digest (already hashed).

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -174,6 +174,7 @@ try-runtime = [
 	"pallet-recovery/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
+	"pallet-wormhole/try-runtime",
 	"sp-runtime/try-runtime",
 ]
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -35,7 +35,8 @@ use crate::{
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{
-		AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU8, Get, NeverEnsureOrigin, VariantCountOf,
+		AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU8, Contains, Get, NeverEnsureOrigin,
+		VariantCountOf,
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -54,7 +55,7 @@ use smallvec::smallvec;
 
 use qp_scheduler::BlockNumberOrTimestamp;
 use sp_runtime::{
-	traits::{BlakeTwo256, One},
+	traits::{AccountIdConversion, BlakeTwo256, One},
 	AccountId32, Perbill, Permill,
 };
 use sp_version::RuntimeVersion;
@@ -709,6 +710,7 @@ impl pallet_multisig::Config for Runtime {
 	type PalletId = MultisigPalletId;
 	type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 	type HighSecurity = HighSecurityConfig;
+	type ProofRecorder = Wormhole;
 }
 
 impl TryFrom<RuntimeCall> for pallet_balances::Call<Runtime> {
@@ -740,6 +742,40 @@ parameter_types! {
 	pub const VolumeFeesBurnRate: Permill = Permill::from_percent(50);
 }
 
+/// Accounts excluded from the wormhole "ambiguous address" heuristic even though their nonce is
+/// zero, i.e. accounts that are known not to be wormhole deposit addresses. Counting any of these
+/// would only inflate the soundness pool (the unsafe direction), and their balances can never
+/// actually be exited via the wormhole.
+pub struct NonWormholeAccounts;
+impl Contains<AccountId> for NonWormholeAccounts {
+	fn contains(account: &AccountId) -> bool {
+		// Registered multisigs spend through their signatories, so the multisig account itself
+		// never signs and never reveals itself. (Funds sent to a pre-computed multisig address
+		// before creation are reconciled by `reveal_address` at creation time.)
+		if pallet_multisig::Pallet::<Runtime>::is_multisig(account) {
+			return true;
+		}
+
+		// The treasury receives a block reward every block but is a keyless governance account
+		// (a multisig that need not be registered in the multisig pallet), not a wormhole deposit.
+		if pallet_treasury::Pallet::<Runtime>::treasury_account().as_ref() == Some(account) {
+			return true;
+		}
+
+		// Genuinely keyless accounts that can never sign, and so can never hold a wormhole
+		// deposit: the `PalletId`-derived pallet accounts and the sentinel minting addresses used
+		// as the `from` side of minted transfers.
+		let keyless: [AccountId; 5] = [
+			TreasuryPalletId::get().into_account_truncating(),
+			MultisigPalletId::get().into_account_truncating(),
+			ReversibleTransfersPalletIdValue::get().into_account_truncating(),
+			MintingAccount::get(),
+			AssetMintingAccount::get(),
+		];
+		keyless.iter().any(|keyless_account| keyless_account == account)
+	}
+}
+
 impl pallet_wormhole::Config for Runtime {
 	type NativeBalance = Balance;
 	type Currency = Balances;
@@ -751,6 +787,7 @@ impl pallet_wormhole::Config for Runtime {
 	/// Both pallets mint native tokens and should use the same sentinel "from" address.
 	type MintingAccount = MintingAccount;
 	type MinimumTransferAmount = WormholeMinimumTransferAmount;
+	type NonWormholeAccounts = NonWormholeAccounts;
 	type VolumeFeeRateBps = VolumeFeeRateBps;
 	type VolumeFeesBurnRate = VolumeFeesBurnRate;
 	type WormholeAccountId = AccountId32;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -742,6 +742,24 @@ parameter_types! {
 	pub const VolumeFeesBurnRate: Permill = Permill::from_percent(50);
 }
 
+parameter_types! {
+	/// Genuinely keyless accounts that can never sign a transaction, and so can never hold a
+	/// wormhole deposit. Excluded from the "ambiguous address" heuristic.
+	///
+	/// These are the `PalletId`-derived pallet accounts and the sentinel minting addresses used as
+	/// the `from` side of minted transfers. The treasury entry here is the *conventional*
+	/// `PalletId`-derived address (`py/trsry`); the actually-*configured* treasury account (which
+	/// may differ in this fork) is excluded separately in `NonWormholeAccounts::contains` via the
+	/// runtime `treasury_account()` storage getter.
+	pub KeylessNonWormholeAccounts: [AccountId; 5] = [
+		TreasuryPalletId::get().into_account_truncating(),
+		MultisigPalletId::get().into_account_truncating(),
+		ReversibleTransfersPalletIdValue::get().into_account_truncating(),
+		MintingAccount::get(),
+		AssetMintingAccount::get(),
+	];
+}
+
 /// Accounts excluded from the wormhole "ambiguous address" heuristic even though their nonce is
 /// zero, i.e. accounts that are known not to be wormhole deposit addresses. Counting any of these
 /// would only inflate the soundness pool (the unsafe direction), and their balances can never
@@ -756,23 +774,15 @@ impl Contains<AccountId> for NonWormholeAccounts {
 			return true;
 		}
 
-		// The treasury receives a block reward every block but is a keyless governance account
-		// (a multisig that need not be registered in the multisig pallet), not a wormhole deposit.
+		// The configured treasury account receives a block reward every block but is a keyless
+		// governance account (a multisig that need not be registered in the multisig pallet), not
+		// a wormhole deposit. In this fork the treasury address is configurable, so we read the
+		// real one rather than assuming the `PalletId`-derived default below.
 		if pallet_treasury::Pallet::<Runtime>::treasury_account().as_ref() == Some(account) {
 			return true;
 		}
 
-		// Genuinely keyless accounts that can never sign, and so can never hold a wormhole
-		// deposit: the `PalletId`-derived pallet accounts and the sentinel minting addresses used
-		// as the `from` side of minted transfers.
-		let keyless: [AccountId; 5] = [
-			TreasuryPalletId::get().into_account_truncating(),
-			MultisigPalletId::get().into_account_truncating(),
-			ReversibleTransfersPalletIdValue::get().into_account_truncating(),
-			MintingAccount::get(),
-			AssetMintingAccount::get(),
-		];
-		keyless.iter().any(|keyless_account| keyless_account == account)
+		KeylessNonWormholeAccounts::get().iter().any(|keyless| keyless == account)
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 131,
+	spec_version: 132,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -162,6 +162,12 @@ pub type UncheckedExtrinsic =
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, TxExtension>;
 
+/// All storage migrations to run on runtime upgrade.
+pub type Migrations = (
+	// v0 -> v1: seed the wormhole soundness counters so pre-upgrade deposits remain exitable.
+	pallet_wormhole::migrations::MigrateV0ToV1<Runtime>,
+);
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -169,7 +175,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(),
+	Migrations,
 >;
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -109,12 +109,16 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	}
 
 	fn count_transfers(call: &RuntimeCall) -> u64 {
+		// NOTE: this must stay in sync with the events matched by `record_proofs_from_events_since`
+		// — we only weight calls whose emitted events we actually record. In particular
+		// `Balances::force_set_balance` is deliberately NOT counted here: it emits `BalanceSet`
+		// (an absolute set, not a transfer/mint), which we cannot turn into a transfer proof and
+		// therefore never record. See the soundness-counter caveat on `reduce_potential_balance`.
 		match call {
 			RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::transfer_all { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::force_transfer { .. }) |
-			RuntimeCall::Balances(pallet_balances::Call::force_set_balance { .. }) |
 			RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) |
 			RuntimeCall::Assets(pallet_assets::Call::transfer_keep_alive { .. }) |
 			RuntimeCall::Assets(pallet_assets::Call::transfer_approved { .. }) |
@@ -266,9 +270,14 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		// the fee charge), so the nonce check is accurate and the captured balance is the
 		// pre-deduction balance. Unsigned transactions (e.g. wormhole exits) have no signer and
 		// are skipped.
+		// We subtract `total_balance` (free + reserved), not just free: an ambiguous account cannot
+		// spend (spending requires signing, which reveals it), so its total balance equals the sum
+		// of credits it received — which is exactly what was added to the pool, provided every
+		// credit path was tracked. (See the caveat on `reduce_potential_balance` re: untracked
+		// credits such as `force_set_balance`.)
 		let reveal_balance = match ensure_signed(origin.clone()) {
 			Ok(signer) if pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer) =>
-				Some(<Balances as Currency<AccountId>>::free_balance(&signer)),
+				Some(<Balances as Currency<AccountId>>::total_balance(&signer)),
 			_ => None,
 		};
 

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -3,9 +3,8 @@ extern crate alloc;
 use crate::*;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use core::marker::PhantomData;
-use frame_support::{
-	pallet_prelude::{InvalidTransaction, TransactionValidityError, ValidTransaction},
-	traits::Currency,
+use frame_support::pallet_prelude::{
+	InvalidTransaction, TransactionValidityError, ValidTransaction,
 };
 use frame_system::ensure_signed;
 use qp_high_security::HighSecurityInspector;
@@ -255,12 +254,7 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		// signers. Unsigned transactions (e.g. wormhole exits) have no signer and are skipped.
 		if let Ok(signer) = ensure_signed(origin.clone()) {
 			if pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer) {
-				let balance = <Balances as Currency<AccountId>>::free_balance(&signer);
-				if balance > 0 {
-					pallet_wormhole::PotentialWormholeBalance::<Runtime>::mutate(|total| {
-						*total = total.saturating_sub(balance);
-					});
-				}
+				pallet_wormhole::Pallet::<Runtime>::reveal_account(&signer);
 			}
 		}
 
@@ -287,7 +281,7 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use frame_support::{assert_ok, pallet_prelude::TransactionValidityError};
+	use frame_support::{assert_ok, pallet_prelude::TransactionValidityError, traits::Currency};
 	use sp_runtime::{traits::TxBaseImplication, AccountId32};
 	fn alice() -> AccountId {
 		AccountId32::from([1; 32])
@@ -982,17 +976,20 @@ mod tests {
 
 	#[test]
 	fn reveal_subtracts_signer_balance_from_potential_pool() {
-		use frame_support::traits::Currency;
 		use sp_runtime::traits::TxBaseImplication;
 
 		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 
-			let signer = alice();
+			// Use a fresh account (not a sentinel/keyless address like alice == [1; 32]) so it is
+			// genuinely ambiguous and not excluded by `NonWormholeAccounts`.
+			let signer = intg_account(80);
+			fund(&signer, 500 * UNIT);
 			let balance = <Balances as Currency<AccountId>>::free_balance(&signer);
 			assert!(balance > 0);
-			// Alice has never signed yet.
+			// The signer has never signed yet.
 			assert_eq!(frame_system::Pallet::<Runtime>::account_nonce(&signer), 0);
+			assert!(pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer));
 
 			// Seed the pool above the signer's balance so the subtraction is observable.
 			let seeded = balance + 1_000 * UNIT;
@@ -1026,8 +1023,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 
-			let signer = alice();
-			// Mark alice as already revealed (nonce > 0).
+			let signer = intg_account(81);
+			fund(&signer, 500 * UNIT);
+			// Mark the signer as already revealed (nonce > 0).
 			frame_system::Pallet::<Runtime>::inc_account_nonce(&signer);
 
 			let seeded = 5_000 * UNIT;
@@ -1297,11 +1295,10 @@ mod tests {
 	}
 
 	// --- mined block rewards flow into the potential pool ---
-	// Mining mints brand-new coins to the miner (and treasury) and records them via
-	// `Wormhole::record_transfer`. Both recipients are ambiguous (never-signed) accounts, so
-	// every freshly minted coin lands in `PotentialWormholeBalance` — exactly the value the
-	// wormhole could later legitimately exit. This guards the soundness invariant against being
-	// tripped by ordinary emission.
+	// Mining mints brand-new coins to the miner (ambiguous, never-signed) and the treasury (a
+	// keyless governance account, excluded via `NonWormholeAccounts`). Only the miner's portion is
+	// indistinguishable from a wormhole deposit, so only it lands in `PotentialWormholeBalance`;
+	// the treasury's portion is correctly excluded since it can never be exited via the wormhole.
 	#[test]
 	fn counter_mining_rewards_increase_potential_balance() {
 		use frame_support::traits::Hooks;
@@ -1335,17 +1332,88 @@ mod tests {
 
 			// New coins were actually minted, and the miner was credited.
 			assert!(issuance_after > issuance_before, "block reward must mint new coins");
-			assert!(
-				<Balances as Currency<AccountId>>::free_balance(&miner_account) > 0,
-				"miner must be credited the mined reward"
-			);
+			let miner_reward = <Balances as Currency<AccountId>>::free_balance(&miner_account);
+			assert!(miner_reward > 0, "miner must be credited the mined reward");
 
-			// Every freshly minted coin went to an ambiguous account (miner + treasury), so the
-			// whole emission shows up as new potential wormhole balance.
+			// The treasury portion is excluded (keyless governance account), so the pool grows by
+			// the miner's ambiguous portion only — and by strictly less than the full emission.
 			assert_eq!(
 				pool_after - pool_before,
-				issuance_after - issuance_before,
-				"mined coins must increase PotentialWormholeBalance by the full emission"
+				miner_reward,
+				"only the miner's (ambiguous) portion of the reward increases PotentialWormholeBalance"
+			);
+			assert!(
+				pool_after - pool_before < issuance_after - issuance_before,
+				"the excluded treasury portion must not be counted into the pool"
+			);
+		});
+	}
+
+	// --- multisig creation reveals a pre-funded address ---
+	// A multisig never signs (it spends via its signatories), so it never reveals itself the way
+	// a normal account does. This guards the attack where someone pre-computes a multisig address,
+	// sends funds to it (counted into the pool because it looks ambiguous), then creates the
+	// multisig: creation must deduct the address's balance so it nets zero into the pool, and the
+	// registered multisig must afterwards be excluded from the ambiguous set.
+	#[test]
+	fn counter_multisig_creation_reveals_prefunded_address() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let creator = intg_account(60);
+			let signers = vec![intg_account(61), intg_account(62)];
+			let threshold = 2u32;
+			fund(&creator, 10_000 * UNIT);
+			mark_revealed(&creator);
+
+			// Pre-compute the multisig address before it is created.
+			let multisig_addr = Multisig::derive_multisig_address(&signers, threshold, 0);
+			assert!(
+				pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&multisig_addr),
+				"pre-creation multisig address must look ambiguous"
+			);
+
+			// Attacker pre-funds the pre-computed address; record_transfer counts it.
+			let sender = intg_account(63);
+			fund(&sender, 5_000 * UNIT);
+			mark_revealed(&sender);
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			let prefund = 1_000 * UNIT;
+			run_transfer(&sender, &multisig_addr, prefund);
+			assert_eq!(
+				pool(),
+				POOL_BASE + prefund,
+				"pre-funding a pre-computed (ambiguous-looking) address is counted into the pool"
+			);
+			assert_eq!(<Balances as Currency<AccountId>>::free_balance(&multisig_addr), prefund);
+
+			// Create the multisig at the same derived address.
+			assert_ok!(Multisig::create_multisig(
+				RuntimeOrigin::signed(creator.clone()),
+				signers.clone(),
+				threshold,
+				0,
+			));
+
+			// Creation reveals the address: its balance is removed from the pool, exactly undoing
+			// the pre-funding, so the multisig nets zero into the soundness pool.
+			assert_eq!(
+				pool(),
+				POOL_BASE,
+				"multisig creation must deduct the pre-funded balance from the pool"
+			);
+			assert!(
+				!pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&multisig_addr),
+				"registered multisig must no longer be treated as ambiguous"
+			);
+
+			// A later receipt to the now-registered multisig is not re-counted.
+			run_transfer(&sender, &multisig_addr, 100 * UNIT);
+			assert_eq!(
+				pool(),
+				POOL_BASE,
+				"post-creation receipts to a registered multisig must not be counted"
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -3,8 +3,9 @@ extern crate alloc;
 use crate::*;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use core::marker::PhantomData;
-use frame_support::pallet_prelude::{
-	InvalidTransaction, TransactionValidityError, ValidTransaction,
+use frame_support::{
+	pallet_prelude::{InvalidTransaction, TransactionValidityError, ValidTransaction},
+	traits::Currency,
 };
 use frame_system::ensure_signed;
 use qp_high_security::HighSecurityInspector;
@@ -207,12 +208,18 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 
 	fn weight(&self, call: &RuntimeCall) -> Weight {
 		let n = Self::count_transfers(call);
-		if n > 0 {
+		let transfer_weight = if n > 0 {
 			// Per transfer: 1 read (TransferCount) + 2 writes (TransferProof + TransferCount)
 			T::DbWeight::get().reads_writes(n, 2 * n)
 		} else {
 			Weight::zero()
-		}
+		};
+
+		// Soundness reveal bookkeeping done in `validate`: worst case reads the signer's nonce
+		// and balance and writes `PotentialWormholeBalance` once.
+		let reveal_weight = T::DbWeight::get().reads_writes(2, 1);
+
+		transfer_weight.saturating_add(reveal_weight)
 	}
 
 	fn prepare(
@@ -230,7 +237,7 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 
 	fn validate(
 		&self,
-		_origin: sp_runtime::traits::DispatchOriginOf<RuntimeCall>,
+		origin: sp_runtime::traits::DispatchOriginOf<RuntimeCall>,
 		_call: &RuntimeCall,
 		_info: &DispatchInfoOf<RuntimeCall>,
 		_len: usize,
@@ -238,8 +245,26 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		_inherited_implication: &impl sp_runtime::traits::Implication,
 		_source: frame_support::pallet_prelude::TransactionSource,
 	) -> sp_runtime::traits::ValidateResult<Self::Val, RuntimeCall> {
-		// No validation needed - just return Ok
-		Ok((ValidTransaction::default(), (), _origin))
+		// Soundness tracking: when an account signs for the very first time it reveals itself as
+		// a regular dilithium account rather than a wormhole deposit address. Remove its balance
+		// from the potential wormhole pool.
+		//
+		// We detect "first signature" by `nonce == 0`. This runs in `validate`, which executes
+		// before `CheckNonce::prepare` increments the nonce (all extensions' `validate` run
+		// before any extension's `prepare`), so `nonce == 0` correctly identifies first-time
+		// signers. Unsigned transactions (e.g. wormhole exits) have no signer and are skipped.
+		if let Ok(signer) = ensure_signed(origin.clone()) {
+			if pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer) {
+				let balance = <Balances as Currency<AccountId>>::free_balance(&signer);
+				if balance > 0 {
+					pallet_wormhole::PotentialWormholeBalance::<Runtime>::mutate(|total| {
+						*total = total.saturating_sub(balance);
+					});
+				}
+			}
+		}
+
+		Ok((ValidTransaction::default(), (), origin))
 	}
 
 	fn post_dispatch(
@@ -297,6 +322,11 @@ mod tests {
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
+
+		// Treasury account + portion are required for mining-reward distribution.
+		pallet_treasury::GenesisConfig::<Runtime>::default()
+			.assimilate_storage(&mut t)
+			.unwrap();
 
 		sp_io::TestExternalities::new(t)
 	}
@@ -516,12 +546,16 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let ext = WormholeProofRecorderExtension::<Runtime>::new();
 
+			// Even non-transfer calls carry the constant soundness reveal-bookkeeping overhead
+			// (read nonce + balance, possibly write the pool), so the base weight is non-zero.
+			let reveal_weight =
+				<Runtime as frame_system::Config>::DbWeight::get().reads_writes(2, 1);
 			let non_transfer =
 				RuntimeCall::System(frame_system::Call::remark { remark: vec![1, 2, 3] });
-			let weight = <WormholeProofRecorderExtension<Runtime> as TransactionExtension<
+			let base_weight = <WormholeProofRecorderExtension<Runtime> as TransactionExtension<
 				RuntimeCall,
 			>>::weight(&ext, &non_transfer);
-			assert_eq!(weight, Weight::zero());
+			assert_eq!(base_weight, reveal_weight);
 
 			let transfer = RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
 				dest: MultiAddress::Id(bob()),
@@ -530,7 +564,8 @@ mod tests {
 			let weight = <WormholeProofRecorderExtension<Runtime> as TransactionExtension<
 				RuntimeCall,
 			>>::weight(&ext, &transfer);
-			assert!(weight.ref_time() > 0);
+			// A transfer adds per-transfer cost on top of the reveal overhead.
+			assert!(weight.ref_time() > base_weight.ref_time());
 
 			let batch = RuntimeCall::Utility(pallet_utility::Call::batch {
 				calls: vec![
@@ -937,6 +972,380 @@ mod tests {
 				count_after,
 				count_before + 1,
 				"Transfer count should increment for multisig transfer"
+			);
+		});
+	}
+
+	// =========================================================================
+	// Soundness reveal tracking
+	// =========================================================================
+
+	#[test]
+	fn reveal_subtracts_signer_balance_from_potential_pool() {
+		use frame_support::traits::Currency;
+		use sp_runtime::traits::TxBaseImplication;
+
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let signer = alice();
+			let balance = <Balances as Currency<AccountId>>::free_balance(&signer);
+			assert!(balance > 0);
+			// Alice has never signed yet.
+			assert_eq!(frame_system::Pallet::<Runtime>::account_nonce(&signer), 0);
+
+			// Seed the pool above the signer's balance so the subtraction is observable.
+			let seeded = balance + 1_000 * UNIT;
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(seeded);
+
+			let ext = WormholeProofRecorderExtension::<Runtime>::new();
+			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+			let result = ext.validate(
+				RuntimeOrigin::signed(signer.clone()),
+				&call,
+				&Default::default(),
+				0,
+				(),
+				&TxBaseImplication::<()>(()),
+				frame_support::pallet_prelude::TransactionSource::External,
+			);
+			assert_ok!(result);
+
+			assert_eq!(
+				pallet_wormhole::PotentialWormholeBalance::<Runtime>::get(),
+				seeded - balance,
+				"Revealing (first signature) must subtract the signer's balance from the pool"
+			);
+		});
+	}
+
+	#[test]
+	fn reveal_is_noop_for_already_revealed_signer() {
+		use sp_runtime::traits::TxBaseImplication;
+
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let signer = alice();
+			// Mark alice as already revealed (nonce > 0).
+			frame_system::Pallet::<Runtime>::inc_account_nonce(&signer);
+
+			let seeded = 5_000 * UNIT;
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(seeded);
+
+			let ext = WormholeProofRecorderExtension::<Runtime>::new();
+			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+			let result = ext.validate(
+				RuntimeOrigin::signed(signer),
+				&call,
+				&Default::default(),
+				0,
+				(),
+				&TxBaseImplication::<()>(()),
+				frame_support::pallet_prelude::TransactionSource::External,
+			);
+			assert_ok!(result);
+
+			assert_eq!(
+				pallet_wormhole::PotentialWormholeBalance::<Runtime>::get(),
+				seeded,
+				"Already-revealed signers must not change the pool"
+			);
+		});
+	}
+
+	// =========================================================================
+	// Full-transaction integration tests for PotentialWormholeBalance
+	//
+	// These drive the WormholeProofRecorderExtension lifecycle the way the real
+	// transaction pipeline does:
+	//   validate()  -> reveal subtraction (sees the pre-tx, un-incremented nonce)
+	//   prepare()   -> snapshot event count
+	//   [CheckNonce::prepare bumps the signer nonce]
+	//   dispatch    -> the call executes and emits Transfer event(s)
+	//   post_dispatch() -> record_transfer() applies the deposit addition
+	//
+	// so BOTH sides of the counter are exercised together, and we assert the net
+	// change to `PotentialWormholeBalance` for each sender/recipient combination.
+	// =========================================================================
+
+	/// Pool baseline large enough that reveal subtractions never saturate at zero.
+	const POOL_BASE: Balance = 10_000_000 * UNIT;
+	const SENDER_BAL: Balance = 1_000 * UNIT;
+
+	fn intg_account(tag: u8) -> AccountId {
+		AccountId32::from([tag; 32])
+	}
+
+	fn fund(who: &AccountId, amount: Balance) {
+		use frame_support::traits::fungible::Mutate;
+		assert_ok!(<Balances as Mutate<AccountId>>::mint_into(who, amount));
+	}
+
+	/// Mark an account as "revealed" (has signed before) by giving it a non-zero nonce.
+	fn mark_revealed(who: &AccountId) {
+		frame_system::Pallet::<Runtime>::inc_account_nonce(who);
+	}
+
+	/// Run a full transaction (whatever `dispatch` performs) through the extension lifecycle.
+	/// `call` is the call presented to validate/prepare; `dispatch` performs the real execution.
+	fn run_lifecycle(from: &AccountId, call: RuntimeCall, dispatch: impl FnOnce()) {
+		use sp_runtime::traits::TxBaseImplication;
+
+		let ext = WormholeProofRecorderExtension::<Runtime>::new();
+		let origin = RuntimeOrigin::signed(from.clone());
+
+		// validate(): reveal runs here against the pre-tx (un-incremented) nonce.
+		let (_, val, _) = ext
+			.validate(
+				origin.clone(),
+				&call,
+				&Default::default(),
+				0,
+				(),
+				&TxBaseImplication::<()>(()),
+				frame_support::pallet_prelude::TransactionSource::External,
+			)
+			.expect("validate should succeed");
+
+		// prepare(): snapshot the event count before the call emits its Transfer event(s).
+		let pre = ext
+			.clone()
+			.prepare(val, &origin, &call, &Default::default(), 0)
+			.expect("prepare should succeed");
+
+		// CheckNonce::prepare would bump the signer's nonce at this point.
+		mark_revealed(from);
+
+		// Execute the real call (emits the Transfer event(s) that post_dispatch scans).
+		dispatch();
+
+		// post_dispatch(): records the transfer proof(s), applying the deposit side.
+		let mut post_info = frame_support::dispatch::PostDispatchInfo::default();
+		<WormholeProofRecorderExtension<Runtime> as TransactionExtension<RuntimeCall>>::post_dispatch(
+			pre,
+			&Default::default(),
+			&mut post_info,
+			0,
+			&Ok(()),
+		)
+		.expect("post_dispatch should succeed");
+	}
+
+	fn transfer_call(to: &AccountId, amount: Balance) -> RuntimeCall {
+		RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
+			dest: MultiAddress::Id(to.clone()),
+			value: amount,
+		})
+	}
+
+	/// Run a full single native transfer from `from` to `to`.
+	fn run_transfer(from: &AccountId, to: &AccountId, amount: Balance) {
+		let from = from.clone();
+		let to = to.clone();
+		run_lifecycle(&from, transfer_call(&to, amount), || {
+			assert_ok!(Balances::transfer_keep_alive(
+				RuntimeOrigin::signed(from.clone()),
+				MultiAddress::Id(to.clone()),
+				amount,
+			));
+		});
+	}
+
+	fn pool() -> Balance {
+		pallet_wormhole::PotentialWormholeBalance::<Runtime>::get()
+	}
+
+	// --- recipient ambiguous, sender already revealed: deposit only ---
+	#[test]
+	fn counter_to_ambiguous_from_revealed_adds_deposit_only() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(40);
+			let to = intg_account(41);
+			fund(&from, SENDER_BAL);
+			mark_revealed(&from); // sender has outgoing history
+						 // `to` keeps nonce 0 (ambiguous)
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			let amount = 100 * UNIT;
+			run_transfer(&from, &to, amount);
+
+			assert_eq!(pool(), POOL_BASE + amount, "deposit to ambiguous recipient adds amount");
+		});
+	}
+
+	// --- recipient revealed, sender already revealed: no change ---
+	#[test]
+	fn counter_to_revealed_from_revealed_no_change() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(42);
+			let to = intg_account(43);
+			fund(&from, SENDER_BAL);
+			mark_revealed(&from);
+			mark_revealed(&to); // recipient already has outgoing history
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			run_transfer(&from, &to, 100 * UNIT);
+
+			assert_eq!(pool(), POOL_BASE, "neither side is ambiguous: no change");
+		});
+	}
+
+	// --- sender ambiguous (first tx -> reveal), recipient revealed: reveal only ---
+	#[test]
+	fn counter_from_ambiguous_to_revealed_subtracts_sender_balance() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(44);
+			let to = intg_account(45);
+			fund(&from, SENDER_BAL); // from stays nonce 0 (ambiguous, will reveal)
+			mark_revealed(&to);
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			run_transfer(&from, &to, 100 * UNIT);
+
+			assert_eq!(
+				pool(),
+				POOL_BASE - SENDER_BAL,
+				"first signature subtracts the sender's full pre-tx balance"
+			);
+		});
+	}
+
+	// --- sender ambiguous AND recipient ambiguous: reveal and deposit both fire ---
+	#[test]
+	fn counter_from_ambiguous_to_ambiguous_applies_both() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(46);
+			let to = intg_account(47);
+			fund(&from, SENDER_BAL); // ambiguous
+							// `to` keeps nonce 0 (ambiguous)
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			let amount = 100 * UNIT;
+			run_transfer(&from, &to, amount);
+
+			assert_eq!(
+				pool(),
+				POOL_BASE + amount - SENDER_BAL,
+				"deposit (+amount) and reveal (-sender balance) both apply"
+			);
+		});
+	}
+
+	// --- sender's second tx must NOT reveal again ---
+	#[test]
+	fn counter_sender_reveals_only_on_first_tx() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(48);
+			let to1 = intg_account(49);
+			let to2 = intg_account(50);
+			fund(&from, SENDER_BAL); // ambiguous
+			mark_revealed(&to1); // isolate the reveal: no deposit on either transfer
+			mark_revealed(&to2);
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			// First tx reveals the sender.
+			run_transfer(&from, &to1, 100 * UNIT);
+			assert_eq!(pool(), POOL_BASE - SENDER_BAL, "first tx reveals sender");
+
+			// Second tx: sender nonce is now > 0, so no further subtraction.
+			run_transfer(&from, &to2, 50 * UNIT);
+			assert_eq!(
+				pool(),
+				POOL_BASE - SENDER_BAL,
+				"second tx from the same sender must not reveal again"
+			);
+		});
+	}
+
+	// --- batch from an ambiguous sender: reveal ONCE, count EACH deposit ---
+	#[test]
+	fn counter_batch_from_ambiguous_reveals_once_counts_each_deposit() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = intg_account(51);
+			let to1 = intg_account(52); // ambiguous
+			let to2 = intg_account(53); // ambiguous
+			fund(&from, SENDER_BAL); // ambiguous
+			pallet_wormhole::PotentialWormholeBalance::<Runtime>::put(POOL_BASE);
+
+			let a1 = 100 * UNIT;
+			let a2 = 50 * UNIT;
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch {
+				calls: vec![transfer_call(&to1, a1), transfer_call(&to2, a2)],
+			});
+
+			run_lifecycle(&from, batch, || {
+				assert_ok!(Utility::batch(
+					RuntimeOrigin::signed(from.clone()),
+					vec![transfer_call(&to1, a1), transfer_call(&to2, a2)],
+				));
+			});
+
+			// Reveal applies once (-SENDER_BAL); both deposits apply (+a1 +a2).
+			assert_eq!(
+				pool(),
+				POOL_BASE + a1 + a2 - SENDER_BAL,
+				"batch reveals the sender once and counts each ambiguous-recipient deposit"
+			);
+		});
+	}
+
+	// --- mined block rewards flow into the potential pool ---
+	// Mining mints brand-new coins to the miner (and treasury) and records them via
+	// `Wormhole::record_transfer`. Both recipients are ambiguous (never-signed) accounts, so
+	// every freshly minted coin lands in `PotentialWormholeBalance` — exactly the value the
+	// wormhole could later legitimately exit. This guards the soundness invariant against being
+	// tripped by ordinary emission.
+	#[test]
+	fn counter_mining_rewards_increase_potential_balance() {
+		use frame_support::traits::Hooks;
+		use qp_wormhole::TestMiner;
+		use sp_consensus_qpow::POW_ENGINE_ID;
+		use sp_runtime::DigestItem;
+
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let miner = TestMiner(777);
+			let miner_account = miner.account_id();
+
+			// A freshly derived miner has never signed a transaction, so it is ambiguous.
+			assert!(
+				pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&miner_account),
+				"freshly derived miner account must be ambiguous (nonce == 0)"
+			);
+
+			// Announce the miner for this block via the pre-runtime digest.
+			System::deposit_log(DigestItem::PreRuntime(POW_ENGINE_ID, miner.preimage().to_vec()));
+
+			let issuance_before = <Balances as Currency<AccountId>>::total_issuance();
+			let pool_before = pool();
+
+			// Mine the block: mints the reward to miner + treasury and records the proofs.
+			MiningRewards::on_finalize(1);
+
+			let issuance_after = <Balances as Currency<AccountId>>::total_issuance();
+			let pool_after = pool();
+
+			// New coins were actually minted, and the miner was credited.
+			assert!(issuance_after > issuance_before, "block reward must mint new coins");
+			assert!(
+				<Balances as Currency<AccountId>>::free_balance(&miner_account) > 0,
+				"miner must be credited the mined reward"
+			);
+
+			// Every freshly minted coin went to an ambiguous account (miner + treasury), so the
+			// whole emission shows up as new potential wormhole balance.
+			assert_eq!(
+				pool_after - pool_before,
+				issuance_after - issuance_before,
+				"mined coins must increase PotentialWormholeBalance by the full emission"
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -3,8 +3,9 @@ extern crate alloc;
 use crate::*;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use core::marker::PhantomData;
-use frame_support::pallet_prelude::{
-	InvalidTransaction, TransactionValidityError, ValidTransaction,
+use frame_support::{
+	pallet_prelude::{InvalidTransaction, TransactionValidityError, ValidTransaction},
+	traits::Currency,
 };
 use frame_system::ensure_signed;
 use qp_high_security::HighSecurityInspector;
@@ -200,7 +201,10 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 	for WormholeProofRecorderExtension<T>
 {
 	type Pre = u32;
-	type Val = ();
+	/// Carries the pre-fee balance captured in `validate` for a first-time signer that must be
+	/// revealed (subtracted from the potential wormhole pool). `None` when there is nothing to
+	/// reveal. The actual subtraction is committed in `prepare`.
+	type Val = Option<Balance>;
 	type Implicit = ();
 
 	const IDENTIFIER: &'static str = "WormholeProofRecorderExtension";
@@ -214,8 +218,8 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 			Weight::zero()
 		};
 
-		// Soundness reveal bookkeeping done in `validate`: worst case reads the signer's nonce
-		// and balance and writes `PotentialWormholeBalance` once.
+		// Soundness reveal bookkeeping: `validate` reads the signer's nonce and balance, and
+		// `prepare` writes `PotentialWormholeBalance` once.
 		let reveal_weight = T::DbWeight::get().reads_writes(2, 1);
 
 		transfer_weight.saturating_add(reveal_weight)
@@ -223,12 +227,19 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 
 	fn prepare(
 		self,
-		_val: Self::Val,
+		val: Self::Val,
 		_origin: &sp_runtime::traits::DispatchOriginOf<RuntimeCall>,
 		_call: &RuntimeCall,
 		_info: &sp_runtime::traits::DispatchInfoOf<RuntimeCall>,
 		_len: usize,
 	) -> Result<Self::Pre, TransactionValidityError> {
+		// Commit the soundness reveal detected in `validate`. This is done here, not in `validate`,
+		// because `validate` must be side-effect free (it can be re-run against discarded overlays
+		// during pool validation), whereas `prepare` runs once as a committed pre-dispatch step.
+		if let Some(balance) = val {
+			pallet_wormhole::Pallet::<Runtime>::reduce_potential_balance(balance);
+		}
+
 		// Snapshot current event count so we only process events added by this tx
 		// (and any events from previous txs in the same block).
 		Ok(frame_system::Pallet::<Runtime>::event_count())
@@ -245,20 +256,23 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		_source: frame_support::pallet_prelude::TransactionSource,
 	) -> sp_runtime::traits::ValidateResult<Self::Val, RuntimeCall> {
 		// Soundness tracking: when an account signs for the very first time it reveals itself as
-		// a regular dilithium account rather than a wormhole deposit address. Remove its balance
-		// from the potential wormhole pool.
+		// a regular dilithium account rather than a wormhole deposit address, so its balance must
+		// be removed from the potential wormhole pool.
 		//
-		// We detect "first signature" by `nonce == 0`. This runs in `validate`, which executes
-		// before `CheckNonce::prepare` increments the nonce (all extensions' `validate` run
-		// before any extension's `prepare`), so `nonce == 0` correctly identifies first-time
-		// signers. Unsigned transactions (e.g. wormhole exits) have no signer and are skipped.
-		if let Ok(signer) = ensure_signed(origin.clone()) {
-			if pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer) {
-				pallet_wormhole::Pallet::<Runtime>::reveal_account(&signer);
-			}
-		}
+		// `validate` is kept side-effect free: here we only *detect* a first-time signer and
+		// capture its balance, returning it via `Val`; the subtraction is committed in `prepare`.
+		// We detect "first signature" by `nonce == 0`. All extensions' `validate` run before any
+		// extension's `prepare` (including `CheckNonce::prepare`, which increments the nonce, and
+		// the fee charge), so the nonce check is accurate and the captured balance is the
+		// pre-deduction balance. Unsigned transactions (e.g. wormhole exits) have no signer and
+		// are skipped.
+		let reveal_balance = match ensure_signed(origin.clone()) {
+			Ok(signer) if pallet_wormhole::Pallet::<Runtime>::is_ambiguous_account(&signer) =>
+				Some(<Balances as Currency<AccountId>>::free_balance(&signer)),
+			_ => None,
+		};
 
-		Ok((ValidTransaction::default(), (), origin))
+		Ok((ValidTransaction::default(), reveal_balance, origin))
 	}
 
 	fn post_dispatch(
@@ -591,7 +605,7 @@ mod tests {
 			let origin = RuntimeOrigin::signed(alice());
 
 			// Prepare should succeed and return current event count
-			let result = ext.prepare((), &origin, &call, &Default::default(), 0);
+			let result = ext.prepare(None, &origin, &call, &Default::default(), 0);
 			assert_ok!(result);
 		});
 	}
@@ -997,16 +1011,28 @@ mod tests {
 
 			let ext = WormholeProofRecorderExtension::<Runtime>::new();
 			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
-			let result = ext.validate(
-				RuntimeOrigin::signed(signer.clone()),
-				&call,
-				&Default::default(),
-				0,
-				(),
-				&TxBaseImplication::<()>(()),
-				frame_support::pallet_prelude::TransactionSource::External,
+			let origin = RuntimeOrigin::signed(signer.clone());
+			let (_, val, _) = ext
+				.validate(
+					origin.clone(),
+					&call,
+					&Default::default(),
+					0,
+					(),
+					&TxBaseImplication::<()>(()),
+					frame_support::pallet_prelude::TransactionSource::External,
+				)
+				.expect("validate should succeed");
+
+			// `validate` must be side-effect free; the subtraction is committed in `prepare`.
+			assert_eq!(
+				pallet_wormhole::PotentialWormholeBalance::<Runtime>::get(),
+				seeded,
+				"validate must not mutate the pool"
 			);
-			assert_ok!(result);
+
+			ext.prepare(val, &origin, &call, &Default::default(), 0)
+				.expect("prepare should succeed");
 
 			assert_eq!(
 				pallet_wormhole::PotentialWormholeBalance::<Runtime>::get(),
@@ -1033,16 +1059,22 @@ mod tests {
 
 			let ext = WormholeProofRecorderExtension::<Runtime>::new();
 			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
-			let result = ext.validate(
-				RuntimeOrigin::signed(signer),
-				&call,
-				&Default::default(),
-				0,
-				(),
-				&TxBaseImplication::<()>(()),
-				frame_support::pallet_prelude::TransactionSource::External,
-			);
-			assert_ok!(result);
+			let origin = RuntimeOrigin::signed(signer);
+			let (_, val, _) = ext
+				.validate(
+					origin.clone(),
+					&call,
+					&Default::default(),
+					0,
+					(),
+					&TxBaseImplication::<()>(()),
+					frame_support::pallet_prelude::TransactionSource::External,
+				)
+				.expect("validate should succeed");
+			assert!(val.is_none(), "an already-revealed signer must capture nothing to reveal");
+
+			ext.prepare(val, &origin, &call, &Default::default(), 0)
+				.expect("prepare should succeed");
 
 			assert_eq!(
 				pallet_wormhole::PotentialWormholeBalance::<Runtime>::get(),

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -216,15 +216,23 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 	fn weight(&self, call: &RuntimeCall) -> Weight {
 		let n = Self::count_transfers(call);
 		let transfer_weight = if n > 0 {
-			// Per transfer: 1 read (TransferCount) + 2 writes (TransferProof + TransferCount)
-			T::DbWeight::get().reads_writes(n, 2 * n)
+			// Per recorded transfer, `record_transfer` touches (worst case):
+			//   reads:  TransferCount (1) + the `is_ambiguous_account` lookup on the recipient,
+			//           which reads the recipient nonce (1) and, when nonce == 0, the
+			//           `NonWormholeAccounts` membership checks `Multisigs` (1) and the configured
+			//           `TreasuryAccount` (1) => 4 reads.
+			//   writes: TransferProof / ZkTree leaf (1) + TransferCount (1) + the conditional
+			//           `PotentialWormholeBalance` deposit add (1) => 3 writes.
+			T::DbWeight::get().reads_writes(4 * n, 3 * n)
 		} else {
 			Weight::zero()
 		};
 
-		// Soundness reveal bookkeeping: `validate` reads the signer's nonce and balance, and
-		// `prepare` writes `PotentialWormholeBalance` once.
-		let reveal_weight = T::DbWeight::get().reads_writes(2, 1);
+		// Soundness reveal bookkeeping for the signer. `validate` runs `is_ambiguous_account` on
+		// the signer — nonce (1) + `Multisigs` (1) + `TreasuryAccount` (1) — and, when ambiguous,
+		// reads the signer's balance (1): 4 reads worst case. `prepare` then writes
+		// `PotentialWormholeBalance` once.
+		let reveal_weight = T::DbWeight::get().reads_writes(4, 1);
 
 		transfer_weight.saturating_add(reveal_weight)
 	}
@@ -564,9 +572,10 @@ mod tests {
 			let ext = WormholeProofRecorderExtension::<Runtime>::new();
 
 			// Even non-transfer calls carry the constant soundness reveal-bookkeeping overhead
-			// (read nonce + balance, possibly write the pool), so the base weight is non-zero.
+			// (read signer nonce + multisig/treasury membership + balance, possibly write the
+			// pool), so the base weight is non-zero.
 			let reveal_weight =
-				<Runtime as frame_system::Config>::DbWeight::get().reads_writes(2, 1);
+				<Runtime as frame_system::Config>::DbWeight::get().reads_writes(4, 1);
 			let non_transfer =
 				RuntimeCall::System(frame_system::Call::remark { remark: vec![1, 2, 3] });
 			let base_weight = <WormholeProofRecorderExtension<Runtime> as TransactionExtension<


### PR DESCRIPTION
# Wormhole soundness turnstile

## Summary

Adds a Zcash-style turnstile to the zk-wormhole so the chain can never mint more
value out of the wormhole than could possibly have been deposited into it. The
invariant enforced on every exit is:

```
TotalWormholeExits <= PotentialWormholeBalance
```

If a ZK soundness bug ever let a forged proof through, this backstop caps the
damage at the currently-available margin and rejects the exit instead of minting
unbacked tokens.

## How it works

- **`PotentialWormholeBalance`** — running total of value held by *ambiguous*
  addresses (accounts with `nonce == 0`, i.e. that have never signed a
  transaction). These are the addresses that could be wormhole deposits.
- **`TotalWormholeExits`** — cumulative value minted via wormhole exits.
- **Deposit tracking**: `record_transfer` adds to the pool whenever a native
  transfer lands in an ambiguous address (covers ordinary transfers, genesis
  endowments, mining rewards, and exits that flow back into the wormhole).
- **Reveal**: the moment an account first signs a transaction it is no longer
  ambiguous, so `WormholeProofRecorderExtension::validate()` subtracts its
  balance from the pool.
- **Enforcement**: `verify_aggregated_proof` checks `exits_after <= potential_balance`
  *before* minting any exit output, and rejects with `SoundnessInvariantViolation`
  otherwise.

A shared `is_ambiguous_account()` helper is the single source of truth for the
`nonce == 0` heuristic, used by both the deposit-tracking and reveal paths.

## Seeding an already-running chain

On a chain that predates this tracking, wormhole deposits made earlier aren't
reflected in `PotentialWormholeBalance` (it would default to `0`), so the first
legitimate exit would trip the invariant and brick the wormhole.

A one-shot versioned migration (`migrations::v1::InitSoundnessCounters`, wired as
`MigrateV0ToV1`) seeds:

```
PotentialWormholeBalance = total_issuance()
```

Every balance in an ambiguous address is backed by issued tokens, so total
issuance is a safe upper bound on what could legitimately be exited — seeding to
it can never block a valid exit. The pool then tightens toward the true ambiguous
sum as accounts reveal themselves. (We intentionally avoid an extra configurable
buffer: it could only loosen the bound, never make it safer.) On a fresh chain
the migration is skipped and the pool is seeded by the block-1 genesis-endowment
`record_transfer` calls instead.

## Changes

- `pallets/wormhole/src/lib.rs` — `PotentialWormholeBalance` / `TotalWormholeExits`
  storage, `SoundnessInvariantViolation` error, `STORAGE_VERSION = 1`,
  deposit tracking in `record_transfer`, invariant enforcement in
  `verify_aggregated_proof`, and the `is_ambiguous_account()` helper.
- `pallets/wormhole/src/migrations.rs` — v0 -> v1 seeding migration (with
  try-runtime pre/post checks).
- `runtime/src/lib.rs` — wire `MigrateV0ToV1` into `Executive` and bump
  `spec_version` 131 -> 132.
- `runtime/src/transaction_extensions.rs` — reveal logic in the proof-recorder
  extension's `validate()`, weight accounting, and extensive integration tests.
- `Cargo.toml`s — `try-runtime` feature plumbing.
- `docs/wormhole-soundness-detection-plan.md` — design write-up.

## Testing

`pallet-wormhole` (25 pass) and the runtime `transaction_extensions` suite
(27 pass) are green. Coverage includes:

- Deposits to ambiguous vs. revealed addresses.
- The full sender/recipient nonce matrix through a complete transaction
  lifecycle (validate -> prepare -> dispatch -> post_dispatch), including batch
  transfers (sender revealed once, each ambiguous recipient counted).
- Mining rewards: a mined block's full emission flows into the pool (miner and
  treasury are both ambiguous).
- Migration seeds the pool to total issuance.
- **Soundness enforcement**: an exit is rejected with
  `SoundnessInvariantViolation` when the margin is exhausted (`P == E`), even when
  the exit targets an ambiguous address (exiting into another wormhole is valid,
  but must still respect the margin), plus the cold-start `P == 0` case.

## Notes

- The `nonce == 0` heuristic is a deliberate over-approximation of "wormhole
  deposit address": unused accounts are also counted, which only makes the bound
  looser (safe). Revealing tightens it back down.
- Exiting into another wormhole address (ambiguous) is a supported operation; the
  exit output legitimately re-counts toward the pool because it's still inside the
  wormhole system. Margin is only consumed when value leaves to a revealed account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes wormhole exit minting and supply accounting with a runtime migration; a bug in counters or reveal timing could block legitimate exits or weaken the backstop.
> 
> **Overview**
> Adds an on-chain **wormhole soundness turnstile** so cumulative ZK exits cannot exceed value tracked as possibly wormhole-backed. The enforced invariant is `TotalWormholeExits <= PotentialWormholeBalance`.
> 
> **`PotentialWormholeBalance`** grows when native transfers (via `record_transfer`) land on *ambiguous* accounts (`nonce == 0`, via `is_ambiguous_account`). **`TotalWormholeExits`** increases only after successful aggregated exits. **`verify_aggregated_proof`** checks the invariant *before* minting and fails with **`SoundnessInvariantViolation`** otherwise.
> 
> First-time signers *reveal* as non-wormhole: **`WormholeProofRecorderExtension::validate`** subtracts the signer’s free balance from the pool (with updated **weight** accounting). Pallet storage version bumps to **v1**; runtime **`spec_version` 132** wires **`MigrateV0ToV1`**, which one-shot seeds **`PotentialWormholeBalance = total_issuance()`** so pre-tracking deposits are not bricked on live chains.
> 
> Includes design doc, try-runtime feature plumbing, and broad pallet/runtime tests (deposit/reveal matrix, mining rewards, margin-exhausted exits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4e863a7b1774d871faee0d6453f07ae644745b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->