### PR TITLE
Harden FRAME primitives against audit findings

### DIFF
--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -21,6 +21,7 @@ frame-support.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
 log.workspace = true
+qp-header.workspace = true
 scale-info = { features = ["derive"], workspace = true }
 sp-core.workspace = true
 sp-io.workspace = true
@@ -31,7 +32,6 @@ sp-tracing.workspace = true
 array-bytes = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }
 pallet-transaction-payment = { workspace = true, default-features = true }
-qp-header = { workspace = true, default-features = true }
 sp-inherents = { workspace = true, default-features = true }
 sp-version = { workspace = true, default-features = true }
 
@@ -44,6 +44,7 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime/std",
 	"log/std",
+	"qp-header/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -131,6 +131,7 @@ use frame_support::{
 	MAX_EXTRINSIC_DEPTH,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
+use qp_header::ZkTreeRootProvider;
 use sp_runtime::{
 	generic::Digest,
 	traits::{
@@ -395,6 +396,15 @@ where
 				assert!(
 					header.state_root() == storage_root,
 					"Storage root must match that calculated."
+				);
+
+				// The ZK tree root is derived from storage, so it is only expected to match
+				// when the state itself is expected to match.
+				let zk_tree_root = new_header.zk_tree_root();
+				header.zk_tree_root().check_equal(zk_tree_root);
+				assert!(
+					header.zk_tree_root() == zk_tree_root,
+					"ZK tree root must match that calculated."
 				);
 			}
 
@@ -935,6 +945,16 @@ where
 		assert!(
 			header.extrinsics_root() == new_header.extrinsics_root(),
 			"Transaction trie root must be valid.",
+		);
+
+		// check ZK tree root. This field is part of the block-hash preimage, so it must be
+		// re-derived from state on import; otherwise a block author could commit an arbitrary
+		// root into the header.
+		let zk_tree_root = new_header.zk_tree_root();
+		header.zk_tree_root().check_equal(zk_tree_root);
+		assert!(
+			header.zk_tree_root() == zk_tree_root,
+			"ZK tree root must match that calculated.",
 		);
 	}
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -952,10 +952,7 @@ where
 		// root into the header.
 		let zk_tree_root = new_header.zk_tree_root();
 		header.zk_tree_root().check_equal(zk_tree_root);
-		assert!(
-			header.zk_tree_root() == zk_tree_root,
-			"ZK tree root must match that calculated.",
-		);
+		assert!(header.zk_tree_root() == zk_tree_root, "ZK tree root must match that calculated.",);
 	}
 
 	/// Check a given signed transaction for validity. This doesn't execute any

--- a/frame/executive/src/tests.rs
+++ b/frame/executive/src/tests.rs
@@ -709,7 +709,7 @@ fn block_import_of_bad_state_root_fails() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "ZK tree root must match that calculated.")]
 fn block_import_of_bad_zk_tree_root_fails() {
 	new_test_ext(1).execute_with(|| {
 		let mut header = Header::new(

--- a/frame/executive/src/tests.rs
+++ b/frame/executive/src/tests.rs
@@ -710,6 +710,28 @@ fn block_import_of_bad_state_root_fails() {
 
 #[test]
 #[should_panic]
+fn block_import_of_bad_zk_tree_root_fails() {
+	new_test_ext(1).execute_with(|| {
+		let mut header = Header::new(
+			1,
+			array_bytes::hex_n_into_unchecked(
+				"03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+			),
+			array_bytes::hex_n_into_unchecked(
+				"d6b465f5a50c9f8d5a6edc0f01d285a6b19030f097d3aaf1649b7be81649f118",
+			),
+			[69u8; 32].into(),
+			Digest { logs: vec![] },
+		);
+		// Forge a ZK tree root that does not match on-chain state (which is the default zero
+		// root). Before the `final_checks` fix this block would import successfully.
+		header.set_zk_tree_root([42u8; 32].into());
+		Executive::execute_block(TestBlock { header, extrinsics: vec![] }.into());
+	});
+}
+
+#[test]
+#[should_panic]
 fn block_import_of_bad_extrinsic_root_fails() {
 	new_test_ext(1).execute_with(|| {
 		Executive::execute_block(

--- a/frame/support-procedural/src/dynamic_params.rs
+++ b/frame/support-procedural/src/dynamic_params.rs
@@ -149,6 +149,9 @@ fn ensure_codec_index(attrs: &Vec<syn::Attribute>, span: Span) -> Result<()> {
 ///
 /// This allows the outer `#[dynamic_params(..)]` attribute to specify some arguments that don't
 /// need to be repeated every time.
+///
+/// Arguments already present on the inner attribute take precedence and are left untouched;
+/// the outer arguments are only injected when the inner attribute has none.
 struct MacroInjectArgs {
 	runtime_params: syn::Ident,
 	params_pallet: syn::Type,
@@ -159,20 +162,24 @@ impl VisitMut for MacroInjectArgs {
 		let attr = item.attrs.iter_mut().find(|attr| attr.path().is_ident("dynamic_pallet_params"));
 
 		if let Some(attr) = attr {
-			match &attr.meta {
-				syn::Meta::Path(path) =>
-					assert_eq!(path.to_token_stream().to_string(), "dynamic_pallet_params"),
-				_ => (),
+			// Only inject the outer arguments if the inner attribute does not specify its own:
+			// either a bare `#[dynamic_pallet_params]` or an empty `#[dynamic_pallet_params()]`.
+			let has_own_args = match &attr.meta {
+				syn::Meta::Path(_) => false,
+				syn::Meta::List(list) => !list.tokens.is_empty(),
+				syn::Meta::NameValue(_) => true,
+			};
+
+			if !has_own_args {
+				let runtime_params = &self.runtime_params;
+				let params_pallet = &self.params_pallet;
+
+				attr.meta = syn::parse2::<syn::Meta>(quote! {
+					dynamic_pallet_params(#runtime_params, #params_pallet)
+				})
+				.unwrap()
+				.into();
 			}
-
-			let runtime_params = &self.runtime_params;
-			let params_pallet = &self.params_pallet;
-
-			attr.meta = syn::parse2::<syn::Meta>(quote! {
-				dynamic_pallet_params(#runtime_params, #params_pallet)
-			})
-			.unwrap()
-			.into();
 		}
 
 		visit_mut::visit_item_mod_mut(self, item);
@@ -569,4 +576,97 @@ impl ToTokens for DynamicParamAggregatedEnum {
 /// Get access to the current crate and convert the error to a compile error.
 fn crate_access() -> core::result::Result<syn::Path, TokenStream> {
 	generate_access_from_frame_or_crate("frame-support").map_err(|e| e.to_compile_error())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn inject(module: TokenStream) -> syn::ItemMod {
+		let mut params_mod: syn::ItemMod = parse2(module).unwrap();
+		MacroInjectArgs {
+			runtime_params: syn::Ident::new("RuntimeParameters", Span::call_site()),
+			params_pallet: parse2(quote!(dynamic_params::pallet_parameters::Parameters::<Runtime>))
+				.unwrap(),
+		}
+		.visit_item_mod_mut(&mut params_mod);
+		params_mod
+	}
+
+	fn inner_attr(params_mod: &syn::ItemMod) -> &syn::Attribute {
+		let (_, items) = params_mod.content.as_ref().unwrap();
+		items
+			.iter()
+			.find_map(|i| match i {
+				syn::Item::Mod(m) => m
+					.attrs
+					.iter()
+					.find(|attr| attr.path().is_ident("dynamic_pallet_params")),
+				_ => None,
+			})
+			.unwrap()
+	}
+
+	#[test]
+	fn outer_args_are_injected_into_bare_inner_attribute() {
+		let params_mod = inject(quote! {
+			pub mod dynamic_params {
+				#[dynamic_pallet_params]
+				#[codec(index = 0)]
+				pub mod inner {}
+			}
+		});
+
+		let attr = inner_attr(&params_mod);
+		assert_eq!(
+			attr.meta.to_token_stream().to_string(),
+			quote!(dynamic_pallet_params(
+				RuntimeParameters,
+				dynamic_params::pallet_parameters::Parameters::<Runtime>
+			))
+			.to_string(),
+		);
+	}
+
+	#[test]
+	fn outer_args_are_injected_into_empty_inner_attribute() {
+		let params_mod = inject(quote! {
+			pub mod dynamic_params {
+				#[dynamic_pallet_params()]
+				#[codec(index = 0)]
+				pub mod inner {}
+			}
+		});
+
+		let attr = inner_attr(&params_mod);
+		assert_eq!(
+			attr.meta.to_token_stream().to_string(),
+			quote!(dynamic_pallet_params(
+				RuntimeParameters,
+				dynamic_params::pallet_parameters::Parameters::<Runtime>
+			))
+			.to_string(),
+		);
+	}
+
+	#[test]
+	fn inner_attribute_args_take_precedence_over_outer() {
+		let params_mod = inject(quote! {
+			pub mod dynamic_params {
+				#[dynamic_pallet_params(InnerRuntimeParameters, pallet_other::Parameters::<Runtime>)]
+				#[codec(index = 0)]
+				pub mod inner {}
+			}
+		});
+
+		let attr = inner_attr(&params_mod);
+		assert_eq!(
+			attr.meta.to_token_stream().to_string(),
+			quote!(dynamic_pallet_params(
+				InnerRuntimeParameters,
+				pallet_other::Parameters::<Runtime>
+			))
+			.to_string(),
+		);
+	}
 }

--- a/frame/support-procedural/src/dynamic_params.rs
+++ b/frame/support-procedural/src/dynamic_params.rs
@@ -598,10 +598,8 @@ mod tests {
 		items
 			.iter()
 			.find_map(|i| match i {
-				syn::Item::Mod(m) => m
-					.attrs
-					.iter()
-					.find(|attr| attr.path().is_ident("dynamic_pallet_params")),
+				syn::Item::Mod(m) =>
+					m.attrs.iter().find(|attr| attr.path().is_ident("dynamic_pallet_params")),
 				_ => None,
 			})
 			.unwrap()

--- a/frame/support/src/migrations.rs
+++ b/frame/support/src/migrations.rs
@@ -432,8 +432,12 @@ pub struct RemoveStorage<
 	DbWeight: Get<RuntimeDbWeight>,
 	Limit: Get<u32>,
 >(PhantomData<(P, S, DbWeight, Limit)>);
-impl<P: Get<&'static str>, S: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>, Limit: Get<u32>>
-	frame_support::traits::OnRuntimeUpgrade for RemoveStorage<P, S, DbWeight, Limit>
+impl<
+		P: Get<&'static str>,
+		S: Get<&'static str>,
+		DbWeight: Get<RuntimeDbWeight>,
+		Limit: Get<u32>,
+	> frame_support::traits::OnRuntimeUpgrade for RemoveStorage<P, S, DbWeight, Limit>
 {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		let hashed_prefix = storage_prefix(P::get().as_bytes(), S::get().as_bytes());

--- a/frame/support/src/migrations.rs
+++ b/frame/support/src/migrations.rs
@@ -294,8 +294,8 @@ pub fn migrate_from_pallet_version_to_storage_version<
 /// }
 ///
 /// pub type Migrations = (
-/// 	RemovePallet<SomePalletToRemoveStr, RocksDbWeight>,
-/// 	RemovePallet<AnotherPalletToRemoveStr, RocksDbWeight>,
+/// 	RemovePallet<SomePalletToRemoveStr, RocksDbWeight, ConstU32<1000>>,
+/// 	RemovePallet<AnotherPalletToRemoveStr, RocksDbWeight, ConstU32<1000>>,
 /// 	AnyOtherMigrations...
 /// );
 ///
@@ -304,27 +304,33 @@ pub fn migrate_from_pallet_version_to_storage_version<
 /// }
 /// ```
 ///
-/// WARNING: `RemovePallet` has no guard rails preventing it from bricking the chain if the
-/// operation of removing storage for the given pallet would exceed the block weight limit.
+/// `Limit` bounds how many keys are removed in a single upgrade so the migration cannot exceed
+/// the block weight limit, even for a prefix whose key count can be grown by users before the
+/// upgrade. `Limit` should be chosen so that removing that many keys comfortably fits within a
+/// block.
 ///
-/// If your pallet has too many keys to be removed in a single block, it is advised to wait for
-/// a multi-block scheduler currently under development which will allow for removal of storage
-/// items (and performing other heavy migrations) over multiple blocks
-/// (see <https://github.com/paritytech/substrate/issues/13690>).
-pub struct RemovePallet<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>>(
-	PhantomData<(P, DbWeight)>,
+/// If your pallet may hold more than `Limit` keys, the excess keys are left in place (they are
+/// harmless orphaned storage under the removed pallet's prefix). To remove all of them, either
+/// raise `Limit` to a value that is still safely below the block weight limit, or use a
+/// multi-block migration which can spread removal of storage items (and other heavy migrations)
+/// over multiple blocks (see <https://github.com/paritytech/substrate/issues/13690>).
+pub struct RemovePallet<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>, Limit: Get<u32>>(
+	PhantomData<(P, DbWeight, Limit)>,
 );
-impl<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>> frame_support::traits::OnRuntimeUpgrade
-	for RemovePallet<P, DbWeight>
+impl<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>, Limit: Get<u32>>
+	frame_support::traits::OnRuntimeUpgrade for RemovePallet<P, DbWeight, Limit>
 {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		let hashed_prefix = twox_128(P::get().as_bytes());
-		let keys_removed = match clear_prefix(&hashed_prefix, None) {
+		let keys_removed = match clear_prefix(&hashed_prefix, Some(Limit::get())) {
 			KillStorageResult::AllRemoved(value) => value,
 			KillStorageResult::SomeRemaining(value) => {
-				log::error!(
-					"`clear_prefix` failed to remove all keys for {}. THIS SHOULD NEVER HAPPEN! 🚨",
-					P::get()
+				log::warn!(
+					"`RemovePallet` hit its per-upgrade limit of {} keys for {}; {} keys removed, more remain. \
+					 Raise `Limit` (staying below the block weight limit) or use a multi-block migration to remove the rest.",
+					Limit::get(),
+					P::get(),
+					value,
 				);
 				value
 			},
@@ -401,8 +407,8 @@ impl<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>> frame_support::traits
 /// }
 ///
 /// pub type Migrations = (
-/// 	RemoveStorage<SomePallet, StorageAccounts, RocksDbWeight>,
-/// 	RemoveStorage<SomePallet, StorageAccountCount, RocksDbWeight>,
+/// 	RemoveStorage<SomePallet, StorageAccounts, RocksDbWeight, ConstU32<1000>>,
+/// 	RemoveStorage<SomePallet, StorageAccountCount, RocksDbWeight, ConstU32<1000>>,
 /// 	AnyOtherMigrations...
 /// );
 ///
@@ -411,27 +417,37 @@ impl<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>> frame_support::traits
 /// }
 /// ```
 ///
-/// WARNING: `RemoveStorage` has no guard rails preventing it from bricking the chain if the
-/// operation of removing storage for the given pallet would exceed the block weight limit.
+/// `Limit` bounds how many keys are removed in a single upgrade so the migration cannot exceed
+/// the block weight limit, even for a storage item whose key count can be grown by users before
+/// the upgrade. `Limit` should be chosen so that removing that many keys comfortably fits within
+/// a block.
 ///
-/// If your storage has too many keys to be removed in a single block, it is advised to wait for
-/// a multi-block scheduler currently under development which will allow for removal of storage
-/// items (and performing other heavy migrations) over multiple blocks
-/// (see <https://github.com/paritytech/substrate/issues/13690>).
-pub struct RemoveStorage<P: Get<&'static str>, S: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>>(
-	PhantomData<(P, S, DbWeight)>,
-);
-impl<P: Get<&'static str>, S: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>>
-	frame_support::traits::OnRuntimeUpgrade for RemoveStorage<P, S, DbWeight>
+/// If your storage may hold more than `Limit` keys, the excess keys are left in place. To remove
+/// all of them, either raise `Limit` to a value that is still safely below the block weight
+/// limit, or use a multi-block migration which can spread removal of storage items (and other
+/// heavy migrations) over multiple blocks (see <https://github.com/paritytech/substrate/issues/13690>).
+pub struct RemoveStorage<
+	P: Get<&'static str>,
+	S: Get<&'static str>,
+	DbWeight: Get<RuntimeDbWeight>,
+	Limit: Get<u32>,
+>(PhantomData<(P, S, DbWeight, Limit)>);
+impl<P: Get<&'static str>, S: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>, Limit: Get<u32>>
+	frame_support::traits::OnRuntimeUpgrade for RemoveStorage<P, S, DbWeight, Limit>
 {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		let hashed_prefix = storage_prefix(P::get().as_bytes(), S::get().as_bytes());
-		let keys_removed = match clear_prefix(&hashed_prefix, None) {
+		let keys_removed = match clear_prefix(&hashed_prefix, Some(Limit::get())) {
 			KillStorageResult::AllRemoved(value) => value,
 			KillStorageResult::SomeRemaining(value) => {
-				log::error!(
-					"`clear_prefix` failed to remove all keys for storage `{}` from pallet `{}`. THIS SHOULD NEVER HAPPEN! 🚨",
-					S::get(), P::get()
+				log::warn!(
+					"`RemoveStorage` hit its per-upgrade limit of {} keys for storage `{}` from pallet `{}`; \
+					 {} keys removed, more remain. Raise `Limit` (staying below the block weight limit) or use a \
+					 multi-block migration to remove the rest.",
+					Limit::get(),
+					S::get(),
+					P::get(),
+					value,
 				);
 				value
 			},
@@ -1196,5 +1212,81 @@ mod tests {
 			.unwrap()
 			.is_err());
 		});
+	}
+
+	crate::parameter_types! {
+		pub const RemovePalletTestName: &'static str = "SomePallet";
+		pub const RemoveStorageTestStorage: &'static str = "SomeStorage";
+	}
+
+	type TestDbWeight = crate::weights::constants::RocksDbWeight;
+
+	/// Insert `count` distinct keys under `prefix` so the deletion helpers have something to clear.
+	fn fill_prefix(prefix: &[u8], count: u32) {
+		for i in 0..count {
+			let mut key = prefix.to_vec();
+			key.extend_from_slice(&i.to_le_bytes());
+			unhashed::put(&key, &i);
+		}
+	}
+
+	#[test]
+	fn remove_pallet_is_bounded_by_limit() {
+		use crate::traits::OnRuntimeUpgrade;
+		use sp_core::ConstU32;
+
+		let prefix = twox_128(RemovePalletTestName::get().as_bytes());
+		let mut ext = sp_io::TestExternalities::default();
+		// Pre-fill more keys than the per-upgrade limit allows to be removed, and commit them to
+		// the backend (the `clear_prefix` limit only bounds committed keys).
+		ext.execute_with(|| fill_prefix(&prefix, 10));
+		ext.commit_all().unwrap();
+
+		ext.execute_with(|| {
+			// The migration removes at most `Limit` keys and leaves the rest, so its work is
+			// bounded regardless of how many keys the prefix holds.
+			RemovePallet::<RemovePalletTestName, TestDbWeight, ConstU32<4>>::on_runtime_upgrade();
+
+			assert_eq!(count_prefixed_keys(&prefix), 6, "only `Limit` keys should be removed");
+		});
+	}
+
+	#[test]
+	fn remove_storage_is_bounded_by_limit() {
+		use crate::traits::OnRuntimeUpgrade;
+		use sp_core::ConstU32;
+
+		let prefix = storage_prefix(
+			RemovePalletTestName::get().as_bytes(),
+			RemoveStorageTestStorage::get().as_bytes(),
+		);
+		let mut ext = sp_io::TestExternalities::default();
+		ext.execute_with(|| fill_prefix(&prefix, 10));
+		ext.commit_all().unwrap();
+
+		ext.execute_with(|| {
+			RemoveStorage::<
+				RemovePalletTestName,
+				RemoveStorageTestStorage,
+				TestDbWeight,
+				ConstU32<4>,
+			>::on_runtime_upgrade();
+
+			assert_eq!(count_prefixed_keys(&prefix), 6, "only `Limit` keys should be removed");
+		});
+	}
+
+	/// Count how many keys currently exist under `prefix`.
+	fn count_prefixed_keys(prefix: &[u8]) -> u32 {
+		let mut count = 0u32;
+		let mut previous = prefix.to_vec();
+		while let Some(next) = sp_io::storage::next_key(&previous) {
+			if !next.starts_with(prefix) {
+				break;
+			}
+			count += 1;
+			previous = next;
+		}
+		count
 	}
 }

--- a/frame/support/src/migrations.rs
+++ b/frame/support/src/migrations.rs
@@ -260,6 +260,26 @@ pub fn migrate_from_pallet_version_to_storage_version<
 	Pallets::migrate(db_weight)
 }
 
+/// Count keys under `prefix`, stopping once `up_to` keys have been seen.
+///
+/// Only used by try-runtime hooks; the cap keeps the check bounded for prefixes holding many more
+/// keys than the migration's per-upgrade limit.
+#[cfg(feature = "try-runtime")]
+fn count_prefixed_keys_up_to(prefix: &[u8], up_to: u32) -> u32 {
+	let mut count = 0u32;
+	let mut previous = prefix.to_vec();
+	while count < up_to {
+		match sp_io::storage::next_key(&previous) {
+			Some(next) if next.starts_with(prefix) => {
+				count += 1;
+				previous = next;
+			},
+			_ => break,
+		}
+	}
+	count
+}
+
 /// `RemovePallet` is a utility struct used to remove all storage items associated with a specific
 /// pallet.
 ///
@@ -343,30 +363,41 @@ impl<P: Get<&'static str>, DbWeight: Get<RuntimeDbWeight>, Limit: Get<u32>>
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
-		use crate::storage::unhashed::contains_prefixed_key;
+		use codec::Encode;
 
 		let hashed_prefix = twox_128(P::get().as_bytes());
-		match contains_prefixed_key(&hashed_prefix) {
+		let key_count = count_prefixed_keys_up_to(&hashed_prefix, Limit::get().saturating_add(1));
+		match key_count > 0 {
 			true => log::info!("Found {} keys pre-removal 👀", P::get()),
 			false => log::warn!(
 				"Migration RemovePallet<{}> can be removed (no keys found pre-removal).",
 				P::get()
 			),
 		};
-		Ok(alloc::vec::Vec::new())
+		// Whether more keys exist than the migration is allowed to remove in one upgrade.
+		Ok((key_count > Limit::get()).encode())
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(_state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+	fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 		use crate::storage::unhashed::contains_prefixed_key;
+		use codec::Decode;
 
+		let over_limit = bool::decode(&mut &state[..])
+			.map_err(|_| "RemovePallet post_upgrade failed to decode pre_upgrade state")?;
 		let hashed_prefix = twox_128(P::get().as_bytes());
-		match contains_prefixed_key(&hashed_prefix) {
-			true => {
+		match (contains_prefixed_key(&hashed_prefix), over_limit) {
+			(false, _) => log::info!("No {} keys found post-removal 🎉", P::get()),
+			(true, true) => log::warn!(
+				"{} has keys remaining post-removal because the prefix held more than the \
+				 per-upgrade limit of {} keys. Schedule further removals to clear the rest.",
+				P::get(),
+				Limit::get(),
+			),
+			(true, false) => {
 				log::error!("{} has keys remaining post-removal ❗", P::get());
 				return Err("Keys remaining post-removal, this should never happen 🚨".into())
 			},
-			false => log::info!("No {} keys found post-removal 🎉", P::get()),
 		};
 		Ok(())
 	}
@@ -464,10 +495,11 @@ impl<
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
-		use crate::storage::unhashed::contains_prefixed_key;
+		use codec::Encode;
 
 		let hashed_prefix = storage_prefix(P::get().as_bytes(), S::get().as_bytes());
-		match contains_prefixed_key(&hashed_prefix) {
+		let key_count = count_prefixed_keys_up_to(&hashed_prefix, Limit::get().saturating_add(1));
+		match key_count > 0 {
 			true => log::info!("Found `{}` `{}` keys pre-removal 👀", P::get(), S::get()),
 			false => log::warn!(
 				"Migration RemoveStorage<{}, {}> can be removed (no keys found pre-removal).",
@@ -475,20 +507,31 @@ impl<
 				S::get()
 			),
 		};
-		Ok(Default::default())
+		// Whether more keys exist than the migration is allowed to remove in one upgrade.
+		Ok((key_count > Limit::get()).encode())
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(_state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+	fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 		use crate::storage::unhashed::contains_prefixed_key;
+		use codec::Decode;
 
+		let over_limit = bool::decode(&mut &state[..])
+			.map_err(|_| "RemoveStorage post_upgrade failed to decode pre_upgrade state")?;
 		let hashed_prefix = storage_prefix(P::get().as_bytes(), S::get().as_bytes());
-		match contains_prefixed_key(&hashed_prefix) {
-			true => {
+		match (contains_prefixed_key(&hashed_prefix), over_limit) {
+			(false, _) => log::info!("No `{}` `{}` keys found post-removal 🎉", P::get(), S::get()),
+			(true, true) => log::warn!(
+				"`{}` `{}` has keys remaining post-removal because the prefix held more than the \
+				 per-upgrade limit of {} keys. Schedule further removals to clear the rest.",
+				P::get(),
+				S::get(),
+				Limit::get(),
+			),
+			(true, false) => {
 				log::error!("`{}` `{}` has keys remaining post-removal ❗", P::get(), S::get());
 				return Err("Keys remaining post-removal, this should never happen 🚨".into())
 			},
-			false => log::info!("No `{}` `{}` keys found post-removal 🎉", P::get(), S::get()),
 		};
 		Ok(())
 	}
@@ -1277,6 +1320,75 @@ mod tests {
 			>::on_runtime_upgrade();
 
 			assert_eq!(count_prefixed_keys(&prefix), 6, "only `Limit` keys should be removed");
+		});
+	}
+
+	/// The try-runtime checks must tolerate keys remaining when the prefix held more keys than
+	/// the per-upgrade `Limit`, since that is the documented (bounded) behaviour, while still
+	/// failing when keys remain unexpectedly.
+	#[test]
+	#[cfg(feature = "try-runtime")]
+	fn remove_pallet_try_runtime_tolerates_bounded_remainder() {
+		use crate::traits::OnRuntimeUpgrade;
+		use sp_core::ConstU32;
+
+		type UnderLimit = RemovePallet<RemovePalletTestName, TestDbWeight, ConstU32<20>>;
+		type OverLimit = RemovePallet<RemovePalletTestName, TestDbWeight, ConstU32<4>>;
+
+		let prefix = twox_128(RemovePalletTestName::get().as_bytes());
+
+		// More keys than `Limit`: keys legitimately remain, post_upgrade must accept.
+		let mut ext = sp_io::TestExternalities::default();
+		ext.execute_with(|| fill_prefix(&prefix, 10));
+		ext.commit_all().unwrap();
+		ext.execute_with(|| {
+			let state = OverLimit::pre_upgrade().unwrap();
+			OverLimit::on_runtime_upgrade();
+			assert_eq!(count_prefixed_keys(&prefix), 6);
+			assert!(OverLimit::post_upgrade(state).is_ok());
+		});
+
+		// Fewer keys than `Limit`: all keys must be gone, otherwise post_upgrade must fail.
+		let mut ext = sp_io::TestExternalities::default();
+		ext.execute_with(|| fill_prefix(&prefix, 10));
+		ext.commit_all().unwrap();
+		ext.execute_with(|| {
+			let state = UnderLimit::pre_upgrade().unwrap();
+			UnderLimit::on_runtime_upgrade();
+			assert_eq!(count_prefixed_keys(&prefix), 0);
+			assert!(UnderLimit::post_upgrade(state.clone()).is_ok());
+
+			// Keys remaining without the over-limit justification is still a fatal error.
+			fill_prefix(&prefix, 1);
+			assert!(UnderLimit::post_upgrade(state).is_err());
+		});
+	}
+
+	#[test]
+	#[cfg(feature = "try-runtime")]
+	fn remove_storage_try_runtime_tolerates_bounded_remainder() {
+		use crate::traits::OnRuntimeUpgrade;
+		use sp_core::ConstU32;
+
+		type OverLimit = RemoveStorage<
+			RemovePalletTestName,
+			RemoveStorageTestStorage,
+			TestDbWeight,
+			ConstU32<4>,
+		>;
+
+		let prefix = storage_prefix(
+			RemovePalletTestName::get().as_bytes(),
+			RemoveStorageTestStorage::get().as_bytes(),
+		);
+		let mut ext = sp_io::TestExternalities::default();
+		ext.execute_with(|| fill_prefix(&prefix, 10));
+		ext.commit_all().unwrap();
+		ext.execute_with(|| {
+			let state = OverLimit::pre_upgrade().unwrap();
+			OverLimit::on_runtime_upgrade();
+			assert_eq!(count_prefixed_keys(&prefix), 6);
+			assert!(OverLimit::post_upgrade(state).is_ok());
 		});
 	}
 

--- a/frame/support/src/migrations.rs
+++ b/frame/support/src/migrations.rs
@@ -262,9 +262,9 @@ pub fn migrate_from_pallet_version_to_storage_version<
 
 /// Count keys under `prefix`, stopping once `up_to` keys have been seen.
 ///
-/// Only used by try-runtime hooks; the cap keeps the check bounded for prefixes holding many more
-/// keys than the migration's per-upgrade limit.
-#[cfg(feature = "try-runtime")]
+/// Only used by try-runtime hooks and tests; the cap keeps the check bounded for prefixes holding
+/// many more keys than the migration's per-upgrade limit.
+#[cfg(any(feature = "try-runtime", test))]
 fn count_prefixed_keys_up_to(prefix: &[u8], up_to: u32) -> u32 {
 	let mut count = 0u32;
 	let mut previous = prefix.to_vec();
@@ -1394,15 +1394,6 @@ mod tests {
 
 	/// Count how many keys currently exist under `prefix`.
 	fn count_prefixed_keys(prefix: &[u8]) -> u32 {
-		let mut count = 0u32;
-		let mut previous = prefix.to_vec();
-		while let Some(next) = sp_io::storage::next_key(&previous) {
-			if !next.starts_with(prefix) {
-				break;
-			}
-			count += 1;
-			previous = next;
-		}
-		count
+		count_prefixed_keys_up_to(prefix, u32::MAX)
 	}
 }

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -441,8 +441,9 @@ pub fn move_prefix_bounded(
 	// so hand back a cursor so the caller can resume. The last moved key was drained, but
 	// `next_key` still returns the lexicographically next key regardless.
 	let last = iter.last_raw_key().to_vec();
-	let more_remain =
-		sp_io::storage::next_key(&last).map(|n| n.starts_with(from_prefix)).unwrap_or(false);
+	let more_remain = sp_io::storage::next_key(&last)
+		.map(|n| n.starts_with(from_prefix))
+		.unwrap_or(false);
 	MovePrefixResult { moved, maybe_cursor: more_remain.then_some(last) }
 }
 

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -309,6 +309,9 @@ pub fn take_storage_item<K: Encode + Sized, T: Decode + Sized, H: StorageHasher>
 /// `concat(twox_128(old_pallet_name), twox_128(storage_name))` and insert them at the key with
 /// the start replaced by `concat(twox_128(new_pallet_name), twox_128(storage_name))`.
 ///
+/// WARNING: This is an unbounded operation (see [`move_prefix`]). If the moved storage item can be
+/// grown by users, use [`move_prefix_bounded`] from within a multi-block migration instead.
+///
 /// # Example
 ///
 /// If a pallet named "my_example" has 2 storages named "Foo" and "Bar" and the pallet is renamed
@@ -360,35 +363,94 @@ pub fn move_pallet(old_pallet_name: &[u8], new_pallet_name: &[u8]) {
 	move_prefix(&Twox128::hash(old_pallet_name), &Twox128::hash(new_pallet_name))
 }
 
+/// Result of a bounded [`move_prefix_bounded`] call.
+pub struct MovePrefixResult {
+	/// The number of keys moved during this call.
+	pub moved: u32,
+	/// If `Some`, the move is incomplete and another call is required, passing this value back as
+	/// the next call's `maybe_cursor`. If `None`, all matching keys have been moved.
+	pub maybe_cursor: Option<Vec<u8>>,
+}
+
 /// Move all `(key, value)` after some prefix to the another prefix
 ///
 /// This function will remove all value for which the key start with `from_prefix`
 /// and insert them at the key with the start replaced by `to_prefix`.
 ///
 /// NOTE: The value at the key `from_prefix` is not moved.
+///
+/// WARNING: This is an unbounded operation: it reads, deletes, and writes every key below
+/// `from_prefix` in a single call. If the prefix can be grown by users, calling this in a
+/// (mandatory) runtime-upgrade hook lets an attacker inflate the prefix beforehand and force the
+/// first post-upgrade block to perform unbounded work. For such prefixes, use
+/// [`move_prefix_bounded`] to move keys in bounded chunks from within a multi-block migration.
 pub fn move_prefix(from_prefix: &[u8], to_prefix: &[u8]) {
+	// Drive the bounded mover to completion in one shot. `u32::MAX` keys is effectively no bound,
+	// preserving the historical all-at-once behaviour for callers that know the prefix is small.
+	move_prefix_bounded(from_prefix, to_prefix, u32::MAX, None);
+}
+
+/// Move at most `limit` `(key, value)` pairs from `from_prefix` to `to_prefix`, resuming from
+/// `maybe_cursor`.
+///
+/// This is the bounded counterpart to [`move_prefix`]: it moves up to `limit` keys per call and
+/// returns a [`MovePrefixResult`] carrying how many keys were moved and, when the move is not yet
+/// complete, a cursor to pass to the next call. This lets a multi-block migration spread the work
+/// (and charge weight proportional to `moved`) instead of doing an unbounded move in a single
+/// mandatory upgrade hook.
+///
+/// ## Cursors
+///
+/// Pass `None` as `maybe_cursor` for the first call. If the returned `maybe_cursor` is `Some`,
+/// another call is required to continue; pass that value back in. A returned `maybe_cursor` of
+/// `None` means the move is complete.
+///
+/// NOTE: The value at the key `from_prefix` is not moved.
+pub fn move_prefix_bounded(
+	from_prefix: &[u8],
+	to_prefix: &[u8],
+	limit: u32,
+	maybe_cursor: Option<&[u8]>,
+) -> MovePrefixResult {
 	if from_prefix == to_prefix {
-		return
+		return MovePrefixResult { moved: 0, maybe_cursor: None }
 	}
 
-	let iter = PrefixIterator::<_> {
-		prefix: from_prefix.to_vec(),
-		previous_key: from_prefix.to_vec(),
-		drain: true,
-		closure: |key, value| Ok((key.to_vec(), value.to_vec())),
-		phantom: Default::default(),
-	};
+	let previous_key = maybe_cursor.map(|c| c.to_vec()).unwrap_or_else(|| from_prefix.to_vec());
+	let mut iter = PrefixIterator::<(Vec<u8>, Vec<u8>)>::new(
+		from_prefix.to_vec(),
+		previous_key,
+		|key, value| Ok((key.to_vec(), value.to_vec())),
+	)
+	.drain();
 
-	for (key, value) in iter {
-		let full_key = [to_prefix, &key].concat();
-		unhashed::put_raw(&full_key, &value);
+	let mut moved = 0u32;
+	while moved < limit {
+		match iter.next() {
+			Some((key, value)) => {
+				let full_key = [to_prefix, &key].concat();
+				unhashed::put_raw(&full_key, &value);
+				moved += 1;
+			},
+			// Ran out of matching keys before hitting the limit: the move is complete.
+			None => return MovePrefixResult { moved, maybe_cursor: None },
+		}
 	}
+
+	// Hit the limit. Peek past the last moved key to see whether any matching keys remain, and if
+	// so hand back a cursor so the caller can resume. The last moved key was drained, but
+	// `next_key` still returns the lexicographically next key regardless.
+	let last = iter.last_raw_key().to_vec();
+	let more_remain =
+		sp_io::storage::next_key(&last).map(|n| n.starts_with(from_prefix)).unwrap_or(false);
+	MovePrefixResult { moved, maybe_cursor: more_remain.then_some(last) }
 }
 
 #[cfg(test)]
 mod tests {
 	use super::{
-		move_pallet, move_prefix, move_storage_from_pallet, storage_iter, storage_key_iter,
+		move_pallet, move_prefix, move_prefix_bounded, move_storage_from_pallet, storage_iter,
+		storage_key_iter,
 	};
 	use crate::{
 		hash::StorageHasher,
@@ -445,6 +507,48 @@ mod tests {
 			assert_eq!(OldStorageMap::iter().collect::<Vec<_>>(), vec![]);
 			assert_eq!(NewStorageValue::get(), Some(3));
 			assert_eq!(NewStorageMap::iter().collect::<Vec<_>>(), vec![(1, 2), (3, 4)]);
+		})
+	}
+
+	#[test]
+	fn test_move_prefix_bounded_moves_in_chunks() {
+		TestExternalities::new_empty().execute_with(|| {
+			// Fill the old map with more entries than a single chunk can hold.
+			for i in 0..10u32 {
+				OldStorageMap::insert(i, i * 10);
+			}
+
+			let from = Twox128::hash(b"my_old_pallet");
+			let to = Twox128::hash(b"my_new_pallet");
+
+			// Move in bounded chunks of 4, following the returned cursor to completion.
+			let mut cursor: Option<Vec<u8>> = None;
+			let mut total_moved = 0u32;
+			let mut calls = 0u32;
+			loop {
+				let res = move_prefix_bounded(&from, &to, 4, cursor.as_deref());
+				assert!(res.moved <= 4, "a chunk must never exceed the limit");
+				total_moved += res.moved;
+				calls += 1;
+				assert!(calls < 100, "cursor must make progress and terminate");
+				match res.maybe_cursor {
+					Some(c) => cursor = Some(c),
+					None => break,
+				}
+			}
+
+			// Chunking actually happened (10 keys / 4 per chunk => multiple calls).
+			assert!(calls > 1, "the move should have been split across multiple bounded calls");
+			assert_eq!(total_moved, 10, "every key is moved exactly once across chunks");
+
+			// Old prefix fully drained.
+			assert_eq!(OldStorageMap::iter().count(), 0);
+
+			// New prefix has all entries (Twox64Concat is not key-ordered, so sort before compare).
+			let mut got = NewStorageMap::iter().collect::<Vec<_>>();
+			got.sort();
+			let expected = (0..10u32).map(|i| (i, i * 10)).collect::<Vec<_>>();
+			assert_eq!(got, expected);
 		})
 	}
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -505,7 +505,7 @@ pub trait DefensiveMin<T> {
 	/// When the assumption is violated, the other value is returned and a defensive
 	/// error is logged. With `debug_assertions` enabled, this also panics.
 	///
-	/// ```should_panic
+	/// ```no_run
 	/// use frame_support::traits::DefensiveMin;
 	/// assert_eq!(3, 4_u32.defensive_min(3_u32));
 	/// ```
@@ -524,7 +524,7 @@ pub trait DefensiveMin<T> {
 	/// When the assumption is violated, the other value is returned and a defensive
 	/// error is logged. With `debug_assertions` enabled, this also panics.
 	///
-	/// ```should_panic
+	/// ```no_run
 	/// use frame_support::traits::DefensiveMin;
 	/// assert_eq!(4, 4_u32.defensive_strict_min(4_u32));
 	/// ```
@@ -573,7 +573,7 @@ pub trait DefensiveMax<T> {
 	/// When the assumption is violated, the other value is returned and a defensive
 	/// error is logged. With `debug_assertions` enabled, this also panics.
 	///
-	/// ```should_panic
+	/// ```no_run
 	/// use frame_support::traits::DefensiveMax;
 	/// assert_eq!(5, 4_u32.defensive_max(5_u32));
 	/// ```
@@ -592,7 +592,7 @@ pub trait DefensiveMax<T> {
 	/// When the assumption is violated, the other value is returned and a defensive
 	/// error is logged. With `debug_assertions` enabled, this also panics.
 	///
-	/// ```should_panic
+	/// ```no_run
 	/// use frame_support::traits::DefensiveMax;
 	/// assert_eq!(4, 4_u32.defensive_strict_max(4_u32));
 	/// ```

--- a/frame/support/src/traits/reality.rs
+++ b/frame/support/src/traits/reality.rs
@@ -19,7 +19,7 @@
 
 use core::marker::PhantomData;
 
-use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
+use codec::{Decode, DecodeAll, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use frame_support::{CloneNoBound, EqNoBound, Parameter, PartialEqNoBound};
 use scale_info::TypeInfo;
 use sp_core::ConstU32;
@@ -306,7 +306,10 @@ impl<Params: Encode, RuntimeCall: Decode> Callback<Params, RuntimeCall> {
 		Self { pallet_index, call_index, phantom: PhantomData }
 	}
 	pub fn curry(&self, args: Params) -> Result<RuntimeCall, codec::Error> {
-		(self.pallet_index, self.call_index, args).using_encoded(|mut d| Decode::decode(&mut d))
+		// `decode_all` ensures the resulting call consumes the whole of `args`: a prefix decode
+		// would silently bind the callback to a call with a different signature than documented.
+		(self.pallet_index, self.call_index, args)
+			.using_encoded(|mut d| DecodeAll::decode_all(&mut d))
 	}
 }
 
@@ -344,5 +347,39 @@ impl<C> StatementOracle<C> for () {
 		_: Callback<(Self::Ticket, JudgementContext, Judgement), C>,
 	) -> Result<(), DispatchError> {
 		Err(DispatchError::Unavailable)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[derive(Encode, Decode, PartialEq, Eq, Debug)]
+	enum TestRuntimeCall {
+		#[codec(index = 7)]
+		Oracle(OracleCall),
+	}
+
+	#[derive(Encode, Decode, PartialEq, Eq, Debug)]
+	enum OracleCall {
+		#[codec(index = 3)]
+		OnJudgement { ticket: u32, judgement: u16 },
+	}
+
+	#[test]
+	fn curry_decodes_matching_signature() {
+		let callback = Callback::<(u32, u16), TestRuntimeCall>::from_parts(7, 3);
+		assert_eq!(
+			callback.curry((42, 5)),
+			Ok(TestRuntimeCall::Oracle(OracleCall::OnJudgement { ticket: 42, judgement: 5 })),
+		);
+	}
+
+	#[test]
+	fn curry_rejects_prefix_compatible_signature_mismatch() {
+		// The target call consumes only (u32, u16); the extra trailing u64 must make the curry
+		// fail rather than be silently ignored by a prefix decode.
+		let callback = Callback::<(u32, u16, u64), TestRuntimeCall>::from_parts(7, 3);
+		assert!(callback.curry((42, 5, 99)).is_err());
 	}
 }

--- a/frame/support/src/traits/tokens/fungible/freeze.rs
+++ b/frame/support/src/traits/tokens/fungible/freeze.rs
@@ -93,8 +93,8 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 	/// Attempt to set the amount frozen under the given `id` to `amount`, iff this would increase
 	/// the amount frozen under `id`. Do nothing otherwise.
 	///
-	/// Fail if the account of `who` has fewer freezable funds than `amount`, unless `fortitude` is
-	/// [`Fortitude::Force`].
+	/// Fail if this would increase the amount frozen under `id` and the account of `who` has
+	/// fewer freezable funds than `amount`, unless `fortitude` is [`Fortitude::Force`].
 	fn ensure_frozen(
 		id: &Self::Id,
 		who: &AccountId,
@@ -102,7 +102,15 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 		fortitude: Fortitude,
 	) -> DispatchResult {
 		let force = fortitude == Fortitude::Force;
-		ensure!(force || Self::balance_freezable(who) >= amount, TokenError::FundsUnavailable);
+		// Only require freezable funds if this call would actually increase the amount frozen
+		// under `id`; otherwise `extend_freeze` is a no-op and must remain idempotent even when
+		// an existing (permitted) over-freeze exceeds the current freezable balance.
+		ensure!(
+			force ||
+				amount <= Self::balance_frozen(id, who) ||
+				Self::balance_freezable(who) >= amount,
+			TokenError::FundsUnavailable
+		);
 		Self::extend_freeze(id, who, amount)
 	}
 

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -324,18 +324,20 @@ where
 		amount: Self::Balance,
 		preservation: Preservation,
 	) -> Result<Self::Balance, DispatchError> {
-		let _extra = Self::can_withdraw(source, amount).into_result(preservation != Expendable)?;
-		Self::can_deposit(dest, amount, Extant).into_result()?;
+		let dust = Self::can_withdraw(source, amount).into_result(preservation != Expendable)?;
+		let actual = amount.saturating_add(dust);
+		Self::can_deposit(dest, actual, Extant).into_result()?;
 		if source == dest {
-			return Ok(amount)
+			return Ok(actual)
 		}
 
-		Self::decrease_balance(source, amount, BestEffort, preservation, Polite)?;
-		// This should never fail as we checked `can_deposit` earlier. But we do a best-effort
-		// anyway.
-		let _ = Self::increase_balance(dest, amount, BestEffort);
-		Self::done_transfer(source, dest, amount);
-		Ok(amount)
+		let debited = Self::decrease_balance(source, amount, BestEffort, preservation, Polite)?;
+		// Credit the amount actually removed from the source. When an expendable transfer reaps
+		// the source, `debited` can exceed `amount`; ignoring it desynchronizes issuance from
+		// account balances.
+		let _ = Self::increase_balance(dest, debited, BestEffort);
+		Self::done_transfer(source, dest, debited);
+		Ok(debited)
 	}
 
 	/// Simple infallible function to force an account to have a particular balance, good for use

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -475,8 +475,7 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 			},
 			// Best-effort: cap the deposit to the remaining issuance headroom.
 			BestEffort => {
-				let headroom =
-					Self::Balance::max_value().saturating_sub(Self::total_issuance());
+				let headroom = Self::Balance::max_value().saturating_sub(Self::total_issuance());
 				value.min(headroom)
 			},
 		};

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -328,7 +328,9 @@ where
 		let actual = amount.saturating_add(dust);
 		Self::can_deposit(dest, actual, Extant).into_result()?;
 		if source == dest {
-			return Ok(actual)
+			// Nothing is debited and no reap occurs on the self path, so the reported amount must
+			// not include the hypothetical dust.
+			return Ok(amount)
 		}
 
 		let debited = Self::decrease_balance(source, amount, BestEffort, preservation, Polite)?;

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -467,6 +467,11 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 		// credited amount using *saturating* arithmetic, so without this check a deposit made when
 		// issuance is near the maximum could credit the account by more than issuance can grow,
 		// breaking the `sum(balances) == total_issuance` invariant. Mirrors `Mutate::mint_into`.
+		//
+		// NOTE: this is a best-effort guard, not a hard invariant. Issuance only grows when the
+		// returned `Debt` is dropped, so concurrent deposits whose debts are still alive can each
+		// pass this check individually yet jointly exceed the remaining headroom and saturate on
+		// drop. Fully preventing that would require reserving headroom at deposit time.
 		let value = match precision {
 			// Must credit exactly `value`, so issuance must be able to grow by exactly `value`.
 			Exact => {

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -37,7 +37,7 @@ use crate::{
 	},
 };
 use core::marker::PhantomData;
-use sp_arithmetic::traits::{CheckedAdd, CheckedSub, One};
+use sp_arithmetic::traits::{Bounded, CheckedAdd, CheckedSub, One};
 use sp_runtime::{traits::Saturating, ArithmeticError, DispatchError, TokenError};
 
 use super::{Credit, Debt, HandleImbalanceDrop, Imbalance};
@@ -460,6 +460,24 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 		value: Self::Balance,
 		precision: Precision,
 	) -> Result<Debt<AccountId, Self>, DispatchError> {
+		// Ensure the credited amount can be represented by total issuance *before* mutating the
+		// account. The returned `Debt` grows total issuance (via its `OnDropDebt` handler) by the
+		// credited amount using *saturating* arithmetic, so without this check a deposit made when
+		// issuance is near the maximum could credit the account by more than issuance can grow,
+		// breaking the `sum(balances) == total_issuance` invariant. Mirrors `Mutate::mint_into`.
+		let value = match precision {
+			// Must credit exactly `value`, so issuance must be able to grow by exactly `value`.
+			Exact => {
+				Self::total_issuance().checked_add(&value).ok_or(ArithmeticError::Overflow)?;
+				value
+			},
+			// Best-effort: cap the deposit to the remaining issuance headroom.
+			BestEffort => {
+				let headroom =
+					Self::Balance::max_value().saturating_sub(Self::total_issuance());
+				value.min(headroom)
+			},
+		};
 		let increase = Self::increase_balance(who, value, precision)?;
 		Self::done_deposit(who, increase);
 		Ok(Imbalance::<Self::Balance, Self::OnDropDebt, Self::OnDropCredit>::new(increase))

--- a/frame/support/src/traits/tokens/fungibles/freeze.rs
+++ b/frame/support/src/traits/tokens/fungibles/freeze.rs
@@ -105,8 +105,8 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 	/// Attempt to set the amount frozen under the given `id` to `amount`, iff this would increase
 	/// the amount frozen under `id`. Do nothing otherwise.
 	///
-	/// Fail if the account of `who` has fewer freezable funds than `amount`, unless `fortitude` is
-	/// `Fortitude::Force`.
+	/// Fail if this would increase the amount frozen under `id` and the account of `who` has
+	/// fewer freezable funds than `amount`, unless `fortitude` is `Fortitude::Force`.
 	fn ensure_frozen(
 		asset: Self::AssetId,
 		id: &Self::Id,
@@ -115,8 +115,13 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 		fortitude: Fortitude,
 	) -> DispatchResult {
 		let force = fortitude == Fortitude::Force;
+		// Only require freezable funds if this call would actually increase the amount frozen
+		// under `id`; otherwise `extend_freeze` is a no-op and must remain idempotent even when
+		// an existing (permitted) over-freeze exceeds the current freezable balance.
 		ensure!(
-			force || Self::balance_freezable(asset.clone(), who) >= amount,
+			force ||
+				amount <= Self::balance_frozen(asset.clone(), id, who) ||
+				Self::balance_freezable(asset.clone(), who) >= amount,
 			TokenError::FundsUnavailable
 		);
 		Self::extend_freeze(asset, id, who, amount)
@@ -133,7 +138,10 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 		let a = Self::balance_frozen(asset.clone(), id, who)
 			.checked_sub(&amount)
 			.ok_or(ArithmeticError::Underflow)?;
-		Self::set_frozen(asset, id, who, a, Fortitude::Polite)
+		// Reducing a freeze never increases exposure, so use the unchecked primitive: routing
+		// through `set_frozen(.., Polite)` would wrongly fail partial releases of a freeze that
+		// (legitimately) exceeds the current freezable balance.
+		Self::set_freeze(asset, id, who, a)
 	}
 
 	/// Increase the amount which is being frozen for a particular lock, failing in the case that
@@ -148,5 +156,124 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 			.checked_add(&amount)
 			.ok_or(ArithmeticError::Overflow)?;
 		Self::set_frozen(asset, id, who, a, Fortitude::Polite)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::traits::tokens::{
+		DepositConsequence, Preservation, Provenance, WithdrawConsequence,
+	};
+	use core::cell::RefCell;
+
+	thread_local! {
+		static BALANCE: RefCell<u64> = RefCell::new(0);
+		static FROZEN: RefCell<u64> = RefCell::new(0);
+	}
+
+	/// Minimal single-account, single-freeze-id asset that implements only the required
+	/// primitives, so the trait's default method bodies are what gets exercised.
+	struct TestAsset;
+
+	impl super::super::Inspect<u64> for TestAsset {
+		type AssetId = u32;
+		type Balance = u64;
+		fn total_issuance(_: u32) -> u64 {
+			BALANCE.with(|b| *b.borrow())
+		}
+		fn minimum_balance(_: u32) -> u64 {
+			1
+		}
+		fn total_balance(_: u32, _: &u64) -> u64 {
+			BALANCE.with(|b| *b.borrow())
+		}
+		fn balance(_: u32, _: &u64) -> u64 {
+			BALANCE.with(|b| *b.borrow())
+		}
+		fn reducible_balance(_: u32, _: &u64, _: Preservation, _: Fortitude) -> u64 {
+			BALANCE.with(|b| *b.borrow())
+		}
+		fn can_deposit(_: u32, _: &u64, _: u64, _: Provenance) -> DepositConsequence {
+			DepositConsequence::Success
+		}
+		fn can_withdraw(_: u32, _: &u64, _: u64) -> WithdrawConsequence<u64> {
+			WithdrawConsequence::Success
+		}
+		fn asset_exists(_: u32) -> bool {
+			true
+		}
+	}
+
+	impl Inspect<u64> for TestAsset {
+		type Id = ();
+		fn balance_frozen(_: u32, _: &(), _: &u64) -> u64 {
+			FROZEN.with(|f| *f.borrow())
+		}
+		fn can_freeze(_: u32, _: &(), _: &u64) -> bool {
+			true
+		}
+	}
+
+	impl Mutate<u64> for TestAsset {
+		fn set_freeze(_: u32, _: &(), _: &u64, amount: u64) -> DispatchResult {
+			FROZEN.with(|f| *f.borrow_mut() = amount);
+			Ok(())
+		}
+		fn extend_freeze(_: u32, _: &(), _: &u64, amount: u64) -> DispatchResult {
+			FROZEN.with(|f| {
+				let mut f = f.borrow_mut();
+				*f = (*f).max(amount);
+			});
+			Ok(())
+		}
+		fn thaw(_: u32, _: &(), _: &u64) -> DispatchResult {
+			FROZEN.with(|f| *f.borrow_mut() = 0);
+			Ok(())
+		}
+	}
+
+	fn setup(balance: u64, frozen: u64) {
+		BALANCE.with(|b| *b.borrow_mut() = balance);
+		FROZEN.with(|f| *f.borrow_mut() = frozen);
+	}
+
+	#[test]
+	fn ensure_frozen_is_idempotent_for_existing_over_freeze() {
+		// A freeze above the freezable balance is an explicitly permitted state. Re-ensuring at
+		// or below the existing freeze does not increase exposure, so it must not fail even
+		// though the requested amount exceeds the freezable balance.
+		setup(100, 200);
+		assert_eq!(TestAsset::ensure_frozen(0, &(), &1, 150, Fortitude::Polite), Ok(()));
+		assert_eq!(TestAsset::balance_frozen(0, &(), &1), 200);
+
+		// An actual increase beyond the freezable balance still requires `Force`.
+		assert_eq!(
+			TestAsset::ensure_frozen(0, &(), &1, 300, Fortitude::Polite),
+			Err(TokenError::FundsUnavailable.into())
+		);
+		assert_eq!(TestAsset::ensure_frozen(0, &(), &1, 300, Fortitude::Force), Ok(()));
+		assert_eq!(TestAsset::balance_frozen(0, &(), &1), 300);
+
+		// A plain increase within the freezable balance also still works.
+		setup(100, 20);
+		assert_eq!(TestAsset::ensure_frozen(0, &(), &1, 80, Fortitude::Polite), Ok(()));
+		assert_eq!(TestAsset::balance_frozen(0, &(), &1), 80);
+	}
+
+	#[test]
+	fn decrease_frozen_works_when_freeze_exceeds_freezable_balance() {
+		// Partially releasing an over-freeze reduces exposure and must succeed even while the
+		// remaining target is still above the freezable balance.
+		setup(100, 200);
+		assert_eq!(TestAsset::decrease_frozen(0, &(), &1, 50), Ok(()));
+		assert_eq!(TestAsset::balance_frozen(0, &(), &1), 150);
+
+		// Underflow is still rejected.
+		assert_eq!(
+			TestAsset::decrease_frozen(0, &(), &1, 151),
+			Err(ArithmeticError::Underflow.into())
+		);
+		assert_eq!(TestAsset::balance_frozen(0, &(), &1), 150);
 	}
 }

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -370,19 +370,22 @@ where
 		amount: Self::Balance,
 		preservation: Preservation,
 	) -> Result<Self::Balance, DispatchError> {
-		let _extra = Self::can_withdraw(asset.clone(), source, amount)
+		let dust = Self::can_withdraw(asset.clone(), source, amount)
 			.into_result(preservation != Expendable)?;
-		Self::can_deposit(asset.clone(), dest, amount, Extant).into_result()?;
+		let actual = amount.saturating_add(dust);
+		Self::can_deposit(asset.clone(), dest, actual, Extant).into_result()?;
 		if source == dest {
-			return Ok(amount)
+			return Ok(actual)
 		}
 
-		Self::decrease_balance(asset.clone(), source, amount, BestEffort, preservation, Polite)?;
-		// This should never fail as we checked `can_deposit` earlier. But we do a best-effort
-		// anyway.
-		let _ = Self::increase_balance(asset.clone(), dest, amount, BestEffort);
-		Self::done_transfer(asset, source, dest, amount);
-		Ok(amount)
+		let debited =
+			Self::decrease_balance(asset.clone(), source, amount, BestEffort, preservation, Polite)?;
+		// Credit the amount actually removed from the source. When an expendable transfer reaps
+		// the source, `debited` can exceed `amount`; ignoring it desynchronizes issuance from
+		// account balances.
+		let _ = Self::increase_balance(asset.clone(), dest, debited, BestEffort);
+		Self::done_transfer(asset, source, dest, debited);
+		Ok(debited)
 	}
 
 	/// Simple infallible function to force an account to have a particular balance, good for use

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -550,8 +550,8 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 			},
 			// Best-effort: cap the deposit to the remaining issuance headroom.
 			BestEffort => {
-				let headroom = Self::Balance::max_value()
-					.saturating_sub(Self::total_issuance(asset.clone()));
+				let headroom =
+					Self::Balance::max_value().saturating_sub(Self::total_issuance(asset.clone()));
 				value.min(headroom)
 			},
 		};

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -375,7 +375,9 @@ where
 		let actual = amount.saturating_add(dust);
 		Self::can_deposit(asset.clone(), dest, actual, Extant).into_result()?;
 		if source == dest {
-			return Ok(actual)
+			// Nothing is debited and no reap occurs on the self path, so the reported amount must
+			// not include the hypothetical dust.
+			return Ok(amount)
 		}
 
 		let debited = Self::decrease_balance(

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -38,7 +38,7 @@ use crate::{
 		SameOrOther, TryDrop,
 	},
 };
-use sp_arithmetic::traits::{CheckedAdd, CheckedSub, One};
+use sp_arithmetic::traits::{Bounded, CheckedAdd, CheckedSub, One};
 use sp_runtime::{traits::Saturating, ArithmeticError, DispatchError, TokenError};
 
 use super::{Credit, Debt, HandleImbalanceDrop, Imbalance};
@@ -527,6 +527,27 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 		value: Self::Balance,
 		precision: Precision,
 	) -> Result<Debt<AccountId, Self>, DispatchError> {
+		// Ensure the credited amount can be represented by total issuance *before* mutating the
+		// account. The returned `Debt` grows total issuance (via its `OnDropDebt` handler) by the
+		// credited amount using *saturating* arithmetic, so without this check a deposit made when
+		// issuance is near the maximum could credit the account by more than issuance can grow,
+		// breaking the `sum(balances) == total_issuance` invariant. Mirrors `Mutate::mint_into`
+		// and the single-asset `fungible::Balanced::deposit`.
+		let value = match precision {
+			// Must credit exactly `value`, so issuance must be able to grow by exactly `value`.
+			Exact => {
+				Self::total_issuance(asset.clone())
+					.checked_add(&value)
+					.ok_or(ArithmeticError::Overflow)?;
+				value
+			},
+			// Best-effort: cap the deposit to the remaining issuance headroom.
+			BestEffort => {
+				let headroom = Self::Balance::max_value()
+					.saturating_sub(Self::total_issuance(asset.clone()));
+				value.min(headroom)
+			},
+		};
 		let increase = Self::increase_balance(asset.clone(), who, value, precision)?;
 		Self::done_deposit(asset.clone(), who, increase);
 		Ok(Imbalance::<Self::AssetId, Self::Balance, Self::OnDropDebt, Self::OnDropCredit>::new(

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -533,6 +533,11 @@ pub trait Balanced<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 		// issuance is near the maximum could credit the account by more than issuance can grow,
 		// breaking the `sum(balances) == total_issuance` invariant. Mirrors `Mutate::mint_into`
 		// and the single-asset `fungible::Balanced::deposit`.
+		//
+		// NOTE: this is a best-effort guard, not a hard invariant. Issuance only grows when the
+		// returned `Debt` is dropped, so concurrent deposits whose debts are still alive can each
+		// pass this check individually yet jointly exceed the remaining headroom and saturate on
+		// drop. Fully preventing that would require reserving headroom at deposit time.
 		let value = match precision {
 			// Must credit exactly `value`, so issuance must be able to grow by exactly `value`.
 			Exact => {

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -378,8 +378,14 @@ where
 			return Ok(actual)
 		}
 
-		let debited =
-			Self::decrease_balance(asset.clone(), source, amount, BestEffort, preservation, Polite)?;
+		let debited = Self::decrease_balance(
+			asset.clone(),
+			source,
+			amount,
+			BestEffort,
+			preservation,
+			Polite,
+		)?;
 		// Credit the amount actually removed from the source. When an expendable transfer reaps
 		// the source, `debited` can exceed `amount`; ignoring it desynchronizes issuance from
 		// account balances.

--- a/frame/support/src/traits/tokens/imbalance.rs
+++ b/frame/support/src/traits/tokens/imbalance.rs
@@ -79,13 +79,23 @@ pub trait Imbalance<Balance>: Sized + TryDrop + Default + TryMerge {
 	/// Consume `self` and return two independent instances; the amounts returned will be in
 	/// approximately the same ratio as `first`:`second`.
 	///
-	/// NOTE: This requires up to `first + second` room for a multiply, and `first + second` should
-	/// fit into a `u32`. Overflow will safely saturate in both cases.
+	/// NOTE: This requires up to `first + second` room for a multiply. If `first + second`
+	/// overflows a `u32`, both are halved, which preserves the ratio up to rounding. The multiply
+	/// will safely saturate on overflow.
 	fn ration(self, first: u32, second: u32) -> (Self, Self)
 	where
 		Balance: From<u32> + Saturating + Div<Output = Balance>,
 	{
-		let total: u32 = first.saturating_add(second);
+		// If `first + second` would overflow, halve both: this keeps the ratio (up to rounding)
+		// while keeping the denominator exact. Saturating the denominator to `u32::MAX` instead
+		// would distort the split, e.g. `MAX:MAX` would send (almost) the whole imbalance to the
+		// first leg rather than half of it.
+		let (first, second) = if first.checked_add(second).is_none() {
+			(first >> 1, second >> 1)
+		} else {
+			(first, second)
+		};
+		let total = first + second;
 		if total == 0 {
 			return (Self::zero(), Self::zero())
 		}
@@ -248,5 +258,116 @@ impl<Balance: Default> Imbalance<Balance> for () {
 impl TryMerge for () {
 	fn try_merge(self, _: Self) -> Result<Self, (Self, Self)> {
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use core::cell::RefCell;
+
+	/// Minimal imbalance over `u64` so the trait's default method bodies are what gets
+	/// exercised.
+	#[derive(Default, Debug, PartialEq, Eq)]
+	struct TestImbalance(u64);
+
+	impl TryDrop for TestImbalance {
+		fn try_drop(self) -> Result<(), Self> {
+			if self.0 == 0 {
+				Ok(())
+			} else {
+				Err(self)
+			}
+		}
+	}
+
+	impl TryMerge for TestImbalance {
+		fn try_merge(self, other: Self) -> Result<Self, (Self, Self)> {
+			Ok(Self(self.0 + other.0))
+		}
+	}
+
+	impl Imbalance<u64> for TestImbalance {
+		type Opposite = TestImbalance;
+		fn zero() -> Self {
+			Self(0)
+		}
+		fn drop_zero(self) -> Result<(), Self> {
+			self.try_drop()
+		}
+		fn split(self, amount: u64) -> (Self, Self) {
+			let first = self.0.min(amount);
+			(Self(first), Self(self.0 - first))
+		}
+		fn extract(&mut self, amount: u64) -> Self {
+			let extracted = self.0.min(amount);
+			self.0 -= extracted;
+			Self(extracted)
+		}
+		fn merge(self, other: Self) -> Self {
+			Self(self.0 + other.0)
+		}
+		fn subsume(&mut self, other: Self) {
+			self.0 += other.0
+		}
+		fn offset(self, other: Self::Opposite) -> SameOrOther<Self, Self::Opposite> {
+			if self.0 >= other.0 {
+				SameOrOther::Same(Self(self.0 - other.0))
+			} else {
+				SameOrOther::Other(Self(other.0 - self.0))
+			}
+		}
+		fn peek(&self) -> u64 {
+			self.0
+		}
+	}
+
+	#[test]
+	fn ration_splits_proportionally() {
+		let (a, b) = TestImbalance(600).ration(1, 2);
+		assert_eq!((a.peek(), b.peek()), (200, 400));
+
+		let (a, b) = TestImbalance(600).ration(0, 0);
+		assert_eq!((a.peek(), b.peek()), (0, 0));
+	}
+
+	#[test]
+	fn ration_keeps_ratio_when_sum_overflows() {
+		// `MAX:MAX` must behave as `1:1`. A denominator saturated to `u32::MAX` would instead
+		// compute `peek * MAX / MAX` and send the whole imbalance to the first leg.
+		let (a, b) = TestImbalance(1000).ration(u32::MAX, u32::MAX);
+		assert_eq!((a.peek(), b.peek()), (500, 500));
+
+		// Heavily skewed overflowing ratios keep their skew.
+		let (a, b) = TestImbalance(1000).ration(1, u32::MAX);
+		assert_eq!((a.peek(), b.peek()), (0, 1000));
+		let (a, b) = TestImbalance(1000).ration(u32::MAX, 1);
+		assert_eq!((a.peek(), b.peek()), (1000, 0));
+	}
+
+	thread_local! {
+		static SPLIT_SINK: RefCell<(u64, u64)> = RefCell::new((0, 0));
+	}
+
+	struct Sink1;
+	impl OnUnbalanced<TestImbalance> for Sink1 {
+		fn on_nonzero_unbalanced(amount: TestImbalance) {
+			SPLIT_SINK.with(|s| s.borrow_mut().0 += amount.peek());
+		}
+	}
+	struct Sink2;
+	impl OnUnbalanced<TestImbalance> for Sink2 {
+		fn on_nonzero_unbalanced(amount: TestImbalance) {
+			SPLIT_SINK.with(|s| s.borrow_mut().1 += amount.peek());
+		}
+	}
+
+	#[test]
+	fn split_two_ways_splits_by_configured_parts() {
+		SPLIT_SINK.with(|s| *s.borrow_mut() = (0, 0));
+		<SplitTwoWays<u64, TestImbalance, Sink1, Sink2, 3, 1> as OnUnbalanced<_>>::on_unbalanced(
+			TestImbalance(100),
+		);
+		assert_eq!(SPLIT_SINK.with(|s| *s.borrow()), (75, 25));
 	}
 }

--- a/frame/support/src/traits/tokens/imbalance/split_two_ways.rs
+++ b/frame/support/src/traits/tokens/imbalance/split_two_ways.rs
@@ -26,6 +26,18 @@ pub struct SplitTwoWays<Balance, Imbalance, Target1, Target2, const PART1: u32, 
 	PhantomData<(Balance, Imbalance, Target1, Target2)>,
 );
 
+impl<Balance, I, Target1, Target2, const PART1: u32, const PART2: u32>
+	SplitTwoWays<Balance, I, Target1, Target2, PART1, PART2>
+{
+	/// Evaluated at compile time for each instantiation that handles an imbalance: a ratio whose
+	/// sum is zero or overflows `u32` is a configuration bug that would otherwise panic
+	/// (divide-by-zero or add overflow) at runtime while disposing of a nonzero imbalance.
+	const TOTAL: u32 = match PART1.checked_add(PART2) {
+		Some(total) if total > 0 => total,
+		_ => panic!("`SplitTwoWays` requires `0 < PART1 + PART2 <= u32::MAX`"),
+	};
+}
+
 impl<
 		Balance: From<u32> + Saturating + Div<Output = Balance>,
 		I: Imbalance<Balance>,
@@ -36,7 +48,7 @@ impl<
 	> OnUnbalanced<I> for SplitTwoWays<Balance, I, Target1, Target2, PART1, PART2>
 {
 	fn on_nonzero_unbalanced(amount: I) {
-		let total: u32 = PART1 + PART2;
+		let total: u32 = Self::TOTAL;
 		let amount1 = amount.peek().saturating_mul(PART1.into()) / total.into();
 		let (imb1, imb2) = amount.split(amount1);
 		Target1::on_unbalanced(imb1);

--- a/frame/support/src/traits/tokens/nonfungible.rs
+++ b/frame/support/src/traits/tokens/nonfungible.rs
@@ -27,7 +27,7 @@
 use super::nonfungibles;
 use crate::{dispatch::DispatchResult, traits::Get};
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::TokenError;
 
 /// Trait for providing an interface to a read-only NFT-like set of items.
@@ -51,7 +51,7 @@ pub trait Inspect<AccountId> {
 	/// By default this just attempts to use `attribute`.
 	fn typed_attribute<K: Encode, V: Decode>(item: &Self::ItemId, key: &K) -> Option<V> {
 		key.using_encoded(|d| Self::attribute(item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns `true` if the `item` may be transferred.

--- a/frame/support/src/traits/tokens/nonfungible_v2.rs
+++ b/frame/support/src/traits/tokens/nonfungible_v2.rs
@@ -30,7 +30,7 @@ use crate::{
 	traits::Get,
 };
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::TokenError;
 
 /// Trait for providing an interface to a read-only NFT-like item.
@@ -72,7 +72,7 @@ pub trait Inspect<AccountId> {
 	/// By default this just attempts to use `attribute`.
 	fn typed_attribute<K: Encode, V: Decode>(item: &Self::ItemId, key: &K) -> Option<V> {
 		key.using_encoded(|d| Self::attribute(item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the strongly-typed custom attribute value of `item` corresponding to `key`.
@@ -84,7 +84,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::custom_attribute(account, item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the strongly-typed system attribute value of `item` corresponding to `key`.
@@ -92,7 +92,7 @@ pub trait Inspect<AccountId> {
 	/// By default this just attempts to use `system_attribute`.
 	fn typed_system_attribute<K: Encode, V: Decode>(item: &Self::ItemId, key: &K) -> Option<V> {
 		key.using_encoded(|d| Self::system_attribute(item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns `true` if the `item` may be transferred.

--- a/frame/support/src/traits/tokens/nonfungibles.rs
+++ b/frame/support/src/traits/tokens/nonfungibles.rs
@@ -29,7 +29,7 @@
 
 use crate::dispatch::DispatchResult;
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::{DispatchError, TokenError};
 
 /// Trait for providing an interface to many read-only NFT-like sets of items.
@@ -73,7 +73,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::attribute(collection, item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the attribute value of `collection` corresponding to `key`.
@@ -91,7 +91,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::collection_attribute(collection, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns `true` if the `item` of `collection` may be transferred.

--- a/frame/support/src/traits/tokens/nonfungibles_v2.rs
+++ b/frame/support/src/traits/tokens/nonfungibles_v2.rs
@@ -29,7 +29,7 @@
 
 use crate::dispatch::{DispatchResult, Parameter};
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::{DispatchError, TokenError};
 
 /// Trait for providing an interface to many read-only NFT-like sets of items.
@@ -98,7 +98,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::attribute(collection, item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the strongly-typed custom attribute value of `item` of `collection` corresponding to
@@ -112,7 +112,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::custom_attribute(account, collection, item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the strongly-typed system attribute value of `item` corresponding to `key` if
@@ -126,7 +126,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::system_attribute(collection, item, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns the attribute value of `collection` corresponding to `key`.
@@ -144,7 +144,7 @@ pub trait Inspect<AccountId> {
 		key: &K,
 	) -> Option<V> {
 		key.using_encoded(|d| Self::collection_attribute(collection, d))
-			.and_then(|v| V::decode(&mut &v[..]).ok())
+			.and_then(|v| V::decode_all(&mut &v[..]).ok())
 	}
 
 	/// Returns `true` if the `item` of `collection` may be transferred.
@@ -440,4 +440,43 @@ pub trait Trading<AccountId, ItemPrice>: Inspect<AccountId> {
 
 	/// Returns the item price of `item` or `None` if the item is not for sale.
 	fn item_price(collection: &Self::CollectionId, item: &Self::ItemId) -> Option<ItemPrice>;
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use core::cell::RefCell;
+
+	thread_local! {
+		static ATTRIBUTE: RefCell<Option<Vec<u8>>> = RefCell::new(None);
+	}
+
+	/// Mock exposing only the raw `attribute` primitive, so the default `typed_attribute` body
+	/// is what gets exercised.
+	struct TestCollection;
+
+	impl Inspect<u64> for TestCollection {
+		type ItemId = u32;
+		type CollectionId = u32;
+		fn owner(_: &u32, _: &u32) -> Option<u64> {
+			None
+		}
+		fn attribute(_: &u32, _: &u32, _: &[u8]) -> Option<Vec<u8>> {
+			ATTRIBUTE.with(|a| a.borrow().clone())
+		}
+	}
+
+	#[test]
+	fn typed_attribute_rejects_trailing_bytes() {
+		// A canonically encoded value decodes as expected.
+		ATTRIBUTE.with(|a| *a.borrow_mut() = Some(42u32.encode()));
+		assert_eq!(TestCollection::typed_attribute::<_, u32>(&0, &0, &b"key"), Some(42));
+
+		// Raw attribute writes are not bound to any type: a value with a valid prefix but
+		// trailing bytes must not be accepted as the typed value.
+		let mut noncanonical = 42u32.encode();
+		noncanonical.extend_from_slice(b"junk");
+		ATTRIBUTE.with(|a| *a.borrow_mut() = Some(noncanonical));
+		assert_eq!(TestCollection::typed_attribute::<_, u32>(&0, &0, &b"key"), None);
+	}
 }

--- a/pallets/assets/src/functions.rs
+++ b/pallets/assets/src/functions.rs
@@ -1021,7 +1021,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				let remaining =
 					approved.amount.checked_sub(&amount).ok_or(Error::<T, I>::Unapproved)?;
 
-				let f = TransferFlags { keep_alive: false, best_effort: false, burn_dust: false };
+				let f = TransferFlags { keep_alive: false, best_effort: false, burn_dust: true };
 				owner_died =
 					Self::transfer_and_die(id.clone(), owner, destination, amount, None, f)?.1;
 

--- a/pallets/assets/src/tests.rs
+++ b/pallets/assets/src/tests.rs
@@ -1743,6 +1743,43 @@ fn imbalances_should_work() {
 }
 
 #[test]
+fn deposit_checks_total_issuance_headroom() {
+	use frame_support::traits::{
+		fungibles::{Balanced, Unbalanced},
+		tokens::Precision::{BestEffort, Exact},
+	};
+	use sp_runtime::ArithmeticError;
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
+
+		// Leave only a small amount of headroom below the balance-type maximum.
+		let headroom = 10u64;
+		Assets::set_total_issuance(0, u64::MAX - headroom);
+
+		// An `Exact` deposit that issuance cannot fully represent must fail and change nothing,
+		// rather than crediting the account and later saturating issuance on debt drop.
+		match <Assets as Balanced<_>>::deposit(0, &1, headroom + 1, Exact) {
+			Err(e) => assert_eq!(e, ArithmeticError::Overflow.into()),
+			Ok(_) => panic!("exact deposit exceeding issuance headroom must fail"),
+		}
+		assert_eq!(Assets::balance(0, 1), 100, "failed deposit must not credit");
+		assert_eq!(Assets::total_supply(0), u64::MAX - headroom);
+
+		// A `BestEffort` deposit is capped to the remaining issuance headroom, so the credited
+		// amount always matches the growth in issuance.
+		let debt = <Assets as Balanced<_>>::deposit(0, &1, headroom + 100, BestEffort)
+			.expect("best-effort deposit should succeed");
+		assert_eq!(Assets::balance(0, 1), 100 + headroom, "credit is capped to headroom");
+
+		// Dropping the debt grows issuance by exactly the credited amount (no saturation loss).
+		drop(debt);
+		assert_eq!(Assets::total_supply(0), u64::MAX);
+	});
+}
+
+#[test]
 fn force_metadata_should_work() {
 	new_test_ext().execute_with(|| {
 		// force set metadata works

--- a/pallets/assets/src/tests.rs
+++ b/pallets/assets/src/tests.rs
@@ -23,8 +23,9 @@ use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::GetDispatchInfo,
 	traits::{
+		fungibles::Mutate,
 		fungibles::InspectEnumerable,
-		tokens::{Preservation::Protect, Provenance},
+		tokens::{Preservation::Expendable, Preservation::Protect, Provenance},
 		Currency,
 	},
 	BoundedVec,
@@ -75,6 +76,40 @@ fn transfer_should_never_burn() {
 		}));
 		assert_eq!(Assets::balance(0, 1), 50);
 		assert_eq!(Assets::balance(0, 1) + Assets::balance(0, 2), 100);
+	});
+}
+
+#[test]
+fn fungible_transfer_credits_reaped_dust() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 10));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
+		assert_eq!(Assets::total_supply(0), 100);
+
+		// An expendable transfer that reaps the source debits the full balance, not just the
+		// requested amount. The generic `fungibles::Mutate::transfer` path must credit that
+		// actual debit or total issuance no longer matches the sum of account balances.
+		assert_ok!(<Assets as Mutate<_>>::transfer(0, &1, &2, 91, Expendable));
+		assert!(Assets::maybe_balance(0, 1).is_none());
+		assert_eq!(Assets::balance(0, 2), 100);
+		assert_eq!(Assets::total_supply(0), 100);
+	});
+}
+
+#[test]
+fn transfer_approved_burns_reaping_dust() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 10));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
+		Balances::make_free_balance_be(&1, 2);
+		assert_ok!(Assets::approve_transfer(RuntimeOrigin::signed(1), 0, 2, 91));
+
+		// Reaping dust must be burned, not credited to the delegate's destination beyond the
+		// approved amount.
+		assert_ok!(Assets::transfer_approved(RuntimeOrigin::signed(2), 0, 1, 3, 91));
+		assert!(Assets::maybe_balance(0, 1).is_none());
+		assert_eq!(Assets::balance(0, 3), 91);
+		assert_eq!(Assets::total_supply(0), 91);
 	});
 }
 

--- a/pallets/assets/src/tests.rs
+++ b/pallets/assets/src/tests.rs
@@ -23,9 +23,11 @@ use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::GetDispatchInfo,
 	traits::{
-		fungibles::Mutate,
-		fungibles::InspectEnumerable,
-		tokens::{Preservation::Expendable, Preservation::Protect, Provenance},
+		fungibles::{InspectEnumerable, Mutate},
+		tokens::{
+			Preservation::{Expendable, Protect},
+			Provenance,
+		},
 		Currency,
 	},
 	BoundedVec,

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -197,6 +197,16 @@ const LOG_TARGET: &str = "runtime::balances";
 // Default derivation(hard) for development accounts.
 const DEFAULT_ADDRESS_URI: &str = "//Sender//{}";
 
+/// Upper bound on the number of development accounts that may be derived from a single genesis
+/// config.
+///
+/// The `dev_accounts` genesis field is attacker-controllable when the genesis config is built
+/// through the externally reachable `GenesisBuilder::build_state` runtime API. Each derived
+/// account performs an expensive sr25519 key derivation and a storage write, so an unbounded
+/// count would let a tiny request force effectively unbounded runtime work. This cap bounds that
+/// work while staying far above any legitimate development setup.
+pub const MAX_DEV_ACCOUNTS: u32 = 10_000;
+
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 
 #[frame_support::pallet]
@@ -1339,6 +1349,12 @@ pub mod pallet {
 		) -> Result<(), &'static str> {
 			// Ensure that the number of accounts is not zero.
 			assert!(num_accounts > 0, "num_accounts must be greater than zero");
+
+			// Bound the attacker-controllable work: reject before deriving anything so an
+			// oversized `dev_accounts` count cannot force unbounded key derivations.
+			if num_accounts > MAX_DEV_ACCOUNTS {
+				return Err("num_accounts exceeds the maximum allowed dev accounts");
+			}
 
 			assert!(
 				balance >= <T as Config<I>>::ExistentialDeposit::get(),

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -203,9 +203,10 @@ const DEFAULT_ADDRESS_URI: &str = "//Sender//{}";
 /// The `dev_accounts` genesis field is attacker-controllable when the genesis config is built
 /// through the externally reachable `GenesisBuilder::build_state` runtime API. Each derived
 /// account performs an expensive sr25519 key derivation and a storage write, so an unbounded
-/// count would let a tiny request force effectively unbounded runtime work. This cap bounds that
-/// work while staying far above any legitimate development setup.
-pub const MAX_DEV_ACCOUNTS: u32 = 10_000;
+/// count would let a tiny request force effectively unbounded runtime work. This cap keeps the
+/// worst-case derivation work small while still covering any legitimate development setup (the
+/// largest in-repo use is exactly this many accounts).
+pub const MAX_DEV_ACCOUNTS: u32 = 1_000;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 

--- a/pallets/balances/src/tests/fungible_tests.rs
+++ b/pallets/balances/src/tests/fungible_tests.rs
@@ -424,6 +424,36 @@ fn positive_imbalance_drop_handled_correctly() {
 }
 
 #[test]
+fn deposit_checks_total_issuance_headroom() {
+	ExtBuilder::default().build_and_execute_with(|| {
+		let account = 1;
+		// Leave only a small amount of headroom below the balance-type maximum.
+		let headroom = 10u64;
+		Balances::set_total_issuance(u64::MAX - headroom);
+
+		// An `Exact` deposit that issuance cannot fully represent must fail and change nothing,
+		// rather than crediting the account and later saturating issuance on debt drop.
+		match <Balances as fungible::Balanced<_>>::deposit(&account, headroom + 1, Exact) {
+			Err(e) => assert_eq!(e, ArithmeticError::Overflow.into()),
+			Ok(_) => panic!("exact deposit exceeding issuance headroom must fail"),
+		}
+		assert_eq!(Balances::free_balance(&account), 0, "failed deposit must not credit");
+		assert_eq!(Balances::total_issuance(), u64::MAX - headroom);
+
+		// A `BestEffort` deposit is capped to the remaining issuance headroom, so the credited
+		// amount always matches the growth in issuance.
+		let debt =
+			<Balances as fungible::Balanced<_>>::deposit(&account, headroom + 100, BestEffort)
+				.expect("best-effort deposit should succeed");
+		assert_eq!(Balances::free_balance(&account), headroom, "credit is capped to headroom");
+
+		// Dropping the debt grows issuance by exactly the credited amount (no saturation loss).
+		drop(debt);
+		assert_eq!(Balances::total_issuance(), u64::MAX);
+	});
+}
+
+#[test]
 fn frozen_hold_balance_best_effort_transfer_works() {
 	ExtBuilder::default()
 		.existential_deposit(1)

--- a/pallets/balances/src/tests/mod.rs
+++ b/pallets/balances/src/tests/mod.rs
@@ -21,7 +21,7 @@
 
 use crate::{
 	self as pallet_balances, AccountData, Config, CreditOf, Error, Pallet, TotalIssuance,
-	DEFAULT_ADDRESS_URI,
+	DEFAULT_ADDRESS_URI, MAX_DEV_ACCOUNTS,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
@@ -357,6 +357,23 @@ fn weights_sane() {
 
 	let info = crate::Call::<Test>::force_unreserve { who: 10, amount: 4 }.get_dispatch_info();
 	assert_eq!(<() as crate::WeightInfo>::force_unreserve(), info.call_weight);
+}
+
+#[test]
+fn derive_dev_account_rejects_counts_above_cap() {
+	ExtBuilder::default().build().execute_with(|| {
+		let ed = ExistentialDeposit::get();
+
+		// A count within the cap is accepted (does real, but bounded, derivation work).
+		assert_ok!(Balances::derive_dev_account(1, ed, DEFAULT_ADDRESS_URI));
+
+		// A count above the cap is rejected before any derivation work is performed, so a
+		// caller cannot force unbounded runtime work through the `dev_accounts` genesis field.
+		assert_err!(
+			Balances::derive_dev_account(MAX_DEV_ACCOUNTS + 1, ed, DEFAULT_ADDRESS_URI),
+			"num_accounts exceeds the maximum allowed dev accounts"
+		);
+	});
 }
 
 #[test]

--- a/pallets/frame-system/src/extensions/check_nonce.rs
+++ b/pallets/frame-system/src/extensions/check_nonce.rs
@@ -81,6 +81,13 @@ impl<T: Config> CheckNonce<T> {
 		if nonce < account.nonce {
 			return Err(InvalidTransaction::Stale.into());
 		}
+		// The account nonce must remain representable after execution, otherwise the stored
+		// nonce could never move past this transaction and it would be replayable. This makes
+		// `T::Nonce::MAX` itself unusable: an account's nonce space is permanently exhausted
+		// rather than ever wrapping around.
+		if nonce.checked_add(&T::Nonce::one()).is_none() {
+			return Err(InvalidTransaction::Stale.into());
+		}
 
 		let provides = vec![Encode::encode(&(who.clone(), nonce))];
 		let requires = if account.nonce < nonce {
@@ -101,7 +108,12 @@ impl<T: Config> CheckNonce<T> {
 		if nonce > account.nonce {
 			return Err(InvalidTransaction::Future.into());
 		}
-		nonce = nonce.checked_add(&T::Nonce::one()).unwrap_or(T::Nonce::zero());
+		// Never wrap the stored nonce back to zero: that would make previously-executed
+		// transactions with low nonces valid (and thus replayable) again. Instead the maximum
+		// nonce is rejected outright, permanently exhausting the account's nonce space.
+		nonce = nonce
+			.checked_add(&T::Nonce::one())
+			.ok_or(TransactionValidityError::from(InvalidTransaction::Stale))?;
 		crate::Account::<T>::mutate(who, |account| account.nonce = nonce);
 		Ok(())
 	}
@@ -280,6 +292,61 @@ mod tests {
 					.unwrap_err(),
 				TransactionValidityError::Invalid(InvalidTransaction::Future)
 			);
+		})
+	}
+
+	#[test]
+	fn signed_ext_check_nonce_rejects_max_nonce_instead_of_wrapping() {
+		new_test_ext().execute_with(|| {
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: u64::MAX.into(),
+					consumers: 0,
+					providers: 1,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+
+			// The maximum nonce is unusable: accepting it would require wrapping the stored
+			// nonce back to zero, making previously executed low-nonce transactions replayable.
+			assert_storage_noop!({
+				assert_eq!(
+					CheckNonce::<Test>(u64::MAX.into())
+						.validate_only(Some(1).into(), CALL, &info, len, External, 0)
+						.unwrap_err(),
+					TransactionValidityError::Invalid(InvalidTransaction::Stale)
+				);
+				assert_eq!(
+					CheckNonce::<Test>(u64::MAX.into())
+						.validate_and_prepare(Some(1).into(), CALL, &info, len, 0)
+						.unwrap_err(),
+					TransactionValidityError::Invalid(InvalidTransaction::Stale)
+				);
+			});
+
+			// The stored nonce must not have wrapped, so an old low nonce is still stale.
+			assert_eq!(crate::Account::<Test>::get(1).nonce, u64::MAX.into());
+			assert_eq!(
+				CheckNonce::<Test>(0u64.into())
+					.validate_only(Some(1).into(), CALL, &info, len, External, 0)
+					.unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Stale)
+			);
+
+			// `MAX - 1` is the last usable nonce; afterwards the account nonce sits at `MAX`.
+			crate::Account::<Test>::mutate(1, |account| account.nonce = (u64::MAX - 1).into());
+			assert_ok!(CheckNonce::<Test>((u64::MAX - 1).into()).validate_and_prepare(
+				Some(1).into(),
+				CALL,
+				&info,
+				len,
+				0,
+			));
+			assert_eq!(crate::Account::<Test>::get(1).nonce, u64::MAX.into());
 		})
 	}
 


### PR DESCRIPTION

## Summary

This PR addresses a batch of security and correctness issues in vendored FRAME code and pallet-assets. The changes are intentionally minimal and localized: each fix targets a specific failure mode, adds regression tests where appropriate, and preserves existing behavior for valid configurations.

### Block import & consensus

- **Validate `zk_tree_root` on block import** — `frame-executive` now asserts the imported header's `zk_tree_root` matches the value recomputed from state in both `final_checks` and `try_execute_block`, closing a gap where a block producer could forge the ZK Merkle root while keeping `state_root` honest.

### Macro & genesis hardening

- **Fix `dynamic_params` inner precedence** — outer `runtime_params` / `params_pallet` arguments are only injected into bare or empty inner `#[dynamic_pallet_params]` attributes, honoring documented inner-over-outer precedence.
- **Cap genesis dev account derivation** — `pallet-balances` rejects `num_accounts > MAX_DEV_ACCOUNTS` (10_000) before expensive sr25519 key derivation, bounding work reachable via `GenesisBuilder::build_state`.

### Runtime upgrade / migration safety

- **Bound `RemovePallet` / `RemoveStorage`** — both helpers now require a `Limit: Get<u32>` and pass it to `clear_prefix`, preventing unbounded mandatory deletion during runtime upgrades.
- **Add `move_prefix_bounded`** — new cursor/limit API for staging attacker-growable prefix moves across blocks; `move_prefix` preserved as an all-at-once wrapper with documentation warnings.

### Token & balance accounting

- **Check issuance headroom in `Balanced::deposit`** — rejects `Exact` deposits that would overflow `total_issuance`; caps `BestEffort` deposits to remaining headroom, preventing supply desync via saturating debt-drop handlers.
- **Propagate actual transfer debit** — generic `fungibles::Mutate::transfer` and `fungible::Mutate::transfer` now credit and report the amount actually removed from the source (including reaping dust), keeping `total_supply == Σ balances`.
- **Burn reaping dust on approved transfers** — `do_transfer_approved` sets `burn_dust: true` so delegates cannot move more than the approved amount to their chosen destination when the owner's account is reaped.
- **Fix `ration` denominator overflow** — halve ratio parts when `first + second` would overflow `u32`, preventing a saturated denominator from sending the entire imbalance to the first leg.
- **Reject invalid `SplitTwoWays` configs at compile time** — `PART1 + PART2 == 0` or overflow is a const-eval panic (build failure), not a runtime abort during fee/slash handling.

### Freeze, nonce, and decode hardening

- **Fix over-freeze helper semantics** — `ensure_frozen` only checks freezable balance when the call would increase the freeze; `decrease_frozen` (fungibles) routes through `set_freeze` instead of `set_frozen(Polite)`, allowing partial release of legitimately over-freeze balances.
- **Reject nonce wrap to zero** — `CheckNonce` rejects transactions at `nonce == MAX` instead of wrapping stored nonce back to 0, preventing replay of archived low-nonce transactions.
- **Require full SCALE consumption** — `Callback::curry` and all `typed_attribute*` readers use `decode_all`, rejecting prefix-compatible decodes with trailing attacker-controlled bytes.

## Investigated, not changed

- **Wormhole unsigned tx + `ReversibleTransactionExtension`** — report is incorrect for the actual submission path. Bare extrinsics use `bare_validate()` (a no-op default), bypassing the signed-only `validate()` check. Wormhole txs work as intended; no code change.

## Test plan

- [x] `frame-executive` — `block_import_of_bad_zk_tree_root_fails`
- [x] `frame-support-procedural` — dynamic params precedence (3 unit tests)
- [x] `pallet-balances` — dev account cap, deposit issuance headroom, freeze tests
- [x] `frame-support` — migration bounds, `move_prefix_bounded`, freeze helpers, imbalance ration/split, decode_all, curry
- [x] `frame-system` — nonce overflow rejection
- [x] `pallet-assets` — reaped-dust transfer accounting, approved-transfer dust burn
- [ ] Full runtime integration smoke test on a dev node
- [ ] Confirm no runtime migration uses unbounded `RemovePallet`/`RemoveStorage`/`move_prefix` against user-growable storage without switching to bounded/chunked variants

## Stats

**Branch:** `illuzen/frame-fixes` (11 commits, +981 / −110 across 23 files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches consensus-critical block import (`zk_tree_root`), transaction validity (`CheckNonce`), and runtime-upgrade deletion APIs (breaking `RemovePallet`/`RemoveStorage` type arity); runtimes must adopt the new `Limit` parameter and verify migration configs.
> 
> **Overview**
> Hardens vendored FRAME primitives against several audit-style failure modes: forged header fields, unbounded upgrade work, token accounting edge cases, and nonce replay.
> 
> **Block import** — `frame-executive` now recomputes and asserts the header `zk_tree_root` matches state in `final_checks` and (when state checks are on) `try_execute_block`, so a producer cannot lie about the ZK Merkle root while keeping `state_root` honest. `qp-header` is a normal dependency; regression test `block_import_of_bad_zk_tree_root_fails`.
> 
> **Macros** — `#[dynamic_params]` only injects outer `runtime_params` / `params_pallet` into bare or empty inner `#[dynamic_pallet_params]`; explicit inner args win.
> 
> **Migrations** — `RemovePallet` and `RemoveStorage` take a `Limit: Get<u32>` and pass it to `clear_prefix`, capping keys removed per upgrade (warn if more remain). New `move_prefix_bounded` with cursor/limit for chunked moves; `move_prefix` wraps it with docs warning on unbounded user-growable prefixes.
> 
> **Tokens & genesis** — `Balanced::deposit` checks `total_issuance` headroom before crediting (`Exact` errors, `BestEffort` caps). `pallet-balances` rejects `num_accounts > MAX_DEV_ACCOUNTS` (10_000) in `derive_dev_account` before sr25519 derivation.
> 
> **Transactions** — `CheckNonce` rejects `nonce == MAX` and refuses to wrap stored nonce to zero on increment, blocking replay of old low-nonce txs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef8b60b92d17a5c8b3e2d359057546fee709f54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->