### PR TITLE
Automate release for v0.7.2-full-moon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.7.1-q-day-2"
+version = "0.7.2-full-moon"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -8434,7 +8434,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.7.1-q-day-2"
+version = "0.7.2-full-moon"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.7.1-q-day-2"
+version = "0.7.2-full-moon"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.7.1-q-day-2"
+version = "0.7.2-full-moon"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 133,
+	spec_version: 134,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Automated version bump for release v0.7.2-full-moon.

https://github.com/Quantus-Network/chain/actions/runs/28516487336

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no logic edits; the spec_version increment is the standard requirement for deploying this runtime build.
> 
> **Overview**
> Automated **v0.7.2-full-moon** release: crate versions for `quantus-node` and `quantus-runtime` move from `0.7.1-q-day-2` to `0.7.2-full-moon`, with matching updates in `Cargo.lock`.
> 
> The on-chain runtime identity is bumped via **`spec_version` 133 → 134** in `runtime/src/lib.rs` so upgraded Wasm is recognized by nodes and tooling. No pallet, API, or application logic changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910bc3377de4b5be30626d641ff13eff4299087d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->