### PR TITLE
fix: fall back to default DNS resolver when system config is unparseable

### DIFF
--- a/client/litep2p/src/lib.rs
+++ b/client/litep2p/src/lib.rs
@@ -50,7 +50,10 @@ use crate::{
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::WebSocketTransport;
 
-use hickory_resolver::TokioResolver;
+use hickory_resolver::{
+	config::{ResolverConfig, GOOGLE},
+	TokioResolver,
+};
 use multiaddr::{Multiaddr, Protocol};
 use transport::Endpoint;
 use types::ConnectionId;
@@ -155,17 +158,18 @@ impl Litep2p {
 		let mut listen_addresses = vec![];
 
 		let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
-			// Some hosts advertise nameservers hickory can't parse (e.g. macOS zoned
-			// link-local IPv6 `fe80::1%en0`); log and fall back instead of aborting startup.
+			// `ResolverConfig::default()` has no nameservers since hickory 0.26, so on a
+			// failed system read fall back to public DNS rather than leave the node unable
+			// to resolve `/dns/` peers.
 			match hickory_resolver::system_conf::read_system_conf() {
 				Ok(conf) => conf,
 				Err(error) => {
 					tracing::error!(
 						target: LOG_TARGET,
 						?error,
-						"failed to read system DNS config; falling back to default resolver",
+						"failed to read system DNS config; falling back to public DNS",
 					);
-					(Default::default(), Default::default())
+					(ResolverConfig::udp_and_tcp(&GOOGLE), Default::default())
 				},
 			}
 		} else {

--- a/client/litep2p/src/lib.rs
+++ b/client/litep2p/src/lib.rs
@@ -155,8 +155,19 @@ impl Litep2p {
 		let mut listen_addresses = vec![];
 
 		let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
-			hickory_resolver::system_conf::read_system_conf()
-				.map_err(|e| Error::CannotReadSystemDnsConfig(e.into()))?
+			// Some hosts advertise nameservers hickory can't parse (e.g. macOS zoned
+			// link-local IPv6 `fe80::1%en0`); log and fall back instead of aborting startup.
+			match hickory_resolver::system_conf::read_system_conf() {
+				Ok(conf) => conf,
+				Err(error) => {
+					tracing::error!(
+						target: LOG_TARGET,
+						?error,
+						"failed to read system DNS config; falling back to default resolver",
+					);
+					(Default::default(), Default::default())
+				},
+			}
 		} else {
 			(Default::default(), Default::default())
 		};


### PR DESCRIPTION
## Summary

- The litep2p backend calls `with_system_resolver()` (added in #586), which reads the OS resolver config via `hickory read_system_conf()` during `Litep2p::new()`.
- If `/etc/resolv.conf` contains a nameserver the parser rejects — notably the macOS zoned link-local IPv6 entry `nameserver fe80::1%en0` — the read returns an error, mapped to `Error::CannotReadSystemDnsConfig`, which propagates out and **aborts the whole service on startup**:

  ```
  Essential task `basic-block-import-worker` failed. Shutting down service.
  Error: Service(Network(Litep2p: Cannot read system DNS config: `failed to parse nameserver address: invalid IP address syntax`))
  ```

  The node cannot start at all on such hosts (reproducible on macOS with the default network config).
- This change logs the parse failure at `error` level and falls back to litep2p's default resolver instead of aborting, preserving #586's "prefer system DNS" intent while no longer bricking startup.

## Root cause

`hickory_resolver::system_conf::read_system_conf()` (via `resolv-conf`) fails to parse a nameserver with an IPv6 zone id (`%en0`). The vendored litep2p treated that read as fatal:

```rust
let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
    hickory_resolver::system_conf::read_system_conf()
        .map_err(|e| Error::CannotReadSystemDnsConfig(e.into()))?   // <- aborts node startup
} else {
    (Default::default(), Default::default())
};
```

## Test plan

- [x] `cargo check -p litep2p`
- [x] Built `quantus-node` and started a `--dev` node on a macOS host whose `/etc/resolv.conf` has `nameserver fe80::1%en0`. Before: startup aborts with `CannotReadSystemDnsConfig`. After: node logs the fallback and boots, mines blocks, and serves RPC (verified transfers, multisig, and tech-collective governance via the CLI).
- [ ] Sanity check on a Linux host with a normal IPv4 `resolv.conf` (system resolver path unchanged).