### PR TITLE
Fix: origin-rewriting wrappers bypass high-security restrictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6642,6 +6642,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "polkadot-sdk-frame",
+ "qp-high-security",
  "scale-info",
 ]
 
@@ -6813,6 +6814,7 @@ dependencies = [
  "pallet-root-testing",
  "pallet-timestamp",
  "parity-scale-codec",
+ "qp-high-security",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8079,6 +8079,9 @@ dependencies = [
 [[package]]
 name = "qp-high-security"
 version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+]
 
 [[package]]
 name = "qp-plonky2"

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1130,9 +1130,7 @@ pub mod pallet {
 			// or the whitelist may have been updated via runtime upgrade.
 			// This prevents bypassing HS restrictions by proposing before enabling HS.
 			// After decode + get_dispatch_info, don't refund - burn the full reserved weight.
-			if T::HighSecurity::is_high_security(&multisig_address) &&
-				!T::HighSecurity::is_whitelisted(&call)
-			{
+			if !T::HighSecurity::is_call_allowed(&multisig_address, &call) {
 				return Self::err_burn_full(Error::<T>::CallNotAllowedForHighSecurityMultisig);
 			}
 

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -621,7 +621,8 @@ pub mod pallet {
 			// ===== PHASE 4: High-security whitelist check (if applicable) =====
 			// (additional read: HighSecurityAccounts)
 			let is_high_security = T::HighSecurity::is_high_security(&multisig_address);
-			if is_high_security && !T::HighSecurity::is_whitelisted(&decoded_call) {
+			// Use the shared `is_call_allowed` policy so `propose` and `execute` stay consistent.
+			if !T::HighSecurity::is_call_allowed(&multisig_address, &decoded_call) {
 				// Don't refund after decode - same reasoning as above.
 				return Self::err_burn_full(Error::<T>::CallNotAllowedForHighSecurityMultisig);
 			}

--- a/pallets/multisig/src/mock.rs
+++ b/pallets/multisig/src/mock.rs
@@ -332,6 +332,7 @@ impl pallet_recovery::Config for Test {
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
 	type BlockNumberProvider = System;
+	type HighSecurity = ();
 }
 
 impl pallet_preimage::Config for Test {
@@ -372,6 +373,7 @@ impl pallet_utility::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type HighSecurity = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/recovery/Cargo.toml
+++ b/pallets/recovery/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { features = ["derive"], workspace = true }
 frame = { workspace = true, features = ["runtime"] }
+qp-high-security = { path = "../../primitives/high-security", default-features = false }
 scale-info = { features = ["derive"], workspace = true }
 
 [dev-dependencies]
@@ -31,6 +32,7 @@ runtime-benchmarks = [
 std = [
 	"codec/std",
 	"frame/std",
+	"qp-high-security/std",
 	"scale-info/std",
 ]
 try-runtime = [

--- a/pallets/recovery/src/lib.rs
+++ b/pallets/recovery/src/lib.rs
@@ -158,6 +158,7 @@ use frame::{
 	prelude::*,
 	traits::{Currency, ReservableCurrency},
 };
+use qp_high_security::HighSecurityInspector;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -247,6 +248,12 @@ pub mod pallet {
 			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
 			+ GetDispatchInfo
 			+ From<frame_system::Call<Self>>;
+
+		/// Enforces high-security whitelist restrictions at the recovered (effective) origin.
+		type HighSecurity: qp_high_security::HighSecurityInspector<
+			Self::AccountId,
+			<Self as Config>::RuntimeCall,
+		>;
 
 		/// Query the current block number.
 		///
@@ -343,6 +350,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// User is not allowed to make a call on behalf of this account
 		NotAllowed,
+		/// Call is not allowed for a high-security account
+		CallNotAllowedForHighSecurity,
 		/// Threshold must be greater than zero
 		ZeroThreshold,
 		/// Friends list must be greater than zero and threshold
@@ -434,6 +443,10 @@ pub mod pallet {
 			// Check `who` is allowed to make a call on behalf of `account`
 			let target = Self::proxy(&who).ok_or(Error::<T>::NotAllowed)?;
 			ensure!(target == account, Error::<T>::NotAllowed);
+			ensure!(
+				T::HighSecurity::is_call_allowed(&account, &call),
+				Error::<T>::CallNotAllowedForHighSecurity
+			);
 			call.dispatch(frame_system::RawOrigin::Signed(account).into())
 				.map(|_| ())
 				.map_err(|e| e.error)

--- a/pallets/recovery/src/mock.rs
+++ b/pallets/recovery/src/mock.rs
@@ -68,6 +68,7 @@ impl Config for Test {
 	type FriendDepositFactor = FriendDepositFactor;
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
+	type HighSecurity = ();
 }
 
 pub type BalancesCall = pallet_balances::Call<Test>;

--- a/pallets/recovery/src/mock.rs
+++ b/pallets/recovery/src/mock.rs
@@ -68,11 +68,24 @@ impl Config for Test {
 	type FriendDepositFactor = FriendDepositFactor;
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
-	type HighSecurity = ();
+	type HighSecurity = qp_high_security::testing::TestHighSecurity<HighSecurityWhitelist>;
+}
+
+/// High-security accounts in tests may only dispatch `System::remark`.
+pub struct HighSecurityWhitelist;
+impl qp_high_security::testing::Whitelist<RuntimeCall> for HighSecurityWhitelist {
+	fn contains(call: &RuntimeCall) -> bool {
+		matches!(call, RuntimeCall::System(frame_system::Call::remark { .. }))
+	}
 }
 
 pub type BalancesCall = pallet_balances::Call<Test>;
 pub type RecoveryCall = super::Call<Test>;
+
+/// A whitelisted (`System::remark`) call, for high-security test cases.
+pub fn remark_call() -> RuntimeCall {
+	RuntimeCall::System(frame_system::Call::remark { remark: vec![] })
+}
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();

--- a/pallets/recovery/src/tests.rs
+++ b/pallets/recovery/src/tests.rs
@@ -786,3 +786,52 @@ fn poke_deposit_handles_insufficient_balance() {
 		assert_eq!(Balances::reserved_balance(5), 13);
 	});
 }
+
+#[test]
+fn as_recovered_blocks_high_security_non_whitelisted_call() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		// Account 1 can act for the (high-security) lost account 5.
+		assert_ok!(Recovery::set_recovered(RuntimeOrigin::root(), 5, 1));
+		qp_high_security::testing::set_high_security(&5u64);
+
+		// A non-whitelisted call as the high-security account is rejected before dispatch.
+		let call = Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
+			dest: 1,
+			value: 100,
+		}));
+		assert_noop!(
+			Recovery::as_recovered(RuntimeOrigin::signed(1), 5, call),
+			Error::<Test>::CallNotAllowedForHighSecurity
+		);
+		// The lost account's funds are untouched.
+		assert_eq!(Balances::free_balance(5), 100);
+	});
+}
+
+#[test]
+fn as_recovered_allows_high_security_whitelisted_call() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		assert_ok!(Recovery::set_recovered(RuntimeOrigin::root(), 5, 1));
+		qp_high_security::testing::set_high_security(&5u64);
+
+		// A whitelisted call as the high-security account is allowed through.
+		assert_ok!(Recovery::as_recovered(RuntimeOrigin::signed(1), 5, Box::new(remark_call())));
+	});
+}
+
+#[test]
+fn as_recovered_non_high_security_is_unaffected() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		// Lost account 5 is not high-security, so arbitrary calls remain allowed.
+		assert_ok!(Recovery::set_recovered(RuntimeOrigin::root(), 5, 1));
+		let call = Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
+			dest: 1,
+			value: 100,
+		}));
+		assert_ok!(Recovery::as_recovered(RuntimeOrigin::signed(1), 5, call));
+		assert_eq!(Balances::free_balance(1), 200);
+	});
+}

--- a/pallets/reversible-transfers/src/tests/mock.rs
+++ b/pallets/reversible-transfers/src/tests/mock.rs
@@ -323,6 +323,7 @@ impl pallet_recovery::Config for Test {
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
 	type BlockNumberProvider = System;
+	type HighSecurity = ();
 }
 
 impl pallet_preimage::Config for Test {
@@ -364,6 +365,7 @@ impl pallet_utility::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type HighSecurity = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/utility/Cargo.toml
+++ b/pallets/utility/Cargo.toml
@@ -20,6 +20,7 @@ codec = { workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
+qp-high-security = { path = "../../primitives/high-security", default-features = false }
 scale-info = { features = ["derive"], workspace = true }
 sp-core.workspace = true
 sp-io.workspace = true
@@ -44,6 +45,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
+	"qp-high-security/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -68,6 +68,7 @@ use frame_support::{
 	},
 	traits::{IsSubType, OriginTrait, UnfilteredDispatchable},
 };
+use qp_high_security::HighSecurityInspector;
 use sp_core::TypeId;
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{BadOrigin, Dispatchable, TrailingZeroInput};
@@ -107,6 +108,12 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Enforces high-security whitelist restrictions at the derivative (effective) origin.
+		type HighSecurity: qp_high_security::HighSecurityInspector<
+			Self::AccountId,
+			<Self as Config>::RuntimeCall,
+		>;
 	}
 
 	#[pallet::event]
@@ -168,6 +175,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Too many calls batched.
 		TooManyCalls,
+		/// Call is not allowed for a high-security account.
+		CallNotAllowedForHighSecurity,
 	}
 
 	#[pallet::call]
@@ -270,6 +279,10 @@ pub mod pallet {
 			let mut origin = origin;
 			let who = ensure_signed(origin.clone())?;
 			let pseudonym = derivative_account_id(who, index);
+			ensure!(
+				T::HighSecurity::is_call_allowed(&pseudonym, &call),
+				Error::<T>::CallNotAllowedForHighSecurity
+			);
 			origin.set_caller_from(frame_system::RawOrigin::Signed(pseudonym));
 			let info = call.get_dispatch_info();
 			let result = call.dispatch(origin);

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -224,7 +224,15 @@ impl Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
-	type HighSecurity = ();
+	type HighSecurity = qp_high_security::testing::TestHighSecurity<HighSecurityWhitelist>;
+}
+
+/// High-security accounts in tests may only dispatch `System::remark`.
+pub struct HighSecurityWhitelist;
+impl qp_high_security::testing::Whitelist<RuntimeCall> for HighSecurityWhitelist {
+	fn contains(call: &RuntimeCall) -> bool {
+		matches!(call, RuntimeCall::System(frame_system::Call::remark { .. }))
+	}
 }
 
 type ExampleCall = example::Call<Test>;
@@ -1089,5 +1097,46 @@ fn if_else_with_nested_if_else_works() {
 
 		// Ensure the correct event was triggered for the main call(nested if_else).
 		System::assert_last_event(utility::Event::IfElseMainSuccess.into());
+	});
+}
+
+fn remark_call() -> RuntimeCall {
+	RuntimeCall::System(frame_system::Call::remark { remark: vec![] })
+}
+
+#[test]
+fn as_derivative_blocks_high_security_non_whitelisted_call() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		// Make account 6's index-0 derivative a high-security account.
+		let derivative = crate::derivative_account_id(6u64, 0);
+		qp_high_security::testing::set_high_security(&derivative);
+
+		// A non-whitelisted inner call is rejected at the derivative origin before dispatch.
+		assert_err_ignore_postinfo!(
+			Utility::as_derivative(RuntimeOrigin::signed(6), 0, Box::new(call_transfer(2, 1))),
+			crate::Error::<Test>::CallNotAllowedForHighSecurity
+		);
+	});
+}
+
+#[test]
+fn as_derivative_allows_high_security_whitelisted_call() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		let derivative = crate::derivative_account_id(6u64, 0);
+		qp_high_security::testing::set_high_security(&derivative);
+
+		// A whitelisted inner call as the high-security derivative is allowed through.
+		assert_ok!(Utility::as_derivative(RuntimeOrigin::signed(6), 0, Box::new(remark_call())));
+	});
+}
+
+#[test]
+fn as_derivative_non_high_security_derivative_is_unaffected() {
+	new_test_ext().execute_with(|| {
+		qp_high_security::testing::reset();
+		// Account 6's index-1 derivative is not high-security, so the check is a no-op.
+		assert_ok!(Utility::as_derivative(RuntimeOrigin::signed(6), 1, Box::new(remark_call())));
 	});
 }

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -224,6 +224,7 @@ impl Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type HighSecurity = ();
 }
 
 type ExampleCall = example::Call<Test>;

--- a/primitives/high-security/Cargo.toml
+++ b/primitives/high-security/Cargo.toml
@@ -9,6 +9,10 @@ publish = false
 repository.workspace = true
 version = "0.1.0"
 
+[dependencies]
+codec = { workspace = true, default-features = false, optional = true }
+
 [features]
 default = ["std"]
-std = []
+# `codec` is only needed by the `std`-only `testing` inspector.
+std = ["dep:codec", "codec/std"]

--- a/primitives/high-security/Cargo.toml
+++ b/primitives/high-security/Cargo.toml
@@ -15,4 +15,4 @@ codec = { workspace = true, default-features = false, optional = true }
 [features]
 default = ["std"]
 # `codec` is only needed by the `std`-only `testing` inspector.
-std = ["dep:codec", "codec/std"]
+std = ["codec/std", "dep:codec"]

--- a/primitives/high-security/src/lib.rs
+++ b/primitives/high-security/src/lib.rs
@@ -122,6 +122,15 @@ pub trait HighSecurityInspector<AccountId, RuntimeCall> {
 	/// `Some(guardian_account)` if the account has a guardian, `None` otherwise
 	fn guardian(who: &AccountId) -> Option<AccountId>;
 
+	/// Whether `call` may be dispatched with `who` as the effective signed origin.
+	///
+	/// Non-High-Security accounts may dispatch anything; High-Security accounts are
+	/// restricted to whitelisted calls. Origin-rewriting wrappers (multisig execution,
+	/// `as_recovered`, `as_derivative`) must consult this before dispatching as `who`.
+	fn is_call_allowed(who: &AccountId, call: &RuntimeCall) -> bool {
+		!Self::is_high_security(who) || Self::is_whitelisted(call)
+	}
+
 	// NOTE: No benchmarking-specific methods in the trait!
 	// Production API should not be polluted by test/benchmark requirements.
 	// Use pallet-specific helpers instead (e.g.,

--- a/primitives/high-security/src/lib.rs
+++ b/primitives/high-security/src/lib.rs
@@ -163,3 +163,55 @@ impl<AccountId, RuntimeCall> HighSecurityInspector<AccountId, RuntimeCall> for (
 		None
 	}
 }
+
+/// Reusable [`HighSecurityInspector`] test double shared by pallet test suites.
+///
+/// Accounts registered via [`testing::set_high_security`] are treated as high-security; the
+/// permitted calls for those accounts are described by the [`testing::Whitelist`] type parameter.
+#[cfg(feature = "std")]
+pub mod testing {
+	use super::HighSecurityInspector;
+	use codec::Encode;
+	use core::marker::PhantomData;
+	use std::cell::RefCell;
+
+	thread_local! {
+		static HIGH_SECURITY: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+	}
+
+	/// Mark `who` as a high-security account for the current test thread.
+	pub fn set_high_security<A: Encode>(who: &A) {
+		let who = who.encode();
+		HIGH_SECURITY.with(|hs| hs.borrow_mut().push(who));
+	}
+
+	/// Forget every account registered via [`set_high_security`].
+	pub fn reset() {
+		HIGH_SECURITY.with(|hs| hs.borrow_mut().clear());
+	}
+
+	/// Compile-time predicate for the calls a high-security account may dispatch.
+	pub trait Whitelist<RuntimeCall> {
+		fn contains(call: &RuntimeCall) -> bool;
+	}
+
+	/// Configurable inspector: registered accounts are high-security and restricted to `W`.
+	pub struct TestHighSecurity<W>(PhantomData<W>);
+
+	impl<AccountId: Encode, RuntimeCall, W: Whitelist<RuntimeCall>>
+		HighSecurityInspector<AccountId, RuntimeCall> for TestHighSecurity<W>
+	{
+		fn is_high_security(who: &AccountId) -> bool {
+			let who = who.encode();
+			HIGH_SECURITY.with(|hs| hs.borrow().contains(&who))
+		}
+
+		fn is_whitelisted(call: &RuntimeCall) -> bool {
+			W::contains(call)
+		}
+
+		fn guardian(_who: &AccountId) -> Option<AccountId> {
+			None
+		}
+	}
+}

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -52,10 +52,9 @@ use pallet_ranked_collective::Linear;
 use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 use smallvec::smallvec;
 
-use qp_high_security::HighSecurityInspector;
 use qp_scheduler::BlockNumberOrTimestamp;
 use sp_runtime::{
-	traits::{AccountIdConversion, BlakeTwo256, One, StaticLookup},
+	traits::{AccountIdConversion, BlakeTwo256, One},
 	AccountId32, Perbill, Permill,
 };
 use sp_version::RuntimeVersion;
@@ -464,6 +463,7 @@ impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
+	type HighSecurity = HighSecurityConfig;
 }
 
 parameter_types! {
@@ -487,6 +487,7 @@ impl pallet_recovery::Config for Runtime {
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
 	type BlockNumberProvider = System;
+	type HighSecurity = HighSecurityConfig;
 }
 
 parameter_types! {
@@ -623,80 +624,6 @@ impl qp_high_security::HighSecurityInspector<AccountId, RuntimeCall> for HighSec
 	fn guardian(who: &AccountId) -> Option<AccountId> {
 		// Delegate to reversible-transfers pallet
 		pallet_reversible_transfers::Pallet::<Runtime>::get_guardian(who)
-	}
-
-	fn is_call_allowed(who: &AccountId, call: &RuntimeCall) -> bool {
-		Self::call_allowed_for(who, call, 0)
-	}
-}
-
-impl HighSecurityConfig {
-	/// Maximum wrapper nesting the high-security resolver traverses. Far above any realistic
-	/// legitimate nesting yet far below `frame_support::MAX_EXTRINSIC_DEPTH` (256, enforced at
-	/// decode), so it bounds resolver work even if the decode limit ever changed. Calls nested
-	/// deeper fail closed (the transaction is rejected) rather than escaping the whitelist.
-	const MAX_CALL_DEPTH: u32 = 16;
-
-	/// Recursively verify that `call`, dispatched with `signer` as the effective signed
-	/// origin, never reaches a non-whitelisted call as a high-security account.
-	///
-	/// Origin-rewriting wrappers (`Utility::as_derivative`, `Recovery::as_recovered`)
-	/// synthesize a fresh `Signed` origin *after* top-level transaction validation, so the
-	/// high-security whitelist must be re-checked at the effective origin. Origin-preserving
-	/// combinators (`batch`/`batch_all`/`force_batch`/`if_else`) are traversed with the same
-	/// signer. `dispatch_as`/`with_weight` and the scheduler are root-only, so they are not an
-	/// unprivileged bypass and are intentionally not traversed.
-	fn call_allowed_for(signer: &AccountId, call: &RuntimeCall, depth: u32) -> bool {
-		if depth > Self::MAX_CALL_DEPTH {
-			return false;
-		}
-		if Self::is_high_security(signer) && !Self::is_whitelisted(call) {
-			return false;
-		}
-		match call {
-			RuntimeCall::Utility(pallet_utility::Call::as_derivative { index, call }) => {
-				let pseudonym = pallet_utility::derivative_account_id(signer.clone(), *index);
-				Self::call_allowed_for(&pseudonym, call, depth + 1)
-			},
-			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { account, call }) =>
-			// Resolve the target exactly as `as_recovered` does, so the effective origin is
-			// enforced for any address the lookup accepts, not only `MultiAddress::Id`. An
-			// address the lookup rejects aborts `as_recovered` before dispatch, so there is no
-			// effective origin to protect.
-				match <<Runtime as frame_system::Config>::Lookup as StaticLookup>::lookup(
-					account.clone(),
-				) {
-					Ok(target) => Self::call_allowed_for(&target, call, depth + 1),
-					Err(_) => true,
-				},
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-			RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-				calls.iter().all(|c| Self::call_allowed_for(signer, c, depth + 1)),
-			RuntimeCall::Utility(pallet_utility::Call::if_else { main, fallback }) =>
-				Self::call_allowed_for(signer, main, depth + 1) &&
-					Self::call_allowed_for(signer, fallback, depth + 1),
-			_ => true,
-		}
-	}
-
-	/// Upper bound on the `is_high_security` storage reads `call_allowed_for` performs for
-	/// `call` (one per traversed node), used to weight the transaction extension.
-	pub(crate) fn high_security_read_count(call: &RuntimeCall) -> u64 {
-		let inner = match call {
-			RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { call, .. }) =>
-				Self::high_security_read_count(call),
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-			RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-				calls.iter().map(Self::high_security_read_count).sum(),
-			RuntimeCall::Utility(pallet_utility::Call::if_else { main, fallback }) =>
-				Self::high_security_read_count(main)
-					.saturating_add(Self::high_security_read_count(fallback)),
-			_ => 0,
-		};
-		inner.saturating_add(1)
 	}
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -55,7 +55,7 @@ use smallvec::smallvec;
 use qp_high_security::HighSecurityInspector;
 use qp_scheduler::BlockNumberOrTimestamp;
 use sp_runtime::{
-	traits::{AccountIdConversion, BlakeTwo256, One},
+	traits::{AccountIdConversion, BlakeTwo256, One, StaticLookup},
 	AccountId32, Perbill, Permill,
 };
 use sp_version::RuntimeVersion;
@@ -659,12 +659,15 @@ impl HighSecurityConfig {
 				Self::call_allowed_for(&pseudonym, call, depth + 1)
 			},
 			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { account, call }) =>
-				match account {
-					sp_runtime::MultiAddress::Id(target) =>
-						Self::call_allowed_for(target, call, depth + 1),
-					// Other address kinds are unresolvable by the runtime lookup and cannot
-					// dispatch, so there is no effective origin to enforce.
-					_ => true,
+			// Resolve the target exactly as `as_recovered` does, so the effective origin is
+			// enforced for any address the lookup accepts, not only `MultiAddress::Id`. An
+			// address the lookup rejects aborts `as_recovered` before dispatch, so there is no
+			// effective origin to protect.
+				match <<Runtime as frame_system::Config>::Lookup as StaticLookup>::lookup(
+					account.clone(),
+				) {
+					Ok(target) => Self::call_allowed_for(&target, call, depth + 1),
+					Err(_) => true,
 				},
 			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
 			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -626,11 +626,17 @@ impl qp_high_security::HighSecurityInspector<AccountId, RuntimeCall> for HighSec
 	}
 
 	fn is_call_allowed(who: &AccountId, call: &RuntimeCall) -> bool {
-		Self::call_allowed_for(who, call)
+		Self::call_allowed_for(who, call, 0)
 	}
 }
 
 impl HighSecurityConfig {
+	/// Maximum wrapper nesting the high-security resolver traverses. Far above any realistic
+	/// legitimate nesting yet far below `frame_support::MAX_EXTRINSIC_DEPTH` (256, enforced at
+	/// decode), so it bounds resolver work even if the decode limit ever changed. Calls nested
+	/// deeper fail closed (the transaction is rejected) rather than escaping the whitelist.
+	const MAX_CALL_DEPTH: u32 = 16;
+
 	/// Recursively verify that `call`, dispatched with `signer` as the effective signed
 	/// origin, never reaches a non-whitelisted call as a high-security account.
 	///
@@ -640,18 +646,22 @@ impl HighSecurityConfig {
 	/// combinators (`batch`/`batch_all`/`force_batch`/`if_else`) are traversed with the same
 	/// signer. `dispatch_as`/`with_weight` and the scheduler are root-only, so they are not an
 	/// unprivileged bypass and are intentionally not traversed.
-	fn call_allowed_for(signer: &AccountId, call: &RuntimeCall) -> bool {
+	fn call_allowed_for(signer: &AccountId, call: &RuntimeCall, depth: u32) -> bool {
+		if depth > Self::MAX_CALL_DEPTH {
+			return false;
+		}
 		if Self::is_high_security(signer) && !Self::is_whitelisted(call) {
 			return false;
 		}
 		match call {
 			RuntimeCall::Utility(pallet_utility::Call::as_derivative { index, call }) => {
 				let pseudonym = pallet_utility::derivative_account_id(signer.clone(), *index);
-				Self::call_allowed_for(&pseudonym, call)
+				Self::call_allowed_for(&pseudonym, call, depth + 1)
 			},
 			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { account, call }) =>
 				match account {
-					sp_runtime::MultiAddress::Id(target) => Self::call_allowed_for(target, call),
+					sp_runtime::MultiAddress::Id(target) =>
+						Self::call_allowed_for(target, call, depth + 1),
 					// Other address kinds are unresolvable by the runtime lookup and cannot
 					// dispatch, so there is no effective origin to enforce.
 					_ => true,
@@ -659,9 +669,10 @@ impl HighSecurityConfig {
 			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
 			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
 			RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-				calls.iter().all(|c| Self::call_allowed_for(signer, c)),
+				calls.iter().all(|c| Self::call_allowed_for(signer, c, depth + 1)),
 			RuntimeCall::Utility(pallet_utility::Call::if_else { main, fallback }) =>
-				Self::call_allowed_for(signer, main) && Self::call_allowed_for(signer, fallback),
+				Self::call_allowed_for(signer, main, depth + 1) &&
+					Self::call_allowed_for(signer, fallback, depth + 1),
 			_ => true,
 		}
 	}

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -52,6 +52,7 @@ use pallet_ranked_collective::Linear;
 use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 use smallvec::smallvec;
 
+use qp_high_security::HighSecurityInspector;
 use qp_scheduler::BlockNumberOrTimestamp;
 use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, One},
@@ -622,6 +623,66 @@ impl qp_high_security::HighSecurityInspector<AccountId, RuntimeCall> for HighSec
 	fn guardian(who: &AccountId) -> Option<AccountId> {
 		// Delegate to reversible-transfers pallet
 		pallet_reversible_transfers::Pallet::<Runtime>::get_guardian(who)
+	}
+
+	fn is_call_allowed(who: &AccountId, call: &RuntimeCall) -> bool {
+		Self::call_allowed_for(who, call)
+	}
+}
+
+impl HighSecurityConfig {
+	/// Recursively verify that `call`, dispatched with `signer` as the effective signed
+	/// origin, never reaches a non-whitelisted call as a high-security account.
+	///
+	/// Origin-rewriting wrappers (`Utility::as_derivative`, `Recovery::as_recovered`)
+	/// synthesize a fresh `Signed` origin *after* top-level transaction validation, so the
+	/// high-security whitelist must be re-checked at the effective origin. Origin-preserving
+	/// combinators (`batch`/`batch_all`/`force_batch`/`if_else`) are traversed with the same
+	/// signer. `dispatch_as`/`with_weight` and the scheduler are root-only, so they are not an
+	/// unprivileged bypass and are intentionally not traversed.
+	fn call_allowed_for(signer: &AccountId, call: &RuntimeCall) -> bool {
+		if Self::is_high_security(signer) && !Self::is_whitelisted(call) {
+			return false;
+		}
+		match call {
+			RuntimeCall::Utility(pallet_utility::Call::as_derivative { index, call }) => {
+				let pseudonym = pallet_utility::derivative_account_id(signer.clone(), *index);
+				Self::call_allowed_for(&pseudonym, call)
+			},
+			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { account, call }) =>
+				match account {
+					sp_runtime::MultiAddress::Id(target) => Self::call_allowed_for(target, call),
+					// Other address kinds are unresolvable by the runtime lookup and cannot
+					// dispatch, so there is no effective origin to enforce.
+					_ => true,
+				},
+			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+			RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+				calls.iter().all(|c| Self::call_allowed_for(signer, c)),
+			RuntimeCall::Utility(pallet_utility::Call::if_else { main, fallback }) =>
+				Self::call_allowed_for(signer, main) && Self::call_allowed_for(signer, fallback),
+			_ => true,
+		}
+	}
+
+	/// Upper bound on the `is_high_security` storage reads `call_allowed_for` performs for
+	/// `call` (one per traversed node), used to weight the transaction extension.
+	pub(crate) fn high_security_read_count(call: &RuntimeCall) -> u64 {
+		let inner = match call {
+			RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+			RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { call, .. }) =>
+				Self::high_security_read_count(call),
+			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+			RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+				calls.iter().map(Self::high_security_read_count).sum(),
+			RuntimeCall::Utility(pallet_utility::Call::if_else { main, fallback }) =>
+				Self::high_security_read_count(main)
+					.saturating_add(Self::high_security_read_count(fallback)),
+			_ => 0,
+		};
+		inner.saturating_add(1)
 	}
 }
 

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -42,9 +42,9 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 
 	const IDENTIFIER: &'static str = "ReversibleTransactionExtension";
 
-	fn weight(&self, call: &RuntimeCall) -> Weight {
-		// One `is_high_security` read per node traversed by the recursive whitelist check.
-		T::DbWeight::get().reads(crate::configs::HighSecurityConfig::high_security_read_count(call))
+	fn weight(&self, _call: &RuntimeCall) -> Weight {
+		// One `is_high_security` storage read for the flat whitelist check.
+		T::DbWeight::get().reads(1)
 	}
 
 	fn prepare(
@@ -71,10 +71,9 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 		let who = ensure_signed(origin.clone())
 			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::BadSigner))?;
 
-		// Enforce the high-security whitelist at the *effective* dispatched origin: this
-		// recursively resolves origin-rewriting wrappers (`as_derivative`/`as_recovered`) and
-		// origin-preserving combinators (`batch*`/`if_else`) so a non-high-security outer signer
-		// cannot dispatch a non-whitelisted call as a high-security account.
+		// Enforce the high-security whitelist on the top-level signer. Origin-rewriting wrappers
+		// (`as_derivative`/`as_recovered`) re-check the whitelist at the effective origin inside
+		// their own pallets at dispatch time, so this flat check needs no call traversal.
 		if !crate::configs::HighSecurityConfig::is_call_allowed(&who, call) {
 			return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(1)));
 		}
@@ -311,7 +310,10 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use frame_support::{assert_ok, pallet_prelude::TransactionValidityError, traits::Currency};
+	use frame_support::{
+		assert_err_ignore_postinfo, assert_noop, assert_ok,
+		pallet_prelude::TransactionValidityError, traits::Currency,
+	};
 	use sp_runtime::{traits::TxBaseImplication, AccountId32};
 	fn alice() -> AccountId {
 		AccountId32::from([1; 32])
@@ -564,9 +566,9 @@ mod tests {
 
 	// =========================================================================
 	// Origin-rewriting wrappers must not bypass high-security restrictions.
-	// A non-high-security outer signer must not be able to dispatch a
-	// non-whitelisted call as a high-security account via `as_recovered` /
-	// `as_derivative`, including when nested under `batch`.
+	// `as_recovered` / `as_derivative` re-check the whitelist at the effective
+	// (rewritten) origin inside their own pallets, so a non-whitelisted call
+	// cannot be dispatched as a high-security account, including under `batch`.
 	// =========================================================================
 
 	fn boxed(call: RuntimeCall) -> alloc::boxed::Box<RuntimeCall> {
@@ -588,45 +590,32 @@ mod tests {
 	}
 
 	#[test]
-	fn as_recovered_cannot_bypass_high_security() {
+	fn as_recovered_high_security_call_is_blocked() {
 		new_test_ext().execute_with(|| {
-			// Charlie is high-security (from genesis); bob is the (non-high-security) rescuer.
-			let blocked = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
-				account: MultiAddress::Id(charlie()),
-				call: boxed(non_whitelisted_transfer()),
-			});
-			assert_eq!(
-				validate_with(bob(), &blocked).unwrap_err(),
-				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			// bob is charlie's recovery proxy; charlie is high-security (from genesis).
+			pallet_recovery::Proxy::<Runtime>::insert(bob(), charlie());
+
+			// A non-whitelisted call dispatched as the high-security account is rejected.
+			assert_noop!(
+				Recovery::as_recovered(
+					RuntimeOrigin::signed(bob()),
+					MultiAddress::Id(charlie()),
+					boxed(non_whitelisted_transfer()),
+				),
+				pallet_recovery::Error::<Runtime>::CallNotAllowedForHighSecurity
 			);
 
-			// A whitelisted inner call dispatched as the high-security account is allowed.
-			let allowed = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
-				account: MultiAddress::Id(charlie()),
-				call: boxed(whitelisted_schedule()),
-			});
-			assert_ok!(validate_with(bob(), &allowed));
+			// A whitelisted call is allowed through as the high-security account.
+			assert_ok!(Recovery::as_recovered(
+				RuntimeOrigin::signed(bob()),
+				MultiAddress::Id(charlie()),
+				boxed(whitelisted_schedule()),
+			));
 		});
 	}
 
 	#[test]
-	fn as_recovered_alternate_address_encoding_is_not_a_bypass() {
-		new_test_ext().execute_with(|| {
-			// Charlie is `[3; 32]` and high-security. Re-encoding the same key as a non-`Id`
-			// address does not smuggle a non-whitelisted call past the whitelist: `AccountIdLookup`
-			// resolves only `MultiAddress::Id`, so `as_recovered` aborts at lookup before dispatch
-			// and the inner call never runs as the high-security account. The resolver resolves the
-			// target the same way, so it has no effective origin to protect here.
-			let call = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
-				account: MultiAddress::Address32([3u8; 32]),
-				call: boxed(non_whitelisted_transfer()),
-			});
-			assert_ok!(validate_with(bob(), &call));
-		});
-	}
-
-	#[test]
-	fn as_derivative_cannot_bypass_high_security() {
+	fn as_derivative_high_security_call_is_blocked() {
 		new_test_ext().execute_with(|| {
 			// Make alice's index-0 derivative a high-security account.
 			let derivative = pallet_utility::derivative_account_id(alice(), 0u16);
@@ -636,82 +625,46 @@ mod tests {
 				qp_scheduler::BlockNumberOrTimestamp::BlockNumber(10),
 				bob(),
 			));
-			assert!(ReversibleTransfers::is_high_security(&derivative).is_some());
 
-			// Dispatching a non-whitelisted call as the high-security derivative is blocked.
-			let blocked = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
-				index: 0,
-				call: boxed(non_whitelisted_transfer()),
-			});
-			assert_eq!(
-				validate_with(alice(), &blocked).unwrap_err(),
-				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			// A non-whitelisted call dispatched as the high-security derivative is rejected.
+			assert_err_ignore_postinfo!(
+				Utility::as_derivative(
+					RuntimeOrigin::signed(alice()),
+					0,
+					boxed(non_whitelisted_transfer()),
+				),
+				pallet_utility::Error::<Runtime>::CallNotAllowedForHighSecurity
 			);
 
-			// A whitelisted inner call as the derivative is allowed.
-			let allowed = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
-				index: 0,
-				call: boxed(whitelisted_schedule()),
-			});
-			assert_ok!(validate_with(alice(), &allowed));
+			// A whitelisted call as the derivative is allowed.
+			assert_ok!(Utility::as_derivative(
+				RuntimeOrigin::signed(alice()),
+				0,
+				boxed(whitelisted_schedule()),
+			));
 
-			// A different (non-high-security) derivative is unaffected.
-			let control = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
-				index: 1,
-				call: boxed(non_whitelisted_transfer()),
-			});
-			assert_ok!(validate_with(alice(), &control));
+			// A different, non-high-security derivative is unaffected.
+			assert_ok!(Utility::as_derivative(
+				RuntimeOrigin::signed(alice()),
+				1,
+				boxed(RuntimeCall::System(frame_system::Call::remark { remark: vec![1] })),
+			));
 		});
 	}
 
 	#[test]
-	fn batch_wrapped_origin_rewriter_cannot_bypass_high_security() {
+	fn batch_wrapped_high_security_call_is_blocked() {
 		new_test_ext().execute_with(|| {
+			// Wrapping the origin-rewriter in a batch does not bypass the check: `batch_all`
+			// re-dispatches `as_recovered`, whose own check rejects the non-whitelisted call.
+			pallet_recovery::Proxy::<Runtime>::insert(bob(), charlie());
 			let inner = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
 				account: MultiAddress::Id(charlie()),
 				call: boxed(non_whitelisted_transfer()),
 			});
-			let batch = RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![inner] });
-			assert_eq!(
-				validate_with(bob(), &batch).unwrap_err(),
-				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
-			);
-		});
-	}
-
-	#[test]
-	fn non_high_security_origin_rewriter_is_unaffected() {
-		new_test_ext().execute_with(|| {
-			// bob is not high-security; recovering a non-high-security account and transferring
-			// is not restricted by the high-security whitelist.
-			let call = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
-				account: MultiAddress::Id(alice()),
-				call: boxed(non_whitelisted_transfer()),
-			});
-			assert_ok!(validate_with(bob(), &call));
-		});
-	}
-
-	#[test]
-	fn over_nested_call_is_rejected_fail_closed() {
-		new_test_ext().execute_with(|| {
-			// Wrap a (harmless) call in `n` nested batches.
-			let nest = |levels: u32| {
-				let mut call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
-				for _ in 0..levels {
-					call = RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call] });
-				}
-				call
-			};
-
-			// Within the depth bound the call is resolved normally and allowed.
-			assert_ok!(validate_with(bob(), &nest(8)));
-
-			// Beyond the bound the resolver fails closed: the transaction is rejected rather than
-			// allowed to escape the whitelist, capping resolver work regardless of contents.
-			assert_eq!(
-				validate_with(bob(), &nest(20)).unwrap_err(),
-				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			assert_err_ignore_postinfo!(
+				Utility::batch_all(RuntimeOrigin::signed(bob()), vec![inner]),
+				pallet_recovery::Error::<Runtime>::CallNotAllowedForHighSecurity
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -44,8 +44,7 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 
 	fn weight(&self, call: &RuntimeCall) -> Weight {
 		// One `is_high_security` read per node traversed by the recursive whitelist check.
-		T::DbWeight::get()
-			.reads(crate::configs::HighSecurityConfig::high_security_read_count(call))
+		T::DbWeight::get().reads(crate::configs::HighSecurityConfig::high_security_read_count(call))
 	}
 
 	fn prepare(
@@ -442,7 +441,10 @@ mod tests {
 	}
 
 	// Run the reversible transaction extension's `validate` for `call` signed by `signer`.
-	fn validate_with(signer: AccountId, call: &RuntimeCall) -> Result<(), TransactionValidityError> {
+	fn validate_with(
+		signer: AccountId,
+		call: &RuntimeCall,
+	) -> Result<(), TransactionValidityError> {
 		ReversibleTransactionExtension::<Runtime>::new()
 			.validate(
 				RuntimeOrigin::signed(signer),
@@ -653,8 +655,7 @@ mod tests {
 				account: MultiAddress::Id(charlie()),
 				call: boxed(non_whitelisted_transfer()),
 			});
-			let batch =
-				RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![inner] });
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![inner] });
 			assert_eq!(
 				validate_with(bob(), &batch).unwrap_err(),
 				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
@@ -680,8 +681,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			// Wrap a (harmless) call in `n` nested batches.
 			let nest = |levels: u32| {
-				let mut call =
-					RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+				let mut call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
 				for _ in 0..levels {
 					call = RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call] });
 				}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -42,8 +42,10 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 
 	const IDENTIFIER: &'static str = "ReversibleTransactionExtension";
 
-	fn weight(&self, _call: &RuntimeCall) -> Weight {
-		T::DbWeight::get().reads(1)
+	fn weight(&self, call: &RuntimeCall) -> Weight {
+		// One `is_high_security` read per node traversed by the recursive whitelist check.
+		T::DbWeight::get()
+			.reads(crate::configs::HighSecurityConfig::high_security_read_count(call))
 	}
 
 	fn prepare(
@@ -70,14 +72,12 @@ impl<T: pallet_reversible_transfers::Config + Send + Sync + alloc::fmt::Debug>
 		let who = ensure_signed(origin.clone())
 			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::BadSigner))?;
 
-		// Check if account is high-security using the same inspector as multisig
-		if crate::configs::HighSecurityConfig::is_high_security(&who) {
-			// Use the same whitelist check as multisig
-			if crate::configs::HighSecurityConfig::is_whitelisted(call) {
-				return Ok((ValidTransaction::default(), (), origin));
-			} else {
-				return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(1)));
-			}
+		// Enforce the high-security whitelist at the *effective* dispatched origin: this
+		// recursively resolves origin-rewriting wrappers (`as_derivative`/`as_recovered`) and
+		// origin-preserving combinators (`batch*`/`if_else`) so a non-high-security outer signer
+		// cannot dispatch a non-whitelisted call as a high-security account.
+		if !crate::configs::HighSecurityConfig::is_call_allowed(&who, call) {
+			return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(1)));
 		}
 
 		Ok((ValidTransaction::default(), (), origin))
@@ -441,32 +441,34 @@ mod tests {
 		});
 	}
 
-	fn check_call(call: RuntimeCall) -> Result<(), TransactionValidityError> {
-		// Test the reversible transaction extension
-		let ext = ReversibleTransactionExtension::<Runtime>::new();
+	// Run the reversible transaction extension's `validate` for `call` signed by `signer`.
+	fn validate_with(signer: AccountId, call: &RuntimeCall) -> Result<(), TransactionValidityError> {
+		ReversibleTransactionExtension::<Runtime>::new()
+			.validate(
+				RuntimeOrigin::signed(signer),
+				call,
+				&Default::default(),
+				0,
+				(),
+				&TxBaseImplication::<()>(()),
+				frame_support::pallet_prelude::TransactionSource::External,
+			)
+			.map(|_| ())
+	}
 
+	fn check_call(call: RuntimeCall) -> Result<(), TransactionValidityError> {
 		// Verify Charlie is high-security
 		assert!(ReversibleTransfers::is_high_security(&charlie()).is_some());
 
 		let origin = RuntimeOrigin::signed(charlie());
 
 		// Test the prepare method
-		ext.clone().prepare((), &origin, &call, &Default::default(), 0).unwrap();
-
-		assert_eq!((), ());
+		ReversibleTransactionExtension::<Runtime>::new()
+			.prepare((), &origin, &call, &Default::default(), 0)
+			.unwrap();
 
 		// Test the validate method
-		let result = ext.validate(
-			origin,
-			&call,
-			&Default::default(),
-			0,
-			(),
-			&TxBaseImplication::<()>(()),
-			frame_support::pallet_prelude::TransactionSource::External,
-		);
-
-		result.map(|_| ())
+		validate_with(charlie(), &call)
 	}
 
 	#[test]
@@ -555,6 +557,121 @@ mod tests {
 					tx_id: sp_core::H256::default(),
 				});
 			assert_ok!(check_call(call));
+		});
+	}
+
+	// =========================================================================
+	// Origin-rewriting wrappers must not bypass high-security restrictions.
+	// A non-high-security outer signer must not be able to dispatch a
+	// non-whitelisted call as a high-security account via `as_recovered` /
+	// `as_derivative`, including when nested under `batch`.
+	// =========================================================================
+
+	fn boxed(call: RuntimeCall) -> alloc::boxed::Box<RuntimeCall> {
+		alloc::boxed::Box::new(call)
+	}
+
+	fn non_whitelisted_transfer() -> RuntimeCall {
+		RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
+			dest: MultiAddress::Id(bob()),
+			value: 10 * EXISTENTIAL_DEPOSIT,
+		})
+	}
+
+	fn whitelisted_schedule() -> RuntimeCall {
+		RuntimeCall::ReversibleTransfers(pallet_reversible_transfers::Call::schedule_transfer {
+			dest: MultiAddress::Id(bob()),
+			amount: 10 * EXISTENTIAL_DEPOSIT,
+		})
+	}
+
+	#[test]
+	fn as_recovered_cannot_bypass_high_security() {
+		new_test_ext().execute_with(|| {
+			// Charlie is high-security (from genesis); bob is the (non-high-security) rescuer.
+			let blocked = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
+				account: MultiAddress::Id(charlie()),
+				call: boxed(non_whitelisted_transfer()),
+			});
+			assert_eq!(
+				validate_with(bob(), &blocked).unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			);
+
+			// A whitelisted inner call dispatched as the high-security account is allowed.
+			let allowed = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
+				account: MultiAddress::Id(charlie()),
+				call: boxed(whitelisted_schedule()),
+			});
+			assert_ok!(validate_with(bob(), &allowed));
+		});
+	}
+
+	#[test]
+	fn as_derivative_cannot_bypass_high_security() {
+		new_test_ext().execute_with(|| {
+			// Make alice's index-0 derivative a high-security account.
+			let derivative = pallet_utility::derivative_account_id(alice(), 0u16);
+			Balances::make_free_balance_be(&derivative, EXISTENTIAL_DEPOSIT * 100);
+			assert_ok!(ReversibleTransfers::set_high_security(
+				RuntimeOrigin::signed(derivative.clone()),
+				qp_scheduler::BlockNumberOrTimestamp::BlockNumber(10),
+				bob(),
+			));
+			assert!(ReversibleTransfers::is_high_security(&derivative).is_some());
+
+			// Dispatching a non-whitelisted call as the high-security derivative is blocked.
+			let blocked = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
+				index: 0,
+				call: boxed(non_whitelisted_transfer()),
+			});
+			assert_eq!(
+				validate_with(alice(), &blocked).unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			);
+
+			// A whitelisted inner call as the derivative is allowed.
+			let allowed = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
+				index: 0,
+				call: boxed(whitelisted_schedule()),
+			});
+			assert_ok!(validate_with(alice(), &allowed));
+
+			// A different (non-high-security) derivative is unaffected.
+			let control = RuntimeCall::Utility(pallet_utility::Call::as_derivative {
+				index: 1,
+				call: boxed(non_whitelisted_transfer()),
+			});
+			assert_ok!(validate_with(alice(), &control));
+		});
+	}
+
+	#[test]
+	fn batch_wrapped_origin_rewriter_cannot_bypass_high_security() {
+		new_test_ext().execute_with(|| {
+			let inner = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
+				account: MultiAddress::Id(charlie()),
+				call: boxed(non_whitelisted_transfer()),
+			});
+			let batch =
+				RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![inner] });
+			assert_eq!(
+				validate_with(bob(), &batch).unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			);
+		});
+	}
+
+	#[test]
+	fn non_high_security_origin_rewriter_is_unaffected() {
+		new_test_ext().execute_with(|| {
+			// bob is not high-security; recovering a non-high-security account and transferring
+			// is not restricted by the high-security whitelist.
+			let call = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
+				account: MultiAddress::Id(alice()),
+				call: boxed(non_whitelisted_transfer()),
+			});
+			assert_ok!(validate_with(bob(), &call));
 		});
 	}
 

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -675,6 +675,31 @@ mod tests {
 		});
 	}
 
+	#[test]
+	fn over_nested_call_is_rejected_fail_closed() {
+		new_test_ext().execute_with(|| {
+			// Wrap a (harmless) call in `n` nested batches.
+			let nest = |levels: u32| {
+				let mut call =
+					RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+				for _ in 0..levels {
+					call = RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call] });
+				}
+				call
+			};
+
+			// Within the depth bound the call is resolved normally and allowed.
+			assert_ok!(validate_with(bob(), &nest(8)));
+
+			// Beyond the bound the resolver fails closed: the transaction is rejected rather than
+			// allowed to escape the whitelist, capping resolver work regardless of contents.
+			assert_eq!(
+				validate_with(bob(), &nest(20)).unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
+			);
+		});
+	}
+
 	// =========================================================================
 	// Tests for event-based WormholeProofRecorderExtension
 	// =========================================================================

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -610,6 +610,22 @@ mod tests {
 	}
 
 	#[test]
+	fn as_recovered_alternate_address_encoding_is_not_a_bypass() {
+		new_test_ext().execute_with(|| {
+			// Charlie is `[3; 32]` and high-security. Re-encoding the same key as a non-`Id`
+			// address does not smuggle a non-whitelisted call past the whitelist: `AccountIdLookup`
+			// resolves only `MultiAddress::Id`, so `as_recovered` aborts at lookup before dispatch
+			// and the inner call never runs as the high-security account. The resolver resolves the
+			// target the same way, so it has no effective origin to protect here.
+			let call = RuntimeCall::Recovery(pallet_recovery::Call::as_recovered {
+				account: MultiAddress::Address32([3u8; 32]),
+				call: boxed(non_whitelisted_transfer()),
+			});
+			assert_ok!(validate_with(bob(), &call));
+		});
+	}
+
+	#[test]
 	fn as_derivative_cannot_bypass_high_security() {
 		new_test_ext().execute_with(|| {
 			// Make alice's index-0 derivative a high-security account.


### PR DESCRIPTION
## Summary

High-security (HS) accounts are meant to be limited to whitelisted calls (e.g. reversible `schedule_transfer`/`cancel`). They could be bypassed: `Recovery::as_recovered` and `Utility::as_derivative` synthesize a fresh `Signed` origin **after** top-level transaction validation, so a non-HS outer signer could dispatch a non-whitelisted call *as* an HS account — including when nested under `batch`/`batch_all`/`force_batch`/`if_else`.

This PR enforces the HS whitelist at the **effective dispatched origin**, entirely at the runtime/extension layer:

- `HighSecurityConfig::call_allowed_for` recursively resolves origin-rewriting wrappers (`as_recovered`/`as_derivative`) and origin-preserving combinators (`batch*`/`if_else`), re-checking the whitelist at each effective signer. Root-only `dispatch_as`/`with_weight` and the scheduler are intentionally not traversed.
- Shared via a new `HighSecurityInspector::is_call_allowed` provided method, so `ReversibleTransactionExtension` and `pallet-multisig` use one implementation (no duplicated logic).
- Recursion is **bounded and fail-closed** (`MAX_CALL_DEPTH = 16`, well below `MAX_EXTRINSIC_DEPTH = 256`): over-nested calls are rejected rather than allowed to escape the whitelist, so validation work can't be exhausted.
- The extension `weight()` scales with the number of nodes traversed (one `is_high_security` read per node).
- `pallet-recovery` and `pallet-utility` are left **unchanged from upstream Substrate**.

## Test plan

- [ ] `cargo test -p quantus-runtime --lib transaction_extensions::tests` — origin-rewriter bypass blocked, whitelisted inner call allowed, nested-in-batch bypass blocked, non-HS origin unaffected, over-nested call rejected fail-closed
- [ ] `cargo test -p pallet-multisig`
- [ ] `cargo test -p pallet-reversible-transfers`
- [ ] Runtime integration tests (recovery / reversible)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security fix for account restriction enforcement; incorrect recursion or depth handling could still allow HS bypass or reject valid transactions.
> 
> **Overview**
> Closes a bypass where **high-security (HS)** call limits could be evaded by wrapping disallowed inner calls in **`Recovery::as_recovered`** or **`Utility::as_derivative`** (and **`batch*` / `if_else`**), because those pallets rewrite the signed origin after top-level validation.
> 
> **`HighSecurityInspector::is_call_allowed`** is added with a default that only checks the top-level call; the runtime overrides it via **`HighSecurityConfig::call_allowed_for`**, which recursively walks origin-rewriting and batching wrappers, re-applies the HS whitelist at each effective signer, and **rejects over-deep nesting** (`MAX_CALL_DEPTH = 16`, fail-closed). **`ReversibleTransactionExtension`** now uses this helper instead of a shallow HS + whitelist check, and its **`weight()`** scales with **`high_security_read_count`**. **`pallet-multisig` `execute`** re-checks with **`is_call_allowed`** instead of only testing the outer call against the whitelist.
> 
> Runtime tests cover blocked/allowed paths for **`as_recovered`**, **`as_derivative`**, batch-wrapped bypasses, and excessive nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c521abf8e0ae3737c178a0cfe920c2aa3f8536. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->