### PR TITLE
Streamline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_DEV_DEBUG: 1
   CARGO_PROFILE_TEST_DEBUG: 1
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   fast-checks:
@@ -35,7 +37,10 @@ jobs:
       - name: Install required components
         run: rustup component add rustfmt --toolchain nightly
       - name: Install taplo
-        run: cargo install taplo-cli --locked
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gunzip > taplo
+          chmod +x taplo
+          sudo mv taplo /usr/local/bin/
       - name: Run format checks
         run: |
           taplo format --check --config taplo.toml
@@ -59,14 +64,19 @@ jobs:
       - name: Setup macOS
         if: matrix.os == 'macos-latest'
         uses: ./.github/actions/macos
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build-${{ matrix.os }}"
+          cache-on-failure: true
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: compile
         run: cargo build --locked --workspace --features runtime-benchmarks,try-runtime
-      - name: Clean build artifacts to free space
-        run: |
-          cargo clean
-          df -h
       - name: test
-        run: SKIP_WASM_BUILD=1 cargo test --locked --workspace --features quantus-runtime/fast-governance
+        run: SKIP_WASM_BUILD=1 cargo nextest run --locked --workspace --features quantus-runtime/fast-governance
 
   analysis:
     name: 🤖 Analysis (Clippy & Doc)
@@ -76,6 +86,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Ubuntu
         uses: ./.github/actions/ubuntu
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "analysis"
+          cache-on-failure: true
       - name: Install required components
         run: rustup component add rust-src clippy
       - name: Run clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: cargo build --locked --workspace --features runtime-benchmarks,try-runtime
       - name: test
         run: SKIP_WASM_BUILD=1 cargo nextest run --locked --workspace --features quantus-runtime/fast-governance
+      - name: doctest
+        run: SKIP_WASM_BUILD=1 cargo test --locked --workspace --doc --features quantus-runtime/fast-governance
 
   analysis:
     name: 🤖 Analysis (Clippy & Doc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,11 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_DEV_DEBUG: 1
   CARGO_PROFILE_TEST_DEBUG: 1
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   fast-checks:
     name: 🏁 Fast Checks (Format)
-    runs-on: ubuntu-latest
+    runs-on: Large-Linux-x64-Runner
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu
@@ -38,7 +36,7 @@ jobs:
         run: rustup component add rustfmt --toolchain nightly
       - name: Install taplo
         run: |
-          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gunzip > taplo
+          curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-linux-x86_64.gz | gunzip > taplo
           chmod +x taplo
           sudo mv taplo /usr/local/bin/
       - name: Run format checks
@@ -54,23 +52,20 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - Large-Linux-x64-Runner
           - macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'Large-Linux-x64-Runner'
         uses: ./.github/actions/ubuntu
       - name: Setup macOS
         if: matrix.os == 'macos-latest'
         uses: ./.github/actions/macos
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "build-${{ matrix.os }}"
-          cache-on-failure: true
+          shared-key: "build-${{ matrix.os == 'Large-Linux-x64-Runner' && 'ubuntu' || matrix.os }}"
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: compile
@@ -83,18 +78,13 @@ jobs:
   analysis:
     name: 🤖 Analysis (Clippy & Doc)
     needs: fast-checks
-    runs-on: ubuntu-latest
+    runs-on: Large-Linux-x64-Runner
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ubuntu
         uses: ./.github/actions/ubuntu
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "analysis"
-          cache-on-failure: true
       - name: Install required components
         run: rustup component add rust-src clippy
       - name: Run clippy


### PR DESCRIPTION
- parallel tests
- download taplo binary instead of building from source
- don't cargo clean before tests
- cache build artifacts with rusty-cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; test execution still uses the same locked workspace and feature flags, with only the runner and caching strategy changed.
> 
> **Overview**
> **CI is tuned for faster feedback** by caching Rust builds, compiling through **sccache**, and running tests with **cargo nextest** instead of plain `cargo test`.
> 
> The **build-and-test** and **analysis** jobs now set `SCCACHE_GHA_ENABLED` / `RUSTC_WRAPPER`, add **mozilla-actions/sccache-action**, and **Swatinem/rust-cache** with per-job `shared-key` values (including OS-specific keys on the matrix). The pre-test **`cargo clean`** step is removed so the compile step’s artifacts can be reused for tests.
> 
> **Fast checks** install **taplo** from a released Linux binary via `curl` rather than `cargo install taplo-cli`, avoiding a source build on every run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5ca2605cc94c66b62d45507eb0e91a2a58de90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->