### PR TITLE
Multisig approve call binding - Require inner call payload in approve

### DIFF
--- a/pallets/multisig/src/benchmarking.rs
+++ b/pallets/multisig/src/benchmarking.rs
@@ -129,6 +129,7 @@ mod benchmarks {
 	}
 
 	/// Insert a single proposal into storage. `approvals` = list of account ids that have approved.
+	/// Returns the encoded inner call stored in the proposal.
 	#[allow(clippy::too_many_arguments)]
 	fn insert_proposal<T: Config>(
 		multisig_address: &T::AccountId,
@@ -139,7 +140,7 @@ mod benchmarks {
 		approvals: &[T::AccountId],
 		status: ProposalStatus,
 		deposit: crate::BalanceOf<T>,
-	) {
+	) -> BoundedCallOf<T> {
 		let system_call = frame_system::Call::<T>::remark { remark: vec![1u8; call_size as usize] };
 		let runtime_call = <T as Config>::RuntimeCall::from(system_call);
 		let encoded = runtime_call.encode();
@@ -147,13 +148,14 @@ mod benchmarks {
 		let bounded_approvals: BoundedApprovalsOf<T> = approvals.to_vec().try_into().unwrap();
 		let proposal_data = ProposalDataOf::<T> {
 			proposer: proposer.clone(),
-			call: bounded_call,
+			call: bounded_call.clone(),
 			expiry,
 			approvals: bounded_approvals,
 			deposit,
 			status,
 		};
 		Proposals::<T>::insert(multisig_address, proposal_id, proposal_data);
+		bounded_call
 	}
 
 	/// Benchmark `create_multisig` extrinsic.
@@ -270,7 +272,7 @@ mod benchmarks {
 		let expiry = frame_system::Pallet::<T>::block_number() + 1000u32.into();
 		// Worst-case approvals decode: threshold-1 approvals (99 for MaxSigners=100)
 		let approvals: Vec<_> = signers[0..threshold as usize - 1].to_vec();
-		insert_proposal::<T>(
+		let stored_call = insert_proposal::<T>(
 			&multisig_address,
 			0,
 			&caller,
@@ -283,7 +285,7 @@ mod benchmarks {
 		let approver = signers[threshold as usize - 1].clone();
 
 		#[extrinsic_call]
-		_(RawOrigin::Signed(approver), multisig_address.clone(), 0u32);
+		_(RawOrigin::Signed(approver), multisig_address.clone(), 0u32, stored_call);
 
 		let proposal = Proposals::<T>::get(&multisig_address, 0).unwrap();
 		assert_eq!(proposal.approvals.len(), threshold as usize);

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -8,7 +8,8 @@
 //! - Create multisig addresses with deterministic generation (signers + threshold + user-provided
 //!   nonce)
 //! - Propose transactions for multisig approval
-//! - Approve proposed transactions
+//! - Approve proposed transactions (approvers resubmit the inner call, which must match the stored
+//!   proposal payload — binding each approval signature to the actual call)
 //! - Execute transactions once threshold is reached (automatic)
 //! - Cleanup of expired proposals via claim_deposits() and remove_expired()
 //! - Per-signer proposal limits for filibuster protection
@@ -406,6 +407,8 @@ pub mod pallet {
 		ProposalNonceExhausted,
 		/// Call weight exceeds MaxInnerCallWeight limit
 		CallWeightExceedsLimit,
+		/// Provided call does not match the stored proposal payload
+		CallMismatch,
 	}
 
 	#[pallet::call]
@@ -724,12 +727,19 @@ pub mod pallet {
 
 		/// Approve a proposed transaction
 		///
+		/// The approver must resubmit the proposal's inner call bytes; the approval is
+		/// only valid if they are byte-equal to the payload stored at `proposal_id`.
+		/// This binds the approver's signature to the actual call being approved, so
+		/// offline/cold-wallet signers can decode and inspect what they are signing
+		/// instead of trusting an opaque proposal id.
+		///
 		/// If this approval brings the total approvals to or above the threshold,
 		/// the proposal status changes to `Approved` and can be executed via `execute()`.
 		///
 		/// Parameters:
 		/// - `multisig_address`: The multisig account
 		/// - `proposal_id`: ID (nonce) of the proposal to approve
+		/// - `call`: The encoded inner call of the proposal (must match the stored payload)
 		///
 		/// Weight: Charges for MAX call size, refunds based on actual
 		#[pallet::call_index(2)]
@@ -739,6 +749,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			multisig_address: T::AccountId,
 			proposal_id: u32,
+			call: BoundedCallOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let approver = ensure_signed(origin)?;
 
@@ -772,6 +783,11 @@ pub mod pallet {
 			// after proposal is loaded, since reading the proposal incurs size-dependent cost.
 			let actual_call_size = proposal.call.len() as u32;
 			let actual_weight = <T as Config>::WeightInfo::approve(actual_call_size);
+
+			// The approval is only valid for the exact payload stored at this proposal_id
+			if call != proposal.call {
+				return Self::err_with_actual_weight(Error::<T>::CallMismatch, actual_weight);
+			}
 
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block > proposal.expiry {

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{mock::*, Error, Event, Multisigs, ProposalStatus, Proposals};
 use codec::Encode;
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_err_ignore_postinfo, assert_noop, assert_ok,
 	dispatch::GetDispatchInfo,
 	traits::{fungible::Mutate, Currency, Get},
 };
@@ -94,6 +94,14 @@ fn dave() -> AccountId32 {
 fn make_call(remark: Vec<u8>) -> crate::BoundedCallOf<Test> {
 	let call = RuntimeCall::System(frame_system::Call::remark { remark });
 	call.encode().try_into().expect("Test call should fit in MaxCallSize")
+}
+
+/// Helper to fetch the stored call bytes of a proposal — what a wallet pulls from
+/// chain state to include in an `approve` call
+fn stored_call(multisig_address: &AccountId32, proposal_id: u32) -> crate::BoundedCallOf<Test> {
+	crate::Proposals::<Test>::get(multisig_address, proposal_id)
+		.expect("proposal should exist")
+		.call
 }
 
 /// Helper function to get the ID of the last proposal created
@@ -458,7 +466,8 @@ fn approve_works() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		// Check event
@@ -507,7 +516,8 @@ fn approve_sets_approved_when_threshold_reached() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		// Proposal should still exist with Approved status
@@ -552,6 +562,103 @@ fn approve_sets_approved_when_threshold_reached() {
 			}
 			.into(),
 		);
+	});
+}
+
+#[test]
+fn approve_fails_on_call_mismatch() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		let creator = alice();
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			2,
+			0
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+
+		let call = make_call(vec![1, 2, 3]);
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			call.clone(),
+			1000
+		));
+
+		let proposal_id = get_last_proposal_id(&multisig_address);
+
+		// Valid signer, valid proposal_id, but a different payload → rejected
+		let wrong_call = make_call(vec![9, 9, 9]);
+		assert_err_ignore_postinfo!(
+			Multisig::approve(
+				RuntimeOrigin::signed(charlie()),
+				multisig_address.clone(),
+				proposal_id,
+				wrong_call
+			),
+			Error::<Test>::CallMismatch
+		);
+
+		// No approval was recorded and status is unchanged
+		let proposal = crate::Proposals::<Test>::get(&multisig_address, proposal_id).unwrap();
+		assert_eq!(proposal.approvals, vec![bob()]);
+		assert_eq!(proposal.status, ProposalStatus::Active);
+	});
+}
+
+#[test]
+fn approve_fails_when_call_matches_other_proposal() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		let creator = alice();
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(creator.clone()),
+			signers.clone(),
+			2,
+			0
+		));
+
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+
+		// Two proposals with different payloads
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			make_call(vec![1]),
+			1000
+		));
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			make_call(vec![2]),
+			1000
+		));
+
+		// Approving proposal 0 with proposal 1's payload must fail — index and
+		// payload must match together
+		assert_err_ignore_postinfo!(
+			Multisig::approve(
+				RuntimeOrigin::signed(charlie()),
+				multisig_address.clone(),
+				0,
+				stored_call(&multisig_address, 1)
+			),
+			Error::<Test>::CallMismatch
+		);
+
+		// The correct payload for proposal 0 is accepted
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 	});
 }
 
@@ -634,7 +741,8 @@ fn cancel_fails_if_already_executed() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		// Execute (removes proposal from storage)
@@ -729,7 +837,8 @@ fn executed_proposals_removed_from_storage() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		// Execute → removed from storage, deposit returned
@@ -837,7 +946,8 @@ fn remove_expired_works_for_approved_expired_proposal() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		let proposal = Proposals::<Test>::get(&multisig_address, proposal_id).unwrap();
@@ -894,7 +1004,8 @@ fn claim_deposits_works_for_approved_expired_proposals() {
 			assert_ok!(Multisig::approve(
 				RuntimeOrigin::signed(charlie()),
 				multisig_address.clone(),
-				proposal_id
+				proposal_id,
+				stored_call(&multisig_address, proposal_id)
 			));
 		}
 
@@ -1178,7 +1289,8 @@ fn only_active_proposals_remain_in_storage() {
 				assert_ok!(Multisig::approve(
 					RuntimeOrigin::signed(charlie()),
 					multisig_address.clone(),
-					id
+					id,
+					stored_call(&multisig_address, id)
 				));
 				// Execute → removed
 				assert_ok!(Multisig::execute(
@@ -1712,7 +1824,8 @@ fn propose_with_threshold_two_waits_for_approval() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(bob()),
 			multisig_address.clone(),
-			proposal_id
+			proposal_id,
+			stored_call(&multisig_address, proposal_id)
 		));
 
 		// Proposal should be Approved but NOT removed
@@ -1780,7 +1893,8 @@ fn no_auto_cleanup_on_propose_approve_cancel() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			1
+			1,
+			stored_call(&multisig_address, 1)
 		));
 		assert!(Proposals::<Test>::get(&multisig_address, 0).is_some()); // expired but still there
 
@@ -1908,7 +2022,7 @@ fn approve_on_already_approved_proposal_emits_signer_approved_only() {
 		));
 
 		// Bob approves - this reaches threshold (2), status becomes Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
 
 		// Verify proposal is Approved
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -1921,7 +2035,8 @@ fn approve_on_already_approved_proposal_emits_signer_approved_only() {
 		assert_ok!(Multisig::approve(
 			RuntimeOrigin::signed(charlie()),
 			multisig_address.clone(),
-			0
+			0,
+			stored_call(&multisig_address, 0)
 		));
 
 		// Should emit SignerApproved but NOT ProposalReadyToExecute (already approved)
@@ -2230,7 +2345,7 @@ fn cancel_works_on_approved_proposal() {
 		));
 
 		// Bob approves - reaches threshold, status becomes Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
 
 		// Verify it's approved
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -2404,7 +2519,7 @@ fn execute_rejects_non_whitelisted_call_after_hs_enabled() {
 		));
 
 		// Bob approves -> threshold reached, status = Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0,));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
 
 		// Verify proposal is approved and ready to execute
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -2454,7 +2569,7 @@ fn execute_allows_whitelisted_call_after_hs_enabled() {
 		));
 
 		// Bob approves
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0,));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
 
 		// Enable high-security
 		set_high_security(&multisig_address);
@@ -2503,7 +2618,7 @@ fn execute_rejects_call_when_max_weight_lowered_after_propose() {
 		));
 
 		// Bob approves - proposal is now ready for execution
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0,));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
 
 		// Simulate runtime upgrade that lowers MaxInnerCallWeight to zero
 		set_max_inner_call_weight(Weight::zero());

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -2022,7 +2022,12 @@ fn approve_on_already_approved_proposal_emits_signer_approved_only() {
 		));
 
 		// Bob approves - this reaches threshold (2), status becomes Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 
 		// Verify proposal is Approved
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -2345,7 +2350,12 @@ fn cancel_works_on_approved_proposal() {
 		));
 
 		// Bob approves - reaches threshold, status becomes Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 
 		// Verify it's approved
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -2519,7 +2529,12 @@ fn execute_rejects_non_whitelisted_call_after_hs_enabled() {
 		));
 
 		// Bob approves -> threshold reached, status = Approved
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 
 		// Verify proposal is approved and ready to execute
 		let proposal = Proposals::<Test>::get(&multisig_address, 0).unwrap();
@@ -2569,7 +2584,12 @@ fn execute_allows_whitelisted_call_after_hs_enabled() {
 		));
 
 		// Bob approves
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 
 		// Enable high-security
 		set_high_security(&multisig_address);
@@ -2618,7 +2638,12 @@ fn execute_rejects_call_when_max_weight_lowered_after_propose() {
 		));
 
 		// Bob approves - proposal is now ready for execution
-		assert_ok!(Multisig::approve(RuntimeOrigin::signed(bob()), multisig_address.clone(), 0, stored_call(&multisig_address, 0)));
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			stored_call(&multisig_address, 0)
+		));
 
 		// Simulate runtime upgrade that lowers MaxInnerCallWeight to zero
 		set_max_inner_call_weight(Weight::zero());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -76,7 +76,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 135,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
-	transaction_version: 2,
+	transaction_version: 3,
 	system_version: 1,
 };
 

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -1161,22 +1161,24 @@ mod tests {
 			});
 
 			// Encode the call and set expiry
-			let encoded_call = inner_call.encode().try_into().unwrap();
+			let encoded_call: pallet_multisig::BoundedCallOf<Runtime> =
+				inner_call.encode().try_into().unwrap();
 			let expiry = System::block_number() + 100;
 
 			// Alice proposes
 			assert_ok!(Multisig::propose(
 				RuntimeOrigin::signed(alice()),
 				multisig_address.clone(),
-				encoded_call,
+				encoded_call.clone(),
 				expiry,
 			));
 
-			// Bob approves (reaches threshold)
+			// Bob approves (reaches threshold), resubmitting the proposal's call
 			assert_ok!(Multisig::approve(
 				RuntimeOrigin::signed(bob()),
 				multisig_address.clone(),
 				0, // proposal_id
+				encoded_call,
 			));
 
 			// Get charlie's transfer count before execution


### PR DESCRIPTION
## Summary

`Multisig::approve` now takes the proposal's encoded inner call as a parameter and rejects the approval (`CallMismatch`) unless it is byte-equal to the payload stored at `(multisig_address, proposal_id)`.

This binds each approval signature to the actual call being approved: a cold wallet decodes the inner call directly from the extrinsic it signs, instead of trusting the hot/mobile wallet's claim about what an opaque proposal id contains. Wallets fetch `Proposals(multisig_address, proposal_id).call` from state and embed it in the approve params.

- Fail-closed check only — no changes to storage, fees, deposits, thresholds, signer checks, call indices, or weight formulas; `CallMismatch` is appended after existing error variants so error indices are stable. No migration needed.
- The extra parameter is bounded by the existing `MaxCallSize` and charged by the length fee; the O(n) comparison is covered by the existing call-size-linear weight component.
- `transaction_version` bumped 2 → 3 (breaking encoding change for `approve`); wallet integrations must pass the new parameter.
- Tests: all existing approve call sites updated, plus mismatch and cross-proposal-payload rejection tests. The `transaction_extensions.rs` change is test-only (a runtime test constructs an approve call).