### PR TITLE
Multisig weight benchmarks

### DIFF
--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -532,6 +532,10 @@ pub mod pallet {
 			// Bookkeeping weight + MaxInnerCallWeight to cover decode + get_dispatch_info cost.
 			// Structured RuntimeCall decode is O(inner_call_count), not O(bytes), so we must
 			// reserve weight for the worst-case inner call to prevent block time overruns.
+			//
+			// Note: MaxInnerCallWeight is a proxy for decode cost, not exact. Decode cost ≠
+			// dispatch weight, but they're correlated (complex calls = more variants to decode).
+			// This is intentionally conservative: over-reservation is refunded on success.
 			<T as Config>::WeightInfo::propose_high_security(call.len() as u32)
 				.saturating_add(T::MaxInnerCallWeight::get())
 		})]

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -438,16 +438,21 @@ pub mod pallet {
 			ensure!(threshold > 0, Error::<T>::ThresholdZero);
 			ensure!(signers.len() >= 2, Error::<T>::NotEnoughSigners);
 
+			// SECURITY: Bound raw input size BEFORE normalization to prevent DoS.
+			// An attacker could submit a huge duplicate-heavy vector; clone/sort/dedup
+			// is O(n log n) on the raw length, but benchmarks only cover MaxSigners.
+			// Reject oversized inputs before doing any expensive work.
+			ensure!(
+				signers.len() <= T::MaxSigners::get() as usize,
+				Error::<T>::TooManySigners
+			);
+
 			// Normalize signers: sort and deduplicate (single authoritative place)
 			let normalized_signers = Self::normalize_signers(&signers);
 
 			// Validate against normalized count (after dedup) - must have at least 2 unique signers
 			ensure!(normalized_signers.len() >= 2, Error::<T>::NotEnoughSigners);
 			ensure!(threshold <= normalized_signers.len() as u32, Error::<T>::ThresholdTooHigh);
-			ensure!(
-				normalized_signers.len() <= T::MaxSigners::get() as usize,
-				Error::<T>::TooManySigners
-			);
 
 			// Generate deterministic multisig address from normalized signers
 			let multisig_address =

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1128,9 +1128,6 @@ pub mod pallet {
 				return Self::err_burn_full(Error::<T>::CallNotAllowedForHighSecurityMultisig);
 			}
 
-			// Calculate bookkeeping weight based on call size
-			let bookkeeping_weight = Self::bookkeeping_weight(proposal.call.len() as u32);
-
 			// EFFECTS: Remove proposal and return deposit BEFORE dispatch (reentrancy protection)
 			Self::remove_proposal_and_return_deposit(
 				&multisig_address,

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -516,10 +516,19 @@ pub mod pallet {
 		/// **For threshold=1:** The proposal is created with `Approved` status immediately
 		/// and can be executed via `execute()` without additional approvals.
 		///
-		/// **Weight:** Charged upfront for worst-case (high-security path with decode).
-		/// Refunded to actual cost on success based on whether HS path was taken.
+		/// **Weight:** Charged upfront includes bookkeeping + MaxInnerCallWeight to cover
+		/// the cost of decoding arbitrary RuntimeCall structures and calling get_dispatch_info().
+		/// On success, refunds based on actual inner call weight. On rejection after decode
+		/// (e.g., CallWeightExceedsLimit, CallNotAllowedForHighSecurityMultisig), the full
+		/// reserved weight is burned to prevent griefing with complex calls that get rejected.
 		#[pallet::call_index(1)]
-		#[pallet::weight(<T as Config>::WeightInfo::propose_high_security(call.len() as u32))]
+		#[pallet::weight({
+			// Bookkeeping weight + MaxInnerCallWeight to cover decode + get_dispatch_info cost.
+			// Structured RuntimeCall decode is O(inner_call_count), not O(bytes), so we must
+			// reserve weight for the worst-case inner call to prevent block time overruns.
+			<T as Config>::WeightInfo::propose_high_security(call.len() as u32)
+				.saturating_add(T::MaxInnerCallWeight::get())
+		})]
 		#[allow(clippy::useless_conversion)]
 		pub fn propose(
 			origin: OriginFor<T>,
@@ -583,11 +592,14 @@ pub mod pallet {
 			// ===== PHASE 3: Decode call (validates call is well-formed for ALL proposals) =====
 			// This catches malformed calls at propose time rather than execute time,
 			// providing consistent error behavior for both HS and non-HS multisigs.
+			// NOTE: Decode cost is O(inner_call_count) for nested calls, not O(bytes).
+			// On decode failure, we burn the full reserved weight to prevent griefing.
 			let decoded_call =
 				<T as Config>::RuntimeCall::decode(&mut &call[..]).map_err(|_| {
 					DispatchErrorWithPostInfo {
 						post_info: PostDispatchInfo {
-							actual_weight: Some(T::DbWeight::get().reads(1)),
+							// Don't refund - decode has been attempted and burned CPU
+							actual_weight: None,
 							pays_fee: Pays::Yes,
 						},
 						error: Error::<T>::InvalidCall.into(),
@@ -599,14 +611,24 @@ pub mod pallet {
 			let call_weight = decoded_call.get_dispatch_info().call_weight;
 			let max_inner_weight = T::MaxInnerCallWeight::get();
 			if call_weight.any_gt(max_inner_weight) {
-				return Self::err_with_weight(Error::<T>::CallWeightExceedsLimit, 1);
+				// Don't refund after decode - the expensive work (decode + get_dispatch_info)
+				// has already been done. Returning None burns the full reserved weight,
+				// preventing griefing with complex calls that get rejected.
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+					error: Error::<T>::CallWeightExceedsLimit.into(),
+				});
 			}
 
 			// ===== PHASE 4: High-security whitelist check (if applicable) =====
 			// (additional read: HighSecurityAccounts)
 			let is_high_security = T::HighSecurity::is_high_security(&multisig_address);
 			if is_high_security && !T::HighSecurity::is_whitelisted(&decoded_call) {
-				return Self::err_with_weight(Error::<T>::CallNotAllowedForHighSecurityMultisig, 2);
+				// Don't refund after decode - same reasoning as above.
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+					error: Error::<T>::CallNotAllowedForHighSecurityMultisig.into(),
+				});
 			}
 
 			// Calculate dynamic fee based on number of signers
@@ -692,12 +714,14 @@ pub mod pallet {
 				});
 			}
 
-			// Refund weight: HS path was charged upfront, refund if non-HS
-			let actual_weight = if is_high_security {
+			// Calculate actual weight: bookkeeping + actual inner call weight (from get_dispatch_info).
+			// We reserved MaxInnerCallWeight upfront; refund the difference.
+			let bookkeeping_weight = if is_high_security {
 				<T as Config>::WeightInfo::propose_high_security(call_len)
 			} else {
 				<T as Config>::WeightInfo::propose(call_len)
 			};
+			let actual_weight = bookkeeping_weight.saturating_add(call_weight);
 
 			Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes })
 		}

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -596,17 +596,8 @@ pub mod pallet {
 			// providing consistent error behavior for both HS and non-HS multisigs.
 			// NOTE: Decode cost is O(inner_call_count) for nested calls, not O(bytes).
 			// On decode failure, we burn the full reserved weight to prevent griefing.
-			let decoded_call =
-				<T as Config>::RuntimeCall::decode(&mut &call[..]).map_err(|_| {
-					DispatchErrorWithPostInfo {
-						post_info: PostDispatchInfo {
-							// Don't refund - decode has been attempted and burned CPU
-							actual_weight: None,
-							pays_fee: Pays::Yes,
-						},
-						error: Error::<T>::InvalidCall.into(),
-					}
-				})?;
+			let decoded_call = <T as Config>::RuntimeCall::decode(&mut &call[..])
+				.map_err(|_| Self::err_burn_full_raw(Error::<T>::InvalidCall))?;
 
 			// ===== PHASE 3b: Check inner call weight against limit =====
 			// This ensures execute() can safely reserve weight at pre-dispatch time.
@@ -616,10 +607,7 @@ pub mod pallet {
 				// Don't refund after decode - the expensive work (decode + get_dispatch_info)
 				// has already been done. Returning None burns the full reserved weight,
 				// preventing griefing with complex calls that get rejected.
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-					error: Error::<T>::CallWeightExceedsLimit.into(),
-				});
+				return Self::err_burn_full(Error::<T>::CallWeightExceedsLimit);
 			}
 
 			// ===== PHASE 4: High-security whitelist check (if applicable) =====
@@ -627,10 +615,7 @@ pub mod pallet {
 			let is_high_security = T::HighSecurity::is_high_security(&multisig_address);
 			if is_high_security && !T::HighSecurity::is_whitelisted(&decoded_call) {
 				// Don't refund after decode - same reasoning as above.
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-					error: Error::<T>::CallNotAllowedForHighSecurityMultisig.into(),
-				});
+				return Self::err_burn_full(Error::<T>::CallNotAllowedForHighSecurityMultisig);
 			}
 
 			// Calculate dynamic fee based on number of signers
@@ -781,23 +766,11 @@ pub mod pallet {
 
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalExpired.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::ProposalExpired, actual_weight);
 			}
 
 			if proposal.approvals.contains(&approver) {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::AlreadyApproved.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::AlreadyApproved, actual_weight);
 			}
 
 			// Add approval
@@ -873,26 +846,14 @@ pub mod pallet {
 
 			// Check if caller is the proposer (1 read already performed)
 			if canceller != proposal.proposer {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::NotProposer.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::NotProposer, actual_weight);
 			}
 
 			// Check if proposal is cancellable (Active or Approved)
 			if proposal.status != ProposalStatus::Active &&
 				proposal.status != ProposalStatus::Approved
 			{
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalNotActive.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::ProposalNotActive, actual_weight);
 			}
 
 			// Remove proposal from storage and return deposit immediately
@@ -970,25 +931,13 @@ pub mod pallet {
 			if proposal.status != ProposalStatus::Active &&
 				proposal.status != ProposalStatus::Approved
 			{
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalNotActive.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::ProposalNotActive, actual_weight);
 			}
 
 			// Check if expired
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block <= proposal.expiry {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(actual_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalNotExpired.into(),
-				});
+				return Self::err_with_actual_weight(Error::<T>::ProposalNotExpired, actual_weight);
 			}
 
 			// Remove proposal from storage and return deposit
@@ -1139,36 +1088,25 @@ pub mod pallet {
 
 			// Must be Approved status
 			if proposal.status != ProposalStatus::Approved {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(bookkeeping_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalNotApproved.into(),
-				});
+				return Self::err_with_actual_weight(
+					Error::<T>::ProposalNotApproved,
+					bookkeeping_weight,
+				);
 			}
 
 			// Must not be expired
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(bookkeeping_weight),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::ProposalExpired.into(),
-				});
+				return Self::err_with_actual_weight(
+					Error::<T>::ProposalExpired,
+					bookkeeping_weight,
+				);
 			}
 
 			// Decode the call
 			// After decode, we've done size-dependent work, so failures should burn full weight.
-			let call =
-				<T as Config>::RuntimeCall::decode(&mut &proposal.call[..]).map_err(|_| {
-					DispatchErrorWithPostInfo {
-						post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-						error: Error::<T>::InvalidCall.into(),
-					}
-				})?;
+			let call = <T as Config>::RuntimeCall::decode(&mut &proposal.call[..])
+				.map_err(|_| Self::err_burn_full_raw(Error::<T>::InvalidCall))?;
 
 			// Re-check call weight at execute time (belt-and-suspenders).
 			// MaxInnerCallWeight could have been lowered via runtime upgrade since propose time.
@@ -1176,10 +1114,7 @@ pub mod pallet {
 			let current_call_weight = call.get_dispatch_info().call_weight;
 			let max_inner_weight = T::MaxInnerCallWeight::get();
 			if current_call_weight.any_gt(max_inner_weight) {
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-					error: Error::<T>::CallWeightExceedsLimit.into(),
-				});
+				return Self::err_burn_full(Error::<T>::CallWeightExceedsLimit);
 			}
 
 			// Re-check high-security whitelist at execute time.
@@ -1190,10 +1125,7 @@ pub mod pallet {
 			if T::HighSecurity::is_high_security(&multisig_address) &&
 				!T::HighSecurity::is_whitelisted(&call)
 			{
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-					error: Error::<T>::CallNotAllowedForHighSecurityMultisig.into(),
-				});
+				return Self::err_burn_full(Error::<T>::CallNotAllowedForHighSecurityMultisig);
 			}
 
 			// Calculate bookkeeping weight based on call size
@@ -1240,7 +1172,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		/// Return an error with actual weight consumed instead of charging full upfront weight.
-		/// Use for early exits where minimal work was performed.
+		/// Use for early exits where minimal work was performed (only DB reads).
 		fn err_with_weight(error: Error<T>, reads: u64) -> DispatchResultWithPostInfo {
 			Err(DispatchErrorWithPostInfo {
 				post_info: PostDispatchInfo {
@@ -1249,6 +1181,31 @@ pub mod pallet {
 				},
 				error: error.into(),
 			})
+		}
+
+		/// Return an error with a specific actual weight.
+		/// Use for failures after size-dependent work (e.g., after loading a proposal).
+		fn err_with_actual_weight(error: Error<T>, weight: Weight) -> DispatchResultWithPostInfo {
+			Err(DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo { actual_weight: Some(weight), pays_fee: Pays::Yes },
+				error: error.into(),
+			})
+		}
+
+		/// Return an error that burns the full reserved weight (no refund).
+		/// Use for failures after expensive work like call decoding where we want to
+		/// prevent griefing with complex calls that get rejected.
+		fn err_burn_full(error: Error<T>) -> DispatchResultWithPostInfo {
+			Err(Self::err_burn_full_raw(error))
+		}
+
+		/// Return a raw DispatchErrorWithPostInfo that burns the full reserved weight.
+		/// Use in map_err closures where the raw error type is needed.
+		fn err_burn_full_raw(error: Error<T>) -> DispatchErrorWithPostInfo {
+			DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+				error: error.into(),
+			}
 		}
 
 		/// Returns the multisig bookkeeping weight for execute (excludes inner call weight).

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1228,18 +1228,6 @@ pub mod pallet {
 			})
 		}
 
-		/// Return a raw DispatchErrorWithPostInfo (not wrapped in Result).
-		/// Use when you need to map_err with a custom error.
-		fn err_with_weight_raw(error: Error<T>, reads: u64) -> DispatchErrorWithPostInfo {
-			DispatchErrorWithPostInfo {
-				post_info: PostDispatchInfo {
-					actual_weight: Some(T::DbWeight::get().reads(reads)),
-					pays_fee: Pays::Yes,
-				},
-				error: error.into(),
-			}
-		}
-
 		/// Returns the multisig bookkeeping weight for execute (excludes inner call weight).
 		fn bookkeeping_weight(call_size: u32) -> Weight {
 			<T as Config>::WeightInfo::execute(call_size)

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -442,6 +442,10 @@ pub mod pallet {
 			// An attacker could submit a huge duplicate-heavy vector; clone/sort/dedup
 			// is O(n log n) on the raw length, but benchmarks only cover MaxSigners.
 			// Reject oversized inputs before doing any expensive work.
+			//
+			// BREAKING CHANGE: This rejects inputs with len > MaxSigners even if they would
+			// deduplicate to ≤ MaxSigners. Previously such inputs were accepted. This is the
+			// correct security tradeoff: users must pre-deduplicate their signer lists.
 			ensure!(signers.len() <= T::MaxSigners::get() as usize, Error::<T>::TooManySigners);
 
 			// Normalize signers: sort and deduplicate (single authoritative place)
@@ -1203,11 +1207,6 @@ pub mod pallet {
 				post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
 				error: error.into(),
 			}
-		}
-
-		/// Returns the multisig bookkeeping weight for execute (excludes inner call weight).
-		fn bookkeeping_weight(call_size: u32) -> Weight {
-			<T as Config>::WeightInfo::execute(call_size)
 		}
 
 		/// Normalize signers: sort and deduplicate.

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -777,17 +777,24 @@ pub mod pallet {
 					}
 				})?;
 
-			// Calculate actual weight based on real call size
+			// Calculate actual weight based on real call size - use this for ALL paths
+			// after proposal is loaded, since reading the proposal incurs size-dependent cost.
 			let actual_call_size = proposal.call.len() as u32;
 			let actual_weight = <T as Config>::WeightInfo::approve(actual_call_size);
 
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
-				return Self::err_with_weight(Error::<T>::ProposalExpired, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalExpired.into(),
+				});
 			}
 
 			if proposal.approvals.contains(&approver) {
-				return Self::err_with_weight(Error::<T>::AlreadyApproved, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::AlreadyApproved.into(),
+				});
 			}
 
 			// Add approval
@@ -856,19 +863,28 @@ pub mod pallet {
 					}
 				})?;
 
+			// Calculate actual weight based on real call size - use for ALL paths
+			// after proposal is loaded, since reading the proposal incurs size-dependent cost.
+			let call_size = proposal.call.len() as u32;
+			let actual_weight = <T as Config>::WeightInfo::cancel(call_size);
+
 			// Check if caller is the proposer (1 read already performed)
 			if canceller != proposal.proposer {
-				return Self::err_with_weight(Error::<T>::NotProposer, 1);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::NotProposer.into(),
+				});
 			}
 
 			// Check if proposal is cancellable (Active or Approved)
 			if proposal.status != ProposalStatus::Active &&
 				proposal.status != ProposalStatus::Approved
 			{
-				return Self::err_with_weight(Error::<T>::ProposalNotActive, 1);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalNotActive.into(),
+				});
 			}
-
-			let call_size = proposal.call.len() as u32;
 
 			// Remove proposal from storage and return deposit immediately
 			Self::remove_proposal_and_return_deposit(
@@ -885,7 +901,6 @@ pub mod pallet {
 				proposal_id,
 			});
 
-			let actual_weight = <T as Config>::WeightInfo::cancel(call_size);
 			Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes })
 		}
 
@@ -935,19 +950,30 @@ pub mod pallet {
 					}
 				})?;
 
+			// Calculate actual weight based on real call size - use for ALL paths
+			// after proposal is loaded, since reading the proposal incurs size-dependent cost.
+			let call_size = proposal.call.len() as u32;
+			let actual_weight = <T as Config>::WeightInfo::remove_expired(call_size);
+
 			// Active or Approved proposals can be removed when expired (Executed/Cancelled
 			// are auto-removed). Approved+expired would otherwise be stuck if proposer
 			// unavailable.
 			if proposal.status != ProposalStatus::Active &&
 				proposal.status != ProposalStatus::Approved
 			{
-				return Self::err_with_weight(Error::<T>::ProposalNotActive, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalNotActive.into(),
+				});
 			}
 
 			// Check if expired
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block <= proposal.expiry {
-				return Self::err_with_weight(Error::<T>::ProposalNotExpired, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalNotExpired.into(),
+				});
 			}
 
 			// Remove proposal from storage and return deposit
@@ -966,9 +992,6 @@ pub mod pallet {
 				removed_by: caller,
 			});
 
-			// Return actual weight based on proposal call size
-			let actual_weight =
-				<T as Config>::WeightInfo::remove_expired(proposal.call.len() as u32);
 			Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes })
 		}
 
@@ -1094,37 +1117,60 @@ pub mod pallet {
 					}
 				})?;
 
+			// Calculate bookkeeping weight based on real call size - use for ALL paths
+			// after proposal is loaded, since reading the proposal incurs size-dependent cost.
+			let call_size = proposal.call.len() as u32;
+			let bookkeeping_weight = <T as Config>::WeightInfo::execute(call_size);
+
 			// Must be Approved status
 			if proposal.status != ProposalStatus::Approved {
-				return Self::err_with_weight(Error::<T>::ProposalNotApproved, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(bookkeeping_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalNotApproved.into(),
+				});
 			}
 
 			// Must not be expired
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
-				return Self::err_with_weight(Error::<T>::ProposalExpired, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: Some(bookkeeping_weight), pays_fee: Pays::Yes },
+					error: Error::<T>::ProposalExpired.into(),
+				});
 			}
 
 			// Decode the call
+			// After decode, we've done size-dependent work, so failures should burn full weight.
 			let call = <T as Config>::RuntimeCall::decode(&mut &proposal.call[..])
-				.map_err(|_| Self::err_with_weight_raw(Error::<T>::InvalidCall, 2))?;
+				.map_err(|_| DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+					error: Error::<T>::InvalidCall.into(),
+				})?;
 
 			// Re-check call weight at execute time (belt-and-suspenders).
 			// MaxInnerCallWeight could have been lowered via runtime upgrade since propose time.
+			// After decode + get_dispatch_info, don't refund - burn the full reserved weight.
 			let current_call_weight = call.get_dispatch_info().call_weight;
 			let max_inner_weight = T::MaxInnerCallWeight::get();
 			if current_call_weight.any_gt(max_inner_weight) {
-				return Self::err_with_weight(Error::<T>::CallWeightExceedsLimit, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+					error: Error::<T>::CallWeightExceedsLimit.into(),
+				});
 			}
 
 			// Re-check high-security whitelist at execute time.
 			// The multisig's HS status may have changed since the proposal was created,
 			// or the whitelist may have been updated via runtime upgrade.
 			// This prevents bypassing HS restrictions by proposing before enabling HS.
+			// After decode + get_dispatch_info, don't refund - burn the full reserved weight.
 			if T::HighSecurity::is_high_security(&multisig_address) &&
 				!T::HighSecurity::is_whitelisted(&call)
 			{
-				return Self::err_with_weight(Error::<T>::CallNotAllowedForHighSecurityMultisig, 2);
+				return Err(DispatchErrorWithPostInfo {
+					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+					error: Error::<T>::CallNotAllowedForHighSecurityMultisig.into(),
+				});
 			}
 
 			// Calculate bookkeeping weight based on call size

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -442,10 +442,7 @@ pub mod pallet {
 			// An attacker could submit a huge duplicate-heavy vector; clone/sort/dedup
 			// is O(n log n) on the raw length, but benchmarks only cover MaxSigners.
 			// Reject oversized inputs before doing any expensive work.
-			ensure!(
-				signers.len() <= T::MaxSigners::get() as usize,
-				Error::<T>::TooManySigners
-			);
+			ensure!(signers.len() <= T::MaxSigners::get() as usize, Error::<T>::TooManySigners);
 
 			// Normalize signers: sort and deduplicate (single authoritative place)
 			let normalized_signers = Self::normalize_signers(&signers);
@@ -719,8 +716,8 @@ pub mod pallet {
 				});
 			}
 
-			// Calculate actual weight: bookkeeping + actual inner call weight (from get_dispatch_info).
-			// We reserved MaxInnerCallWeight upfront; refund the difference.
+			// Calculate actual weight: bookkeeping + actual inner call weight (from
+			// get_dispatch_info). We reserved MaxInnerCallWeight upfront; refund the difference.
 			let bookkeeping_weight = if is_high_security {
 				<T as Config>::WeightInfo::propose_high_security(call_len)
 			} else {
@@ -785,14 +782,20 @@ pub mod pallet {
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalExpired.into(),
 				});
 			}
 
 			if proposal.approvals.contains(&approver) {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::AlreadyApproved.into(),
 				});
 			}
@@ -871,7 +874,10 @@ pub mod pallet {
 			// Check if caller is the proposer (1 read already performed)
 			if canceller != proposal.proposer {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::NotProposer.into(),
 				});
 			}
@@ -881,7 +887,10 @@ pub mod pallet {
 				proposal.status != ProposalStatus::Approved
 			{
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalNotActive.into(),
 				});
 			}
@@ -962,7 +971,10 @@ pub mod pallet {
 				proposal.status != ProposalStatus::Approved
 			{
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalNotActive.into(),
 				});
 			}
@@ -971,7 +983,10 @@ pub mod pallet {
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block <= proposal.expiry {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(actual_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalNotExpired.into(),
 				});
 			}
@@ -1125,7 +1140,10 @@ pub mod pallet {
 			// Must be Approved status
 			if proposal.status != ProposalStatus::Approved {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(bookkeeping_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(bookkeeping_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalNotApproved.into(),
 				});
 			}
@@ -1134,17 +1152,22 @@ pub mod pallet {
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {
 				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: Some(bookkeeping_weight), pays_fee: Pays::Yes },
+					post_info: PostDispatchInfo {
+						actual_weight: Some(bookkeeping_weight),
+						pays_fee: Pays::Yes,
+					},
 					error: Error::<T>::ProposalExpired.into(),
 				});
 			}
 
 			// Decode the call
 			// After decode, we've done size-dependent work, so failures should burn full weight.
-			let call = <T as Config>::RuntimeCall::decode(&mut &proposal.call[..])
-				.map_err(|_| DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
-					error: Error::<T>::InvalidCall.into(),
+			let call =
+				<T as Config>::RuntimeCall::decode(&mut &proposal.call[..]).map_err(|_| {
+					DispatchErrorWithPostInfo {
+						post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+						error: Error::<T>::InvalidCall.into(),
+					}
 				})?;
 
 			// Re-check call weight at execute time (belt-and-suspenders).

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -293,6 +293,42 @@ fn create_multisig_deduplicates_signers() {
 	});
 }
 
+/// Regression test: raw signer input is bounded BEFORE deduplication to prevent DoS.
+/// An attacker could submit a huge duplicate-heavy vector that would dedup to ≤ MaxSigners,
+/// but the sort/dedup cost is O(n log n) on the raw length. We reject oversized raw inputs
+/// even if they would normalize to a valid count.
+#[test]
+fn create_multisig_rejects_oversized_raw_input_even_if_would_dedup_to_valid() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let creator = alice();
+
+		// MaxSigners is 10 in mock. Create 11 signers that would dedup to just 2.
+		// Old behavior: would accept (dedup first, then check).
+		// New behavior: rejects immediately (check raw length first).
+		let signers = vec![
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			bob(),
+			charlie(),
+		]; // 11 elements, but only 2 unique
+		assert_eq!(signers.len(), 11);
+
+		// Should fail with TooManySigners even though dedup would yield only 2
+		assert_noop!(
+			Multisig::create_multisig(RuntimeOrigin::signed(creator), signers, 2, 0),
+			Error::<Test>::TooManySigners
+		);
+	});
+}
+
 #[test]
 fn create_multiple_multisigs_increments_nonce() {
 	new_test_ext().execute_with(|| {

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -306,19 +306,8 @@ fn create_multisig_rejects_oversized_raw_input_even_if_would_dedup_to_valid() {
 		// MaxSigners is 10 in mock. Create 11 signers that would dedup to just 2.
 		// Old behavior: would accept (dedup first, then check).
 		// New behavior: rejects immediately (check raw length first).
-		let signers = vec![
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			bob(),
-			charlie(),
-		]; // 11 elements, but only 2 unique
+		let signers =
+			vec![bob(), bob(), bob(), bob(), bob(), bob(), bob(), bob(), bob(), bob(), charlie()]; // 11 elements, but only 2 unique
 		assert_eq!(signers.len(), 11);
 
 		// Should fail with TooManySigners even though dedup would yield only 2

--- a/pallets/multisig/src/weights.rs
+++ b/pallets/multisig/src/weights.rs
@@ -65,7 +65,14 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `Multisig::Multisigs` (r:1 w:1)
 	/// Proof: `Multisig::Multisigs` (`max_values`: None, `max_size`: Some(6892), added: 9367, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:0)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Wormhole::PotentialWormholeBalance` (r:1 w:1)
+	/// Proof: `Wormhole::PotentialWormholeBalance` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
 	/// The range of component `s` is `[2, 100]`.
+	///
+	/// Note: Weight includes worst-case Wormhole reveal_address path where a pre-funded
+	/// multisig address has nonzero balance, triggering PotentialWormholeBalance mutation.
 	fn create_multisig(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
@@ -74,8 +81,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(20_952_861, 10357)
 			// Standard Error: 991
 			.saturating_add(Weight::from_parts(17_405, 0).saturating_mul(s.into()))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+			// Base: 1 read (Multisigs) + 1 write (Multisigs)
+			// Wormhole reveal_address worst-case: 1 read (System::Account for balance)
+			//   + 1 read (PotentialWormholeBalance) + 1 write (PotentialWormholeBalance)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Multisig::Multisigs` (r:1 w:1)
 	/// Proof: `Multisig::Multisigs` (`max_values`: None, `max_size`: Some(6892), added: 9367, mode: `MaxEncodedLen`)
@@ -212,7 +222,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	/// Storage: `Multisig::Multisigs` (r:1 w:1)
 	/// Proof: `Multisig::Multisigs` (`max_values`: None, `max_size`: Some(6892), added: 9367, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:0)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Wormhole::PotentialWormholeBalance` (r:1 w:1)
+	/// Proof: `Wormhole::PotentialWormholeBalance` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
 	/// The range of component `s` is `[2, 100]`.
+	///
+	/// Note: Weight includes worst-case Wormhole reveal_address path where a pre-funded
+	/// multisig address has nonzero balance, triggering PotentialWormholeBalance mutation.
 	fn create_multisig(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
@@ -221,8 +238,11 @@ impl WeightInfo for () {
 		Weight::from_parts(20_952_861, 10357)
 			// Standard Error: 991
 			.saturating_add(Weight::from_parts(17_405, 0).saturating_mul(s.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			// Base: 1 read (Multisigs) + 1 write (Multisigs)
+			// Wormhole reveal_address worst-case: 1 read (System::Account for balance)
+			//   + 1 read (PotentialWormholeBalance) + 1 write (PotentialWormholeBalance)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Multisig::Multisigs` (r:1 w:1)
 	/// Proof: `Multisig::Multisigs` (`max_values`: None, `max_size`: Some(6892), added: 9367, mode: `MaxEncodedLen`)


### PR DESCRIPTION
## Summary

Address V12 audit findings for the multisig pallet related to weight undercharging and DoS vectors.

## Changes

### 1. `propose` weight reservation for inner call decode cost

**Issue:** The `propose` function decodes arbitrary `RuntimeCall` bytes and calls `get_dispatch_info()`, which is O(inner_call_count) for nested calls like `Utility::batch`. The benchmark only measured flat `remark` calls, so the per-byte weight (333 ps) only reflects memcpy, not recursive enum decoding.

**Fix:** 
- Add `MaxInnerCallWeight` to upfront weight reservation (like `execute` already does)
- Burn full reserved weight on post-decode rejections (`InvalidCall`, `CallWeightExceedsLimit`, `CallNotAllowedForHighSecurityMultisig`)
- Refund based on actual inner call weight from `get_dispatch_info()` on success

### 2. `create_multisig` unbounded signer vector DoS

**Issue:** `create_multisig` accepts an unbounded `Vec<AccountId>`, performs expensive normalization (clone, sort O(n log n), dedup) before enforcing `MaxSigners`. An attacker could submit huge duplicate-heavy vectors that cost more CPU than the benchmarked weight covers.

**Fix:** Check `signers.len() <= MaxSigners` immediately after basic validation, before calling `normalize_signers()`.

### 3. Failed path weight undercharging across multiple dispatchables

**Issue:** After loading variable-size proposal data from storage, error paths like `ProposalExpired`, `AlreadyApproved`, `NotProposer`, etc. used `err_with_weight()` which only charged fixed DB read counts, not the actual size-dependent storage read cost.

**Fix:** Calculate size-aware `actual_weight` immediately after loading proposal data and use it for all subsequent error paths:
- `approve`: `ProposalExpired`, `AlreadyApproved`
- `cancel`: `NotProposer`, `ProposalNotActive`
- `remove_expired`: `ProposalNotActive`, `ProposalNotExpired`
- `execute`: `ProposalNotApproved`, `ProposalExpired` (pre-decode); burn full weight for post-decode errors

### 4. `create_multisig` missing Wormhole storage weight

**Issue:** The benchmark only measured `Multisig::Multisigs` storage, but production calls `T::ProofRecorder::reveal_address()` which reads the account balance and, if nonzero, mutates `Wormhole::PotentialWormholeBalance`. An attacker could pre-fund derived multisig addresses to trigger this unweighted path.

**Fix:** Add Wormhole storage operations to `create_multisig` weight:
- +2 reads: `System::Account`, `Wormhole::PotentialWormholeBalance`
- +1 write: `Wormhole::PotentialWormholeBalance`

## Testing

All 54 existing multisig pallet tests pass.

## Security Impact

These fixes ensure block weight accounting accurately reflects actual CPU and storage costs, preventing availability DoS through underpriced extrinsics. No funds-at-risk issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-critical fee/weight math on multisig dispatchables; behavior shifts (higher propose cost, stricter failure charging) but targets DoS undercharging rather than fund logic.
> 
> **Overview**
> Tightens **block weight and CPU accounting** on multisig extrinsics so underpriced work cannot be used for availability griefing (V12 audit follow-up).
> 
> **`create_multisig`** rejects `signers.len() > MaxSigners` **before** `normalize_signers` (clone/sort/dedup), so huge duplicate-heavy vectors cannot force expensive normalization on undercharged weight.
> 
> **`propose`** now reserves **bookkeeping + `MaxInnerCallWeight`** upfront (decode + `get_dispatch_info()` can scale with nested calls, not just byte length). After decode, failures (`InvalidCall`, `CallWeightExceedsLimit`, high-security whitelist) return **`actual_weight: None`** so the full reservation is burned; success charges bookkeeping plus the **measured** inner call weight.
> 
> **`approve`**, **`cancel`**, **`remove_expired`**, and **`execute`** compute **call-size-aware** weights as soon as the proposal is loaded and use them on common error paths instead of fixed read-only `err_with_weight`. **`execute`** likewise burns the full reservation on post-decode validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288b134b167af6d0c51e0dd17c954ee652370e01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->