### PR TITLE
Automate release for v0.7.2-rsn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.7.1-q-day-2"
+version = "0.7.2-rsn"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -8434,7 +8434,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.7.1-q-day-2"
+version = "0.7.2-rsn"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.7.1-q-day-2"
+version = "0.7.2-rsn"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.7.1-q-day-2"
+version = "0.7.2-rsn"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 133,
+	spec_version: 134,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.7.2-rsn.

https://github.com/Quantus-Network/chain/actions/runs/28500893933

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumping `spec_version` affects chain/runtime upgrade coordination; the change is small but operators must align Wasm/native builds with spec 134.
> 
> **Overview**
> This PR is an **automated release version bump** for **v0.7.2-rsn** (patch workflow). It aligns crate versions and the on-chain runtime spec so nodes and tooling report the new release.
> 
> **Package versions** move from `0.7.1-q-day-2` to `0.7.2-rsn` in `node/Cargo.toml`, `runtime/Cargo.toml`, and matching `Cargo.lock` entries for `quantus-node` and `quantus-runtime`.
> 
> **On-chain compatibility:** `runtime/src/lib.rs` bumps `VERSION.spec_version` from **133** to **134**. That is the standard Substrate signal for a runtime upgrade; reviewers should confirm release notes / upgrade procedures match this spec bump even though this diff contains no pallet or migration code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be119292dbcd18472a612856e27333048c407e52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->