### PR TITLE
Automate release for v0.8.0-exodus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7758,7 +7758,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.7.2-full-moon"
+version = "0.8.0-exodus"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -7821,7 +7821,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.7.2-full-moon"
+version = "0.8.0-exodus"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.7.2-full-moon"
+version = "0.8.0-exodus"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.7.2-full-moon"
+version = "0.8.0-exodus"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 135,
+	spec_version: 136,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
Automated version bump for release v0.8.0-exodus.

https://github.com/Quantus-Network/chain/actions/runs/29983995665

Triggered by workflow run: major

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and spec_version-only changes with no behavioral code modifications; standard release hygiene for Substrate chains.
> 
> **Overview**
> Automated **v0.8.0-exodus** release: crate versions move from `0.7.2-full-moon` to `0.8.0-exodus` for `quantus-node` and `quantus-runtime` (including `Cargo.lock`).
> 
> On-chain compatibility is updated by incrementing **`spec_version`** from **135** to **136** in `runtime/src/lib.rs`. No pallet, migration, or application logic changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a8a35e63ff4481f261de85965a0d117604b9138. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->