### PR TITLE
Automate release for v0.8.0-exodus

### DIFF
--- a/docs/release-notes/v0.8.0-exodus.md
+++ b/docs/release-notes/v0.8.0-exodus.md
@@ -1,0 +1,13 @@
+# v0.8.0-exodus
+
+Runtime upgrade — `spec_version` **136**.
+
+This re-publishes the `v0.8.0-exodus` release. The original release run
+([29984561572](https://github.com/Quantus-Network/chain/actions/runs/29984561572))
+created the tag but produced no GitHub release: the `x86_64-pc-windows-msvc`
+build leg failed because `docify::embed!` (docify_macros 0.2.9) panics on
+Windows CRLF checkouts, and with `fail-fast` that cancelled the other platforms
+and skipped the publish job.
+
+Fixed in #625 by pinning Rust sources to LF (`.gitattributes`), so the Windows
+build compiles and the full matrix + runtime wasm publish normally.


### PR DESCRIPTION
## Purpose

Re-fire the **Release Tag & Publish** workflow for `v0.8.0-exodus`, which previously created a tag but no release (Windows CRLF build failure, now fixed in #625).

Merging this PR (it carries the `release-proposal` label and the version in its title) runs `create-tag` → re-creates the `v0.8.0-exodus` tag at current `main` (which now includes the `.gitattributes` LF fix) → builds all platforms incl. Windows → srtool runtime wasm → publishes the GitHub release with binaries + wasm.

## Why the tag was deleted first

The stale tag pointed at `b4316f8e` (pre-fix, no `.gitattributes`); reusing it would fail the Windows leg again. It's been deleted so `create-tag` recreates it at the fixed commit. `spec_version` stays **136** — this does not go through the release-proposal workflow, so nothing re-increments it.

## Contents

Just release notes (`docs/release-notes/v0.8.0-exodus.md`) — the diff needed to open the PR; no code/version changes.