### PR TITLE
ci: drop Windows target from release build matrix

### DIFF
--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -68,6 +68,10 @@ jobs:
     needs: create-tag
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let one platform's failure cancel the others (which previously left
+      # a dangling tag with no release). create-github-release still requires all
+      # remaining legs to succeed before publishing.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -78,8 +82,10 @@ jobs:
             os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-15-intel
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # x86_64-pc-windows-msvc removed: `docify::embed!` in frame-support
+          # panics on Windows ("internal error: entered unreachable code"), which
+          # failed the v0.8.0-exodus build and blocked its release. Re-add only
+          # once docify builds on Windows.
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `Quantus - Release Tag & Publish` workflow for **v0.8.0-exodus** pushed the tag but never published a release ([run 29984561572](https://github.com/Quantus-Network/chain/actions/runs/29984561572)).

Root cause: the `x86_64-pc-windows-msvc` build leg cannot compile `frame-support` — the `docify::embed!` proc-macro **panics on Windows** (`internal error: entered unreachable code`, 7×). With the default `fail-fast: true`, that failure **cancelled the other four platform builds**, and `create-github-release` (gated on `needs.build-and-release.result == 'success'`) was **skipped**. So we got a tag with no release and no node binaries. The srtool runtime job is independent and did produce the wasm.

## Fix

- Remove the `x86_64-pc-windows-msvc` target from the release matrix (a Substrate node has no Windows use case here).
- Set `fail-fast: false` so one platform can no longer cancel the others and leave a dangling tag.

`create-github-release` still requires all remaining legs to succeed before publishing, so partial releases are still prevented.

## Follow-up

After this merges, the stale `v0.8.0-exodus` tag needs to be deleted and the release re-fired for the same version (main is already at spec_version 136 — do **not** route through the release-proposal workflow, which would re-increment to 137).