### PR TITLE
ci: fix Windows release build (force LF for .rs files)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force LF line endings for Rust sources on all platforms.
+#
+# The `docify::embed!` proc-macro (used throughout frame-support) computes byte
+# offsets into the source file it reads, assuming single-byte `\n` line
+# terminators. On Windows, git's default `core.autocrlf=true` checks files out
+# with CRLF, so those offsets drift and docify hits `unreachable!()`
+# ("internal error: entered unreachable code"), breaking the windows-latest
+# release build. Pinning `.rs` to LF keeps the checkout consistent everywhere.
+*.rs text eol=lf


### PR DESCRIPTION
## Problem

The `Quantus - Release Tag & Publish` workflow for **v0.8.0-exodus** pushed the tag but never published a release ([run 29984561572](https://github.com/Quantus-Network/chain/actions/runs/29984561572)). The `x86_64-pc-windows-msvc` build leg failed to compile `frame-support`:

```
error: proc macro panicked
  --> frame\support\src\storage\types\counted_map.rs:94:9
   = help: message: internal error: entered unreachable code
error: could not compile `frame-support` (lib) due to 7 previous errors
```

With the default `fail-fast: true`, that cancelled the other four platforms and skipped `create-github-release`, leaving a tag with no release.

## Root cause

It's a **CRLF bug in `docify_macros` 0.2.9** (a transitive dep of the `docify::embed!` doc macros in `frame-support`). `line_start_position()` walks `source.lines()` and adds **one** byte per line for the terminator:

```rust
for line in source.lines() {
    cursor += line.len();
    if cursor > pos { return cursor - line.len(); }
    cursor += 1; // '\n'  <-- assumes single-byte LF
}
unreachable!()
```

On Windows, git checks the repo out with CRLF (`core.autocrlf` defaults to true), so each line is 2 bytes longer than counted. `cursor` never catches up to the span byte-offset `pos`, the loop falls through, and `unreachable!()` fires. It only ever affected the Windows leg — the only place we build for Windows.

## Fix

Add a `.gitattributes` pinning Rust sources to LF:

```
*.rs text eol=lf
```

All `.rs` files are already stored as LF, so this changes nothing on Linux/macOS and simply stops the Windows checkout from converting to CRLF — keeping docify's offset math correct. No dependency or vendored-crate changes.

Supersedes #624 (which removed the Windows target — a workaround, not a fix).

## Follow-up

After merge, re-fire the release for v0.8.0-exodus (the stale tag was already deleted; main is at spec_version 136, so do **not** route through the release-proposal workflow, which would re-increment to 137).