### PR TITLE
Tokenomics update: 50/50 treasury/miner split, 4-year emission half-life, no pre-mine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6189,6 +6189,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/docs/RUNTIME_SURFACE.md
+++ b/docs/RUNTIME_SURFACE.md
@@ -116,7 +116,7 @@ All `Config` impls live in `runtime/src/configs/mod.rs` unless noted.
 - No dispatchable calls. Implements `Hooks` (`on_initialize`/`on_finalize`) to track block timing and recompute difficulty. Powers the `QPoWApi` runtime API.
 
 ### Index 6 — `MiningRewards` (`pallet-mining-rewards`, local)
-- `Currency = Balances`, `ProofRecorder = Wormhole`, `MaxSupply = 21_000_000 * UNIT`, `EmissionDivisor = 26_280_000`, `Treasury = pallet_treasury::Pallet`, `MintingAccount`, `Unit = UNIT`.
+- `Currency = Balances`, `ProofRecorder = Wormhole`, `MaxSupply = 21_000_000 * UNIT`, `EmissionDivisor = 15_163_560`, `Treasury = pallet_treasury::Pallet`, `MintingAccount`, `Unit = UNIT`.
 - No dispatchable calls. Exposes `TransactionFeesCollector` + `collect_transaction_fees`. `on_finalize` mints block reward (70% miner / 30% treasury split per fee-structure docs).
 
 ### Index 7 — `Preimage` (`pallet-preimage`)

--- a/pallets/mining-rewards/src/mock.rs
+++ b/pallets/mining-rewards/src/mock.rs
@@ -36,7 +36,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const SS58Prefix: u8 = 189;
 	pub const MaxSupply: u128 = 21_000_000 * UNIT;
-	pub const EmissionDivisor: u128 = 26_280_000;
+	pub const EmissionDivisor: u128 = 15_163_560;
 	pub const ExistentialDeposit: Balance = 1;
 }
 

--- a/pallets/mining-rewards/src/tests.rs
+++ b/pallets/mining-rewards/src/tests.rs
@@ -550,9 +550,8 @@ fn test_fees_and_rewards_to_miner() {
 #[ignore] // This test takes a very long time (~120M blocks simulation), run manually with --ignored
 fn test_emission_simulation_120m_blocks() {
 	new_test_ext().execute_with(|| {
-		// Add realistic initial supply similar to genesis
-		let treasury_account = Treasury::account_id();
-		let _ = Balances::deposit_creating(&treasury_account, 3_600_000 * UNIT);
+		// No pre-mine at genesis: the treasury starts empty and the initial supply is just the
+		// existential deposits of the test accounts (negligible vs. MaxSupply).
 
 		println!("=== Mining Rewards Emission Simulation ===");
 		println!("Max Supply: {:.0} tokens", MaxSupply::get() as f64 / UNIT as f64);
@@ -563,12 +562,15 @@ fn test_emission_simulation_120m_blocks() {
 		const MAX_BLOCKS: u64 = 130_000_000;
 		const REPORT_INTERVAL: u64 = 1_000_000; // Report every 1M blocks
 		const UNIT: u128 = 1_000_000_000_000; // For readable output
+		// 4 years of 12-second blocks: 4 * 365.25 days * 86400 s / 12 s
+		const FOUR_YEARS_BLOCKS: u64 = 10_519_200;
 
 		let initial_supply = Balances::total_issuance();
 		let mut current_supply = initial_supply;
 		let mut total_miner_rewards = 0u128;
 		let mut total_treasury_rewards = 0u128;
 		let mut block = 0u64;
+		let mut four_year_stats: Option<(u128, u128, u128)> = None;
 
 		println!("Block       Supply        %MaxSupply  BlockReward   ToTreasury   ToMiner      Remaining");
 		println!("{}", "-".repeat(90));
@@ -613,6 +615,12 @@ fn test_emission_simulation_120m_blocks() {
 			total_treasury_rewards += treasury_reward;
 			total_miner_rewards += miner_reward;
 			block += 1;
+
+			// Snapshot state at the 4-year mark for tokenomics validation
+			if block == FOUR_YEARS_BLOCKS {
+				four_year_stats =
+					Some((current_supply, total_miner_rewards, total_treasury_rewards));
+			}
 
 			// Print progress report at intervals
 			if block.is_multiple_of(REPORT_INTERVAL) {
@@ -671,6 +679,39 @@ fn test_emission_simulation_120m_blocks() {
 		println!();
 		println!("=== Time Estimates (12s blocks) ===");
 		println!("Total Time: {:.1} days ({:.1} years)", days, years);
+
+		// === 4-Year Checkpoint Validation ===
+		// Target tokenomics: after ~4 years of 12s blocks, approximately 50% of the mineable
+		// supply has been emitted, half of it (25% of mineable supply) to the treasury.
+		let (supply_4y, miner_4y, treasury_4y) =
+			four_year_stats.expect("simulation must run past the 4-year mark");
+		let mineable_supply = MaxSupply::get() - initial_supply;
+		let emitted_4y = supply_4y - initial_supply;
+		let emitted_pct_4y = (emitted_4y as f64 / mineable_supply as f64) * 100.0;
+		let miner_pct_4y = (miner_4y as f64 / mineable_supply as f64) * 100.0;
+		let treasury_pct_4y = (treasury_4y as f64 / mineable_supply as f64) * 100.0;
+
+		println!();
+		println!("=== 4-Year Checkpoint (block {}) ===", FOUR_YEARS_BLOCKS);
+		println!("Emitted: {:.6} tokens ({:.2}% of mineable supply)", emitted_4y as f64 / UNIT as f64, emitted_pct_4y);
+		println!("To Miners: {:.6} tokens ({:.2}% of mineable supply)", miner_4y as f64 / UNIT as f64, miner_pct_4y);
+		println!("To Treasury: {:.6} tokens ({:.2}% of mineable supply)", treasury_4y as f64 / UNIT as f64, treasury_pct_4y);
+
+		assert!(
+			(49.0..=51.0).contains(&emitted_pct_4y),
+			"~50% of mineable supply should be emitted after 4 years, got {:.2}%",
+			emitted_pct_4y
+		);
+		assert!(
+			(24.0..=26.0).contains(&treasury_pct_4y),
+			"~25% of mineable supply should have gone to treasury after 4 years, got {:.2}%",
+			treasury_pct_4y
+		);
+		assert!(
+			(24.0..=26.0).contains(&miner_pct_4y),
+			"~25% of mineable supply should have gone to miners after 4 years, got {:.2}%",
+			miner_pct_4y
+		);
 
 		// === Comprehensive Emission Validation ===
 

--- a/pallets/treasury/Cargo.toml
+++ b/pallets/treasury/Cargo.toml
@@ -14,6 +14,7 @@ codec = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { optional = true, workspace = true, default-features = false }
 frame-support.workspace = true
 frame-system.workspace = true
+log.workspace = true
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-runtime.workspace = true
 
@@ -33,6 +34,12 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
+	"log/std",
 	"scale-info/std",
 	"sp-runtime/std",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
 ]

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -32,6 +32,7 @@
 //! The `mining-rewards` pallet uses the [`TreasuryProvider`] trait to determine where and
 //! how much of each block reward should be allocated to the treasury.
 
+pub mod migrations;
 pub mod weights;
 pub use weights::WeightInfo;
 
@@ -55,7 +56,9 @@ pub mod pallet {
 	///
 	/// This establishes an explicit baseline for future storage migrations.
 	/// Increment this and add a migration hook when storage layout changes.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+	///
+	/// v1: `TreasuryPortion` set to 50% (50/50 treasury/miner split, see `migrations::v1`).
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/treasury/src/migrations.rs
+++ b/pallets/treasury/src/migrations.rs
@@ -1,0 +1,70 @@
+//! Storage migrations for `pallet-treasury`.
+
+extern crate alloc;
+
+use crate::pallet::{Config, Pallet, TreasuryPortion};
+use core::marker::PhantomData;
+use frame_support::{
+	traits::{Get, UncheckedOnRuntimeUpgrade},
+	weights::Weight,
+};
+use sp_runtime::Permill;
+
+#[cfg(feature = "try-runtime")]
+use alloc::vec::Vec;
+
+/// v0 -> v1: tokenomics change to a 50/50 treasury/miner split of block rewards.
+pub mod v1 {
+	use super::*;
+
+	/// The treasury portion enforced by this migration (50% treasury / 50% miner).
+	pub fn treasury_portion() -> Permill {
+		Permill::from_percent(50)
+	}
+
+	/// Sets [`TreasuryPortion`] to 50% on an already-running chain.
+	///
+	/// This accompanies the emission-divisor change in the runtime config: together they
+	/// implement the updated tokenomics where roughly half the mineable supply is emitted
+	/// over the first four years, split equally between miners and the treasury.
+	pub struct SetTreasuryPortionToHalf<T>(PhantomData<T>);
+
+	impl<T: Config> UncheckedOnRuntimeUpgrade for SetTreasuryPortionToHalf<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let portion = treasury_portion();
+			TreasuryPortion::<T>::put(portion);
+
+			log::info!(
+				target: "runtime::treasury",
+				"Set TreasuryPortion to {:?} (50/50 treasury/miner split)",
+				portion,
+			);
+
+			T::DbWeight::get().reads_writes(0, 1)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+			Ok(Vec::new())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			frame_support::ensure!(
+				TreasuryPortion::<T>::get() == Some(treasury_portion()),
+				"TreasuryPortion must be 50% after the v1 migration"
+			);
+			Ok(())
+		}
+	}
+}
+
+/// Versioned v0 -> v1 migration. Runs [`v1::SetTreasuryPortionToHalf`] only when the on-chain
+/// storage version is 0, then bumps the on-chain storage version to 1.
+pub type MigrateV0ToV1<T> = frame_support::migrations::VersionedMigration<
+	0,
+	1,
+	v1::SetTreasuryPortionToHalf<T>,
+	Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -171,6 +171,7 @@ try-runtime = [
 	"pallet-recovery/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
+	"pallet-treasury/try-runtime",
 	"pallet-wormhole/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -140,7 +140,7 @@ impl pallet_mining_rewards::Config for Runtime {
 	type ProofRecorder = Wormhole;
 	type WeightInfo = pallet_mining_rewards::weights::SubstrateWeight<Runtime>;
 	type MaxSupply = ConstU128<{ 21_000_000 * UNIT }>; // 21 million tokens
-	type EmissionDivisor = ConstU128<26_280_000>; // Divide remaining supply by this amount
+	type EmissionDivisor = ConstU128<15_163_560>; // Divide remaining supply by this amount
 	type Treasury = pallet_treasury::Pallet<Runtime>;
 	type MintingAccount = MintingAccount;
 	type Unit = MiningUnit;

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -107,11 +107,9 @@ fn heisenberg_treasury_account() -> AccountId {
 	)
 }
 
-/// Total supply used for genesis (same portion% goes to treasury at genesis as in pallet).
-const GENESIS_SUPPLY: u128 = 21_000_000;
-
-/// Treasury genesis params per profile. Initial balance = portion of GENESIS_SUPPLY (same as
-/// pallet portion).
+/// Treasury genesis params per profile. The portion only configures the ongoing mining-reward
+/// split; the treasury receives NO genesis endowment (no pre-mine) and accumulates solely from
+/// its share of block rewards.
 #[derive(Clone)]
 struct TreasuryGenesis {
 	account: AccountId,
@@ -158,10 +156,9 @@ fn genesis_template(
 		.collect::<Vec<_>>();
 	balances.extend(extra_balances);
 
-	let total_supply_raw = GENESIS_SUPPLY.saturating_mul(UNIT);
-	let treasury_balance = treasury.portion.mul_floor(total_supply_raw);
+	// No pre-mine: the treasury starts at zero balance and is funded only by its share of
+	// mining rewards. It is intentionally NOT added to `balances`.
 	let treasury_account = treasury.account.clone();
-	balances.push((treasury_account.clone(), treasury_balance));
 
 	let config = RuntimeGenesisConfig {
 		balances: BalancesConfig { balances: balances.clone(), dev_accounts: None },
@@ -252,7 +249,7 @@ pub fn development_config_genesis() -> Value {
 		};
 
 		let treasury =
-			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(50) };
 		let mut template_value =
 			genesis_template(endowed_accounts, treasury, tech_collective, vec![]);
 		// `genesis_template` adds a chain-spec-only field; strip before deserializing.
@@ -269,7 +266,7 @@ pub fn development_config_genesis() -> Value {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	{
 		let treasury =
-			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+			TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(50) };
 		genesis_template(endowed_accounts, treasury, tech_collective, vec![])
 	}
 }
@@ -287,7 +284,7 @@ pub fn heisenberg_config_genesis() -> Value {
 		&tech_collective,
 	);
 	let treasury =
-		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(50) };
 	genesis_template(endowed_accounts, treasury, tech_collective, vec![])
 }
 
@@ -380,7 +377,7 @@ pub fn planck_config_genesis() -> Value {
 		&tech_collective,
 	);
 	let treasury =
-		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(30) };
+		TreasuryGenesis { account: treasury_account, portion: Permill::from_percent(50) };
 	genesis_template(endowed_accounts, treasury, tech_collective, signer_fee_seed)
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 134,
+	spec_version: 135,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -166,6 +166,8 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, TxExtension>;
 pub type Migrations = (
 	// v0 -> v1: seed the wormhole soundness counters so pre-upgrade deposits remain exitable.
 	pallet_wormhole::migrations::MigrateV0ToV1<Runtime>,
+	// v0 -> v1: set the treasury portion to 50% (50/50 treasury/miner reward split).
+	pallet_treasury::migrations::MigrateV0ToV1<Runtime>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/runtime/tests/common.rs
+++ b/runtime/tests/common.rs
@@ -30,7 +30,7 @@ impl TestCommons {
 		let treasury_account = Self::treasury_account();
 		pallet_treasury::GenesisConfig::<Runtime> {
 			treasury_account: Some(treasury_account.clone()),
-			treasury_portion: Some(Permill::from_percent(30)), // 30% to treasury, 70% to miner
+			treasury_portion: Some(Permill::from_percent(50)), // 50% to treasury, 50% to miner
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION
## Summary

Updates the chain's tokenomics so that roughly **50% of the mineable supply is emitted over the first 4 years**, split **equally between miners and the treasury** (25% each). All changes to the live chain are executable via a standard runtime upgrade (`spec_version` 134 → 135); no node restart or offline intervention is required.

## Changes

### 1. Emission divisor: `26_280_000` → `15_163_560`

The per-block reward is `remaining_supply / EmissionDivisor`. The new divisor equals 4 years of 12-second blocks (10,519,200) divided by ln(2), which places the emission curve's half-life at exactly the 4-year mark. This is a compile-time runtime constant, so it takes effect the moment the upgraded runtime is enacted.

### 2. Treasury portion: 30% → 50% via storage migration

The treasury/miner split lives in on-chain storage (`pallet-treasury`'s `TreasuryPortion`), so the change ships as a versioned storage migration:

- New `pallets/treasury/src/migrations.rs` with a v0 → v1 `VersionedMigration` that sets `TreasuryPortion` to `Permill::from_percent(50)`.
- Treasury pallet storage version bumped to 1; migration wired into the runtime's `Migrations` tuple.
- Includes `try-runtime` pre/post-upgrade checks (the treasury pallet and runtime gained the missing `try-runtime` feature wiring).
- The migration only runs on chains at storage version 0 (i.e. the live testnet); fresh chains genesis directly at version 1.

### 3. Genesis presets: 50% portion, no treasury pre-mine

- All presets (`dev`, `heisenberg`, `planck`) now set the treasury portion to 50%, matching the post-upgrade testnet so testnet and mainnet share the same configuration.
- **The treasury genesis endowment is removed entirely** (previously 30% of the 21M supply, ~6.3M tokens). The treasury now starts at zero balance and is funded exclusively by its share of block rewards. Its first reward (~0.69 tokens) comfortably exceeds the existential deposit (0.001), so the account is created on the first block.
- The treasury account is still set in the treasury pallet's genesis config and still owns asset id 0 for the wormhole.

Note: dev/testnet presets still endow the test accounts (Alice/Bob/Charlie, faucet) — a mainnet spec should use its own preset with no endowments.

## Verification

The emission simulation (`test_emission_simulation_120m_blocks`) was extended with a 4-year checkpoint and updated to start from a zero-pre-mine supply. Results with the new parameters:

| Metric (at block 10,519,200 ≈ 4 years) | Value |
|---|---|
| Emitted | 10,505,968 tokens (**50.03%** of mineable supply) |
| To miners | 5,252,984 tokens (**25.01%**) |
| To treasury | 5,252,984 tokens (**25.01%**) |

The test now asserts these stay within 49–51% / 24–26% bands. Long-run behavior is unchanged in shape: ~99.98% of the 21M max supply emitted after ~49 years, with an exact 50.0/50.0 miner/treasury split of all emissions.

Run it with:

```bash
cargo test -p pallet-mining-rewards --release test_emission_simulation_120m_blocks -- --ignored --nocapture
```

## Test plan

- [x] `cargo test -p pallet-treasury` (13 tests)
- [x] `cargo test -p pallet-mining-rewards` (22 tests + ignored simulation run manually)
- [x] `cargo test -p quantus-runtime` (23 integration tests)
- [x] `cargo check -p pallet-treasury --features try-runtime`
- [x] Emission simulation 4-year checkpoint assertions pass
- [ ] `try-runtime` dry-run of the migration against live testnet state
- [ ] Enact upgrade on testnet and confirm `TreasuryPortionUpdated`/reward split in the first post-upgrade blocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core monetary policy (emission rate, reward split, and genesis supply distribution) and relies on a storage migration on existing networks; incorrect parameters or migration behavior would affect all future minting.
> 
> **Overview**
> Ships a **tokenomics overhaul** via runtime upgrade (`spec_version` **134 → 135**): faster emission, equal miner/treasury share of block rewards, and no treasury genesis allocation.
> 
> **Emission:** `EmissionDivisor` changes from `26_280_000` to **`15_163_560`** in runtime config (and mining-rewards mocks/tests), targeting ~**50% of mineable supply** emitted in the first **4 years** at 12s blocks. Per-block reward remains `remaining_supply / EmissionDivisor`.
> 
> **Treasury split on live chains:** Adds **`pallet-treasury` v0→v1 migration** that sets on-chain `TreasuryPortion` to **50%** (was 30%), bumps pallet storage version to **1**, wires **`MigrateV0ToV1`** into the runtime `Migrations` tuple, and adds **`log`** + **`try-runtime`** support on the treasury pallet.
> 
> **Genesis:** All presets (`dev`, `heisenberg`, `planck`) use **50%** treasury portion; **treasury pre-mine is removed** (no balance entry in genesis `balances`—treasury is funded only from mining). Docs updated for the new divisor.
> 
> **Tests:** Long-run emission simulation drops the artificial treasury genesis deposit, adds a **4-year checkpoint** with assertions (~50% emitted, ~25% each to miners and treasury).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50deb203aaa4341faf93c7b0d87e01ad50ca336. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->