### PR TITLE
ci: fix blocked releases — drop Windows target, add dispatch retry path

### DIFF
--- a/.github/workflows/quantus-hotfix-release.yml
+++ b/.github/workflows/quantus-hotfix-release.yml
@@ -61,6 +61,9 @@ jobs:
     needs: create-hotfix-tag
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let one platform's failure cancel the others (which previously left
+      # a dangling tag with no release).
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -70,9 +73,11 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
-            os: macos-13
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: macos-15-intel
+          # x86_64-pc-windows-msvc removed: `docify::embed!` in frame-support
+          # panics on Windows ("internal error: entered unreachable code"), which
+          # failed the v0.8.0-exodus build and blocked its release. Re-add only
+          # once docify builds on Windows.
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@v4

--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -68,6 +68,10 @@ jobs:
     needs: create-tag
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let one platform's failure cancel the others (which previously left
+      # a dangling tag with no release). create-github-release still requires all
+      # remaining legs to succeed before publishing.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -78,8 +82,10 @@ jobs:
             os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-15-intel
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # x86_64-pc-windows-msvc removed: `docify::embed!` in frame-support
+          # panics on Windows ("internal error: entered unreachable code"), which
+          # failed the v0.8.0-exodus build and blocked its release. Re-add only
+          # once docify builds on Windows.
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@v4

--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -5,11 +5,35 @@ on:
     types: [closed]
     branches:
       - main
+  # Manual retry path: re-run the build/release for a version whose tag was
+  # already created (e.g. a previous run failed after create-tag succeeded).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version tag (e.g. v0.8.0-exodus). Created if missing.'
+        required: true
+        type: string
+      is_runtime_upgrade:
+        description: 'Is this a runtime upgrade (build srtool runtime)?'
+        required: true
+        default: true
+        type: boolean
+      release_branch:
+        description: 'Target branch for the release (e.g. release/v0.8.0-exodus)'
+        required: true
+        type: string
+      is_draft:
+        description: 'Create as draft release?'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   create-tag:
     name: Create Tag
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-proposal')
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-proposal'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,33 +48,43 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from PR title
+      - name: Extract version
         id: extract_version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Extract version from PR title (format: "ci: Automate version bump to vX.Y.Z")
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*')
-          if [ -z "$VERSION" ]; then
-            echo "Error: Could not extract version from PR title: ${{ github.event.pull_request.title }}"
-            exit 1
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-
-          # Check if this is a draft release
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
-            echo "is_draft=true" >> $GITHUB_OUTPUT
-            echo "release_branch=main" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "is_draft=${{ inputs.is_draft }}" >> $GITHUB_OUTPUT
+            echo "release_branch=${{ inputs.release_branch }}" >> $GITHUB_OUTPUT
           else
-            echo "is_draft=false" >> $GITHUB_OUTPUT
-            echo "release_branch=release/$VERSION" >> $GITHUB_OUTPUT
+            # Extract version from PR title (format: "ci: Automate version bump to vX.Y.Z")
+            VERSION=$(echo "$PR_TITLE" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*')
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from PR title: $PR_TITLE"
+              exit 1
+            fi
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+            # Check if this is a draft release
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
+              echo "is_draft=true" >> $GITHUB_OUTPUT
+              echo "release_branch=main" >> $GITHUB_OUTPUT
+            else
+              echo "is_draft=false" >> $GITHUB_OUTPUT
+              echo "release_branch=release/$VERSION" >> $GITHUB_OUTPUT
+            fi
           fi
           echo "Extracted version: $VERSION"
 
       - name: Detect runtime upgrade
         id: detect_upgrade
         run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "is_runtime_upgrade=${{ inputs.is_runtime_upgrade }}" >> $GITHUB_OUTPUT
           # If version contains a dash after the numbers, it's a runtime upgrade
-          if [[ "${{ steps.extract_version.outputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z0-9] ]]; then
+          elif [[ "${{ steps.extract_version.outputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z0-9] ]]; then
             echo "is_runtime_upgrade=true" >> $GITHUB_OUTPUT
           else
             echo "is_runtime_upgrade=false" >> $GITHUB_OUTPUT
@@ -60,8 +94,17 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a "${{ steps.extract_version.outputs.version }}" -m "Automate release for ${{ steps.extract_version.outputs.version }}"
-          git push origin "${{ steps.extract_version.outputs.version }}"
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" > /dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping creation"
+            exit 0
+          fi
+          TARGET_REF="HEAD"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TARGET_REF="origin/${{ steps.extract_version.outputs.release_branch }}"
+          fi
+          git tag -a "$VERSION" -m "Automate release for $VERSION" "$TARGET_REF"
+          git push origin "$VERSION"
 
   build-and-release:
     name: Build & Release


### PR DESCRIPTION
## Why

The `v0.8.0-exodus` release run ([29984561572](https://github.com/Quantus-Network/chain/actions/runs/29984561572)) created the tag but no GitHub release. Root cause: the `x86_64-pc-windows-msvc` leg fails to compile `frame-support` because `docify::embed!` (0.2.9) panics on Windows with `internal error: entered unreachable code` ([upstream docify issue #5](https://github.com/sam0x17/docify/issues/5)). With default `fail-fast: true`, that canceled the four healthy legs mid-build, so no binary artifacts were uploaded and `create-github-release` was skipped. `v0.7.2-full-moon` failed the same way.

## Changes

- **Drop `x86_64-pc-windows-msvc`** from the release matrix (cherry-picked from the prepared `ci/drop-windows-release-target` branch). Re-add only once docify builds on Windows.
- **`fail-fast: false`** on the build matrix, so one platform's failure no longer cancels the others and leaves a dangling tag.
- **`workflow_dispatch` retry path** in `quantus-release.yml`: inputs `version`, `is_runtime_upgrade`, `release_branch`, `is_draft`. Tag creation is now idempotent (skipped when the tag already exists), so a release can be re-published for an existing tag — previously there was no recovery path at all.
- Same hardening in `quantus-hotfix-release.yml` (fail-fast, drop Windows, and replace the retired `macos-13` runner with `macos-15-intel`).

## After merge

Re-publish the dangling `v0.8.0-exodus` release with:

```
gh workflow run quantus-release.yml   -f version=v0.8.0-exodus   -f is_runtime_upgrade=true   -f release_branch=release/v0.8.0-exodus   -f is_draft=false
```

The same can be done for `v0.7.2-full-moon` if desired.