### PR TITLE
Security hardening for wormhole / ZK-tree metering and commitment paths, plus related leaf-keying and deposit-tracking fixes.

### DIFF
--- a/pallets/mining-rewards/src/mock.rs
+++ b/pallets/mining-rewards/src/mock.rs
@@ -156,10 +156,11 @@ impl qp_wormhole::TransferProofRecorder<sp_core::crypto::AccountId32, u32, u128>
 		from: sp_core::crypto::AccountId32,
 		to: sp_core::crypto::AccountId32,
 		amount: u128,
-	) {
+	) -> bool {
 		RECORDED_PROOFS.with(|proofs| {
 			proofs.borrow_mut().push(RecordedTransferProof { asset_id, from, to, amount });
 		});
+		true
 	}
 
 	fn reveal_address(_account: sp_core::crypto::AccountId32) {}

--- a/pallets/multisig/src/mock.rs
+++ b/pallets/multisig/src/mock.rs
@@ -249,7 +249,8 @@ impl qp_wormhole::TransferProofRecorder<AccountId, u32, Balance> for MockProofRe
 		_from: AccountId,
 		_to: AccountId,
 		_amount: Balance,
-	) {
+	) -> bool {
+		true
 	}
 
 	fn reveal_address(account: AccountId) {

--- a/pallets/reversible-transfers/src/tests/mock.rs
+++ b/pallets/reversible-transfers/src/tests/mock.rs
@@ -239,10 +239,11 @@ impl qp_wormhole::TransferProofRecorder<AccountId, u32, Balance> for MockProofRe
 		from: AccountId,
 		to: AccountId,
 		amount: Balance,
-	) {
+	) -> bool {
 		RECORDED_PROOFS.with(|proofs| {
 			proofs.borrow_mut().push(RecordedTransferProof { asset_id, from, to, amount });
 		});
+		true
 	}
 
 	fn reveal_address(_account: AccountId) {}

--- a/pallets/wormhole/src/benchmarking.rs
+++ b/pallets/wormhole/src/benchmarking.rs
@@ -12,8 +12,9 @@ use qp_wormhole_verifier::{ProofWithPublicInputs, C, F};
 /// This proof is used to benchmark the actual deserialization and verification cost.
 const PRIVATE_BATCH_PROOF_HEX: &str = include_str!("../test-data/private_batch.hex");
 
-/// Maximum number of nullifiers in an private-batch proof (default aggregation size)
-const MAX_NULLIFIERS: u32 = 32;
+/// Maximum number of nullifiers in a private-batch proof: one per leaf proof, derived
+/// from the compiled circuit so the benchmark tracks the `QP_NUM_LEAF_PROOFS` build knob.
+const MAX_NULLIFIERS: u32 = crate::circuit_config::NUM_LEAF_PROOFS as u32;
 
 /// The D const parameter for plonky2 proofs (extension degree = 2)
 const D: usize = 2;

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -1332,8 +1332,24 @@ pub mod pallet {
 			to: <T as Config>::WormholeAccountId,
 			amount: BalanceOf<T>,
 		) {
-			let asset_id_value = asset_id.unwrap_or_default();
-			Self::record_transfer(asset_id_value, &from, &to, amount);
+			// The wormhole tags native leaves with `asset_id == 0`, but `pallet_assets` uses
+			// id 0 for an unrelated, independently-mintable token. Genuine native reaches us as
+			// `None` (from `Balances` events); a `pallet_assets` asset-0 credit reaches us as
+			// `Some(0)` (from `Assets::Issued`). These must not be conflated: a `Some(0)` credit
+			// is backed by no native, so recording it as a native deposit would inflate the
+			// native potential-balance pool and insert a natively-exitable leaf, letting an
+			// asset-0 issuer mint unbacked native out of the wormhole.
+			match asset_id {
+				// Native token.
+				None => Self::record_transfer(T::AssetId::default(), &from, &to, amount),
+				// A `pallet_assets` asset whose id collides with the reserved native id. The
+				// wormhole only supports native exits, and this is not a native deposit, so it
+				// must not touch native accounting — drop it.
+				Some(id) if id == T::AssetId::default() => {},
+				// A genuine non-native asset: recorded as an inert (non-native, never-exitable)
+				// leaf, preserving the existing behaviour for future asset-wormhole support.
+				Some(id) => Self::record_transfer(id, &from, &to, amount),
+			}
 		}
 
 		fn reveal_address(account: <T as Config>::WormholeAccountId) {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -368,6 +368,10 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// Override system AccountId for wormhole operations
+		///
+		/// The `AsRef<[u8]>`/`From<[u8; 32]>` bounds allow `record_transfer` to
+		/// canonicalize recipients (reduce each 8-byte limb mod the Goldilocks prime)
+		/// before keying `TransferCount` and inserting ZK-tree leaves.
 		type WormholeAccountId: Parameter
 			+ Member
 			+ MaybeSerializeDeserialize
@@ -375,6 +379,8 @@ pub mod pallet {
 			+ MaybeDisplay
 			+ Ord
 			+ MaxEncodedLen
+			+ AsRef<[u8]>
+			+ From<[u8; 32]>
 			+ Into<<Self as frame_system::Config>::AccountId>
 			+ From<<Self as frame_system::Config>::AccountId>;
 
@@ -393,6 +399,11 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, [u8; 32], bool, ValueQuery>;
 
 	/// Transfer count per recipient - used to generate unique leaf indices in the ZK trie.
+	///
+	/// Keyed on the *canonical* recipient (each 8-byte limb reduced mod the Goldilocks
+	/// prime, matching the ZK leaf encoding — see `canonical_leaf_recipient`), so that a
+	/// recipient and its non-canonical byte aliases share one count sequence and two
+	/// distinct deposits can never commit to identical leaves.
 	#[pallet::storage]
 	#[pallet::getter(fn transfer_count)]
 	pub type TransferCount<T: Config> =
@@ -1217,6 +1228,22 @@ pub mod pallet {
 			}
 		}
 
+		/// Canonical form of a recipient for ZK-leaf keying.
+		///
+		/// Reduces each 8-byte limb of the 32-byte account mod the Goldilocks prime —
+		/// the exact reduction the leaf hash's lossy encoding applies — so that
+		/// `TransferCount` and the stored leaf recipient are keyed per leaf-encoding
+		/// class rather than per raw byte string. The withdrawal circuit binds the
+		/// leaf's recipient felts to a canonical Poseidon output, so canonicalizing
+		/// never changes who can exit a leaf. Non-32-byte accounts are returned
+		/// unchanged (the leaf hash requires 32-byte accounts anyway).
+		fn canonical_leaf_recipient(to: &T::WormholeAccountId) -> T::WormholeAccountId {
+			match <[u8; 32]>::try_from(to.as_ref()) {
+				Ok(bytes) => pallet_zk_tree::tree::canonicalize_account_bytes(bytes).into(),
+				Err(_) => to.clone(),
+			}
+		}
+
 		/// Record a transfer in the ZK tree and emit events.
 		///
 		/// This inserts the transfer data into the 4-ary Poseidon Merkle tree
@@ -1230,15 +1257,27 @@ pub mod pallet {
 			to: &<T as Config>::WormholeAccountId,
 			amount: BalanceOf<T>,
 		) {
-			let current_count = TransferCount::<T>::get(to);
+			// The ZK leaf commits to the recipient through a lossy encoding that reduces
+			// each 8-byte limb mod the Goldilocks prime, so a recipient and its
+			// non-canonical byte aliases encode identically. Key the transfer count and
+			// the stored leaf on the canonical form so every deposit gets a unique
+			// (recipient-class, count) pair — otherwise a deposit to an alias would start
+			// its own count at 0 and could commit to the same leaf (and thus the same
+			// `H(secret, transfer_count)` nullifier) as a canonical deposit, leaving one
+			// of the two permanently unexitable.
+			let leaf_to = Self::canonical_leaf_recipient(to);
+			let current_count = TransferCount::<T>::get(&leaf_to);
 
 			// Increment transfer count for this recipient
-			TransferCount::<T>::insert(to, current_count.saturating_add(T::TransferCount::one()));
+			TransferCount::<T>::insert(
+				&leaf_to,
+				current_count.saturating_add(T::TransferCount::one()),
+			);
 
 			// Insert into ZK tree for Merkle proof generation
 			// Returns the leaf index for clients to use when fetching proofs
 			let leaf_index = T::ZkTree::record_transfer(
-				to.clone().into(),
+				leaf_to.into(),
 				current_count.into(),
 				asset_id.clone(),
 				amount,

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -228,11 +228,15 @@ pub mod pallet {
 
 	/// Current storage version of the pallet.
 	///
-	/// v1 introduces the wormhole soundness counters (`PotentialWormholeBalance` and
-	/// `TotalWormholeExits`). The v0 -> v1 migration seeds `PotentialWormholeBalance` so
-	/// that wormhole deposits made before the soundness tracking existed can still be
-	/// exited (see `migrations::v1`).
-	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	/// - v1 introduces the wormhole soundness counters (`PotentialWormholeBalance` and
+	///   `TotalWormholeExits`). The v0 -> v1 migration seeds `PotentialWormholeBalance` so that
+	///   wormhole deposits made before the soundness tracking existed can still be exited (see
+	///   `migrations::v1`).
+	/// - v2 re-keys `TransferCount` onto the Goldilocks-canonical recipient form. The v1 -> v2
+	///   migration merges any pre-upgrade raw-keyed entries into their canonical key (see
+	///   `migrations::v2`) so prospective deposits cannot restart a count sequence that collides
+	///   with pre-upgrade leaves.
+	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -1422,7 +1426,16 @@ pub mod pallet {
 				// A `pallet_assets` asset whose id collides with the reserved native id. The
 				// wormhole only supports native exits, and this is not a native deposit, so it
 				// must not touch native accounting — drop it.
-				Some(id) if id == T::AssetId::default() => false,
+				Some(id) if id == T::AssetId::default() => {
+					log::warn!(
+						target: "runtime::wormhole",
+						"Dropping pallet_assets asset-0 credit (not native): from={:?} to={:?} amount={:?}",
+						from,
+						to,
+						amount,
+					);
+					false
+				},
 				// A genuine non-native asset: recorded as an inert (non-native, never-exitable)
 				// leaf, preserving the existing behaviour for future asset-wormhole support.
 				Some(id) => {

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -639,21 +639,20 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 
-			// Full validation including ZK verification (defense-in-depth, also done in
-			// validate_unsigned). Weight returned depends on which stage failed.
-			let (bundle, _) = match Self::validate_private_batch_proof(&proof_bytes) {
+			// The ZK verification is the block-inclusion gate in `ValidateUnsigned::pre_dispatch`,
+			// which always runs before this dispatch for a bare (unsigned) extrinsic and rejects
+			// any proof that fails to verify. This body therefore only re-runs the cheap
+			// pre-validation to recover the bundle before processing — re-verifying here would
+			// double the ZK-verify cost while the declared weight only accounts for one verify.
+			let (_, _, bundle, _) = match Self::pre_validate_private_batch_proof(&proof_bytes) {
 				Ok(result) => result,
 				Err(e) => {
-					// Determine weight based on which stage failed
-					let actual_weight = match e {
-						// ZK verification was attempted - full weight consumed
-						Error::<T>::ProofVerificationFailed =>
-							Some(<T as Config>::WeightInfo::verify_private_batch()),
-						// Failed before ZK verification - minimal weight
-						_ => Some(<T as Config>::WeightInfo::pre_validate_proof()),
-					};
+					// Only cheap pre-validation runs here, so any failure is pre-verify work.
 					return Err(DispatchErrorWithPostInfo {
-						post_info: PostDispatchInfo { actual_weight, pays_fee: Pays::No },
+						post_info: PostDispatchInfo {
+							actual_weight: Some(<T as Config>::WeightInfo::pre_validate_proof()),
+							pays_fee: Pays::No,
+						},
 						error: e.into(),
 					});
 				},
@@ -677,16 +676,18 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 
-			let (bundle, _) = match Self::validate_public_batch_proof(&proof_bytes) {
+			// ZK verification is the block-inclusion gate in `pre_dispatch` (see
+			// `verify_private_batch`); this body only re-runs the cheap pre-validation.
+			let (_, _, bundle, _) = match Self::pre_validate_public_batch_proof(&proof_bytes) {
 				Ok(result) => result,
 				Err(e) => {
-					let actual_weight = match e {
-						Error::<T>::ProofVerificationFailed =>
-							Some(<T as Config>::WeightInfo::verify_public_batch()),
-						_ => Some(<T as Config>::WeightInfo::pre_validate_public_batch_proof()),
-					};
 					return Err(DispatchErrorWithPostInfo {
-						post_info: PostDispatchInfo { actual_weight, pays_fee: Pays::No },
+						post_info: PostDispatchInfo {
+							actual_weight: Some(
+								<T as Config>::WeightInfo::pre_validate_public_batch_proof(),
+							),
+							pays_fee: Pays::No,
+						},
 						error: e.into(),
 					});
 				},
@@ -1027,10 +1028,16 @@ pub mod pallet {
 		type Call = Call<T>;
 
 		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+			// Pool admission runs on every gossiped transaction, so it deliberately performs
+			// only the cheap pre-validation (deserialize, parse, bundle checks) and NOT the
+			// expensive ZK verification. The full verify is the block-inclusion gate in
+			// `pre_dispatch`; deferring it here prevents unsigned, fee-free traffic from
+			// forcing unbounded verification work per gossiped byte-variant of a proof.
 			match call {
 				Call::verify_private_batch { proof_bytes } => {
-					let (bundle, validity) = Self::validate_private_batch_proof(proof_bytes)
-						.map_err(|_| InvalidTransaction::Call)?;
+					let (_, _, bundle, validity) =
+						Self::pre_validate_private_batch_proof(proof_bytes)
+							.map_err(|_| InvalidTransaction::Call)?;
 
 					let total_amount: u64 = bundle
 						.segments
@@ -1042,15 +1049,16 @@ pub mod pallet {
 						.sum();
 
 					ValidTransaction::with_tag_prefix("WormholePrivateBatch")
-						.and_provides(sp_io::hashing::blake2_256(proof_bytes))
+						.and_provides(Self::exit_bundle_provides_tag(&bundle))
 						.priority(total_amount)
 						.longevity(5)
 						.propagate(true)
 						.build()
 				},
 				Call::verify_public_batch { proof_bytes } => {
-					let (bundle, validity) = Self::validate_public_batch_proof(proof_bytes)
-						.map_err(|_| InvalidTransaction::Call)?;
+					let (_, _, bundle, validity) =
+						Self::pre_validate_public_batch_proof(proof_bytes)
+							.map_err(|_| InvalidTransaction::Call)?;
 
 					// Inert (dummy-padded) segments are already `false` in `validity`,
 					// so filtering on validity alone excludes them.
@@ -1064,7 +1072,7 @@ pub mod pallet {
 						.sum();
 
 					ValidTransaction::with_tag_prefix("WormholePublicBatch")
-						.and_provides(sp_io::hashing::blake2_256(proof_bytes))
+						.and_provides(Self::exit_bundle_provides_tag(&bundle))
 						.priority(total_amount)
 						.longevity(5)
 						.propagate(true)
@@ -1075,10 +1083,22 @@ pub mod pallet {
 		}
 
 		fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
-			// Skip re-validation - validate_unsigned already did full verification,
-			// and dispatch will verify again as defense-in-depth
+			// Block-inclusion gate. Unlike `validate_unsigned` (pool admission), this runs
+			// the FULL validation including ZK verification, and returning `Err` here
+			// excludes the transaction from the block being built (and makes a block that
+			// includes an unverifiable proof invalid on import). This is what keeps
+			// unverified/junk proofs out of blocks now that pool admission is verify-free.
 			match call {
-				Call::verify_private_batch { .. } | Call::verify_public_batch { .. } => Ok(()),
+				Call::verify_private_batch { proof_bytes } => Self::validate_private_batch_proof(
+					proof_bytes,
+				)
+				.map(|_| ())
+				.map_err(|_| InvalidTransaction::Call.into()),
+				Call::verify_public_batch { proof_bytes } => Self::validate_public_batch_proof(
+					proof_bytes,
+				)
+				.map(|_| ())
+				.map_err(|_| InvalidTransaction::Call.into()),
 				_ => Err(InvalidTransaction::Call.into()),
 			}
 		}
@@ -1105,10 +1125,21 @@ pub mod pallet {
 			Ok(validity)
 		}
 
-		/// Validate a private-batch proof (cheap checks + full ZK verification).
-		fn validate_private_batch_proof(
+		/// Cheap pre-validation of a private-batch proof: deserialize, parse public
+		/// inputs, and run the cheap bundle checks — but **not** the expensive ZK
+		/// verification. Returns the verifier and deserialized proof (so a caller can
+		/// optionally run the ZK verify), plus the parsed bundle and per-segment validity.
+		///
+		/// This is the work performed on the transaction-pool admission path
+		/// (`validate_unsigned`), where running the full ZK verify would let unsigned,
+		/// fee-free traffic force unbounded verification work per gossiped proof. The
+		/// full verification is deferred to the block-inclusion gate (`pre_dispatch`).
+		fn pre_validate_private_batch_proof(
 			proof_bytes: &[u8],
-		) -> Result<(ExitBundle, Vec<bool>), Error<T>> {
+		) -> Result<
+			(&'static crate::WormholeVerifier, ProofWithPublicInputs<F, C, D>, ExitBundle, Vec<bool>),
+			Error<T>,
+		> {
 			let verifier = crate::get_private_batch_verifier()
 				.map_err(|_| Error::<T>::VerifierNotAvailable)?;
 			let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
@@ -1122,6 +1153,16 @@ pub mod pallet {
 
 			let validity = Self::validate_exit_bundle_common(&bundle)?;
 
+			Ok((verifier, proof, bundle, validity))
+		}
+
+		/// Validate a private-batch proof (cheap checks + full ZK verification).
+		fn validate_private_batch_proof(
+			proof_bytes: &[u8],
+		) -> Result<(ExitBundle, Vec<bool>), Error<T>> {
+			let (verifier, proof, bundle, validity) =
+				Self::pre_validate_private_batch_proof(proof_bytes)?;
+
 			verifier.verify(proof).map_err(|e| {
 				log::error!("Private-batch proof verification failed: {:?}", e);
 				Error::<T>::ProofVerificationFailed
@@ -1130,10 +1171,14 @@ pub mod pallet {
 			Ok((bundle, validity))
 		}
 
-		/// Validate a public-batch proof (cheap checks + full ZK verification).
-		fn validate_public_batch_proof(
+		/// Cheap pre-validation of a public-batch proof (no ZK verify). See
+		/// [`Self::pre_validate_private_batch_proof`].
+		fn pre_validate_public_batch_proof(
 			proof_bytes: &[u8],
-		) -> Result<(ExitBundle, Vec<bool>), Error<T>> {
+		) -> Result<
+			(&'static crate::WormholeVerifier, ProofWithPublicInputs<F, C, D>, ExitBundle, Vec<bool>),
+			Error<T>,
+		> {
 			let verifier =
 				crate::get_public_batch_verifier().map_err(|_| Error::<T>::VerifierNotAvailable)?;
 			let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
@@ -1155,12 +1200,38 @@ pub mod pallet {
 
 			let validity = Self::validate_exit_bundle_common(&bundle)?;
 
+			Ok((verifier, proof, bundle, validity))
+		}
+
+		/// Validate a public-batch proof (cheap checks + full ZK verification).
+		fn validate_public_batch_proof(
+			proof_bytes: &[u8],
+		) -> Result<(ExitBundle, Vec<bool>), Error<T>> {
+			let (verifier, proof, bundle, validity) =
+				Self::pre_validate_public_batch_proof(proof_bytes)?;
+
 			verifier.verify(proof).map_err(|e| {
 				log::error!("Public-batch proof verification failed: {:?}", e);
 				Error::<T>::ProofVerificationFailed
 			})?;
 
 			Ok((bundle, validity))
+		}
+
+		/// Stable, semantic transaction-pool dedup tag for an exit bundle: a hash of the
+		/// bundle's nullifiers. Two encodings of the same logical exit (e.g. a proof
+		/// resubmitted with a mutated non-PI byte) share nullifiers and therefore collide
+		/// on this tag, so the pool holds one entry per logical exit instead of one per
+		/// distinct byte string (which `blake2_256(proof_bytes)` allowed an attacker to
+		/// bypass with a single-byte change).
+		fn exit_bundle_provides_tag(bundle: &ExitBundle) -> [u8; 32] {
+			let mut preimage = Vec::new();
+			for segment in &bundle.segments {
+				for nullifier in &segment.nullifiers {
+					preimage.extend_from_slice(nullifier.as_ref());
+				}
+			}
+			sp_io::hashing::blake2_256(&preimage)
 		}
 
 		/// Whether `account` is "ambiguous": it has never signed a transaction (`nonce == 0`) and

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -1089,16 +1089,14 @@ pub mod pallet {
 			// includes an unverifiable proof invalid on import). This is what keeps
 			// unverified/junk proofs out of blocks now that pool admission is verify-free.
 			match call {
-				Call::verify_private_batch { proof_bytes } => Self::validate_private_batch_proof(
-					proof_bytes,
-				)
-				.map(|_| ())
-				.map_err(|_| InvalidTransaction::Call.into()),
-				Call::verify_public_batch { proof_bytes } => Self::validate_public_batch_proof(
-					proof_bytes,
-				)
-				.map(|_| ())
-				.map_err(|_| InvalidTransaction::Call.into()),
+				Call::verify_private_batch { proof_bytes } =>
+					Self::validate_private_batch_proof(proof_bytes)
+						.map(|_| ())
+						.map_err(|_| InvalidTransaction::Call.into()),
+				Call::verify_public_batch { proof_bytes } =>
+					Self::validate_public_batch_proof(proof_bytes)
+						.map(|_| ())
+						.map_err(|_| InvalidTransaction::Call.into()),
 				_ => Err(InvalidTransaction::Call.into()),
 			}
 		}
@@ -1137,7 +1135,12 @@ pub mod pallet {
 		fn pre_validate_private_batch_proof(
 			proof_bytes: &[u8],
 		) -> Result<
-			(&'static crate::WormholeVerifier, ProofWithPublicInputs<F, C, D>, ExitBundle, Vec<bool>),
+			(
+				&'static crate::WormholeVerifier,
+				ProofWithPublicInputs<F, C, D>,
+				ExitBundle,
+				Vec<bool>,
+			),
 			Error<T>,
 		> {
 			let verifier = crate::get_private_batch_verifier()
@@ -1176,7 +1179,12 @@ pub mod pallet {
 		fn pre_validate_public_batch_proof(
 			proof_bytes: &[u8],
 		) -> Result<
-			(&'static crate::WormholeVerifier, ProofWithPublicInputs<F, C, D>, ExitBundle, Vec<bool>),
+			(
+				&'static crate::WormholeVerifier,
+				ProofWithPublicInputs<F, C, D>,
+				ExitBundle,
+				Vec<bool>,
+			),
 			Error<T>,
 		> {
 			let verifier =

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -1405,7 +1405,7 @@ pub mod pallet {
 			from: <T as Config>::WormholeAccountId,
 			to: <T as Config>::WormholeAccountId,
 			amount: BalanceOf<T>,
-		) {
+		) -> bool {
 			// The wormhole tags native leaves with `asset_id == 0`, but `pallet_assets` uses
 			// id 0 for an unrelated, independently-mintable token. Genuine native reaches us as
 			// `None` (from `Balances` events); a `pallet_assets` asset-0 credit reaches us as
@@ -1415,14 +1415,20 @@ pub mod pallet {
 			// asset-0 issuer mint unbacked native out of the wormhole.
 			match asset_id {
 				// Native token.
-				None => Self::record_transfer(T::AssetId::default(), &from, &to, amount),
+				None => {
+					Self::record_transfer(T::AssetId::default(), &from, &to, amount);
+					true
+				},
 				// A `pallet_assets` asset whose id collides with the reserved native id. The
 				// wormhole only supports native exits, and this is not a native deposit, so it
 				// must not touch native accounting — drop it.
-				Some(id) if id == T::AssetId::default() => {},
+				Some(id) if id == T::AssetId::default() => false,
 				// A genuine non-native asset: recorded as an inert (non-native, never-exitable)
 				// leaf, preserving the existing behaviour for future asset-wormhole support.
-				Some(id) => Self::record_transfer(id, &from, &to, amount),
+				Some(id) => {
+					Self::record_transfer(id, &from, &to, amount);
+					true
+				},
 			}
 		}
 

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -16,6 +16,17 @@ use qp_wormhole_verifier::{
 /// (see `PrivateBatchPublicInputs::try_from_u64_slice` in `qp-wormhole-inputs`).
 const PRIVATE_BATCH_PI_HEADER_FELTS: usize = 8;
 
+/// Fixed transaction-pool priority for unsigned wormhole exit submissions.
+///
+/// Must not be derived from public-input amounts: pool admission
+/// (`validate_unsigned`) only runs cheap pre-validation, so those amounts are
+/// attacker-controlled. Combined with the nullifier-based `provides` tag, an
+/// amount-derived priority would let junk with inflated PIs usurp a victim's
+/// same-tag exit (the pool replaces on strictly higher priority). A constant
+/// makes first-seen win; amount-based ordering is not needed for `Pays::No`
+/// exit traffic.
+pub const UNSIGNED_EXIT_PRIORITY: u64 = 1;
+
 /// Expected public-input count of the private-batch circuit compiled into this runtime.
 fn private_batch_expected_public_inputs() -> usize {
 	PRIVATE_BATCH_PI_HEADER_FELTS + circuit_config::NUM_LEAF_PROOFS * PUBLIC_INPUTS_FELTS_LEN
@@ -1035,45 +1046,29 @@ pub mod pallet {
 			// forcing unbounded verification work per gossiped byte-variant of a proof.
 			match call {
 				Call::verify_private_batch { proof_bytes } => {
-					let (_, _, bundle, validity) =
+					// `validity` is computed for its side-effect of rejecting
+					// wholly-unspendable / all-dummy bundles via the cheap checks;
+					// priority must not read amounts from it (see UNSIGNED_EXIT_PRIORITY).
+					let (_, _, bundle, _validity) =
 						Self::pre_validate_private_batch_proof(proof_bytes)
 							.map_err(|_| InvalidTransaction::Call)?;
 
-					let total_amount: u64 = bundle
-						.segments
-						.iter()
-						.zip(validity.iter())
-						.filter(|(_, valid)| **valid)
-						.flat_map(|(segment, _)| segment.account_data.iter())
-						.map(|a| a.summed_output_amount as u64)
-						.sum();
-
 					ValidTransaction::with_tag_prefix("WormholePrivateBatch")
 						.and_provides(Self::exit_bundle_provides_tag(&bundle))
-						.priority(total_amount)
+						.priority(crate::UNSIGNED_EXIT_PRIORITY)
 						.longevity(5)
 						.propagate(true)
 						.build()
 				},
 				Call::verify_public_batch { proof_bytes } => {
-					let (_, _, bundle, validity) =
+					// Same as the private-batch path: cheap checks only, fixed priority.
+					let (_, _, bundle, _validity) =
 						Self::pre_validate_public_batch_proof(proof_bytes)
 							.map_err(|_| InvalidTransaction::Call)?;
 
-					// Inert (dummy-padded) segments are already `false` in `validity`,
-					// so filtering on validity alone excludes them.
-					let total_amount: u64 = bundle
-						.segments
-						.iter()
-						.zip(validity.iter())
-						.filter(|(_, valid)| **valid)
-						.flat_map(|(segment, _)| segment.account_data.iter())
-						.map(|a| a.summed_output_amount as u64)
-						.sum();
-
 					ValidTransaction::with_tag_prefix("WormholePublicBatch")
 						.and_provides(Self::exit_bundle_provides_tag(&bundle))
-						.priority(total_amount)
+						.priority(crate::UNSIGNED_EXIT_PRIORITY)
 						.longevity(5)
 						.propagate(true)
 						.build()

--- a/pallets/wormhole/src/migrations.rs
+++ b/pallets/wormhole/src/migrations.rs
@@ -2,15 +2,13 @@
 
 extern crate alloc;
 
-use crate::{Config, Pallet, PotentialWormholeBalance};
+use crate::{Config, Pallet, PotentialWormholeBalance, TransferCount};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use frame_support::{
 	traits::{Currency, Get, UncheckedOnRuntimeUpgrade},
 	weights::Weight,
 };
-
-#[cfg(feature = "try-runtime")]
-use alloc::vec::Vec;
 
 /// v0 -> v1: introduce the wormhole soundness counters.
 pub mod v1 {
@@ -68,6 +66,117 @@ pub type MigrateV0ToV1<T> = frame_support::migrations::VersionedMigration<
 	0,
 	1,
 	v1::InitSoundnessCounters<T>,
+	Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;
+
+/// v1 -> v2: re-key `TransferCount` onto the Goldilocks-canonical recipient form.
+pub mod v2 {
+	use super::*;
+	use pallet_zk_tree::tree::canonicalize_account_bytes;
+
+	fn max_count<T: Config>(a: T::TransferCount, b: T::TransferCount) -> T::TransferCount {
+		if a.into() >= b.into() {
+			a
+		} else {
+			b
+		}
+	}
+
+	/// Merges any pre-upgrade `TransferCount` entries keyed on non-canonical recipients into
+	/// their canonical key (max of the counts), then removes the raw keys.
+	///
+	/// Prospective `record_transfer` calls key on the canonical form. Without this merge, a
+	/// pre-upgrade deposit to a non-canonical alias leaves count state under the raw key while
+	/// post-upgrade deposits to that leaf-encoding class restart from the (empty) canonical
+	/// key — recreating the leaf/nullifier collision the canonical re-keying was meant to
+	/// fix. Taking the max count ensures the next deposit uses a fresh index past every
+	/// already-committed leaf in the class. Already-colliding pre-upgrade leaves (if any)
+	/// cannot be rewritten here; this only prevents *new* collisions.
+	pub struct CanonicalizeTransferCountKeys<T>(PhantomData<T>);
+
+	impl<T: Config> UncheckedOnRuntimeUpgrade for CanonicalizeTransferCountKeys<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut reads: u64 = 0;
+			let mut writes: u64 = 0;
+			let mut merged: u64 = 0;
+
+			// Collect first — mutating the map while iterating is unsafe.
+			let mut aliases: Vec<(T::WormholeAccountId, T::TransferCount)> = Vec::new();
+			for (key, count) in TransferCount::<T>::iter() {
+				reads = reads.saturating_add(1);
+				let Ok(bytes) = <[u8; 32]>::try_from(key.as_ref()) else {
+					continue;
+				};
+				let canonical = canonicalize_account_bytes(bytes);
+				if canonical != bytes {
+					aliases.push((key, count));
+				}
+			}
+
+			for (raw_key, raw_count) in aliases {
+				let Ok(bytes) = <[u8; 32]>::try_from(raw_key.as_ref()) else {
+					continue;
+				};
+				let canonical_key: T::WormholeAccountId = canonicalize_account_bytes(bytes).into();
+				let existing = TransferCount::<T>::get(&canonical_key);
+				reads = reads.saturating_add(1);
+				let merged_count = max_count::<T>(existing, raw_count);
+				TransferCount::<T>::insert(&canonical_key, merged_count);
+				TransferCount::<T>::remove(&raw_key);
+				writes = writes.saturating_add(2);
+				merged = merged.saturating_add(1);
+			}
+
+			log::info!(
+				target: "runtime::wormhole",
+				"Canonicalized TransferCount keys: merged {} non-canonical entries",
+				merged,
+			);
+
+			T::DbWeight::get().reads_writes(reads, writes)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+			use codec::Encode;
+			let non_canonical = TransferCount::<T>::iter()
+				.filter(|(key, _)| {
+					<[u8; 32]>::try_from(key.as_ref())
+						.map(|bytes| canonicalize_account_bytes(bytes) != bytes)
+						.unwrap_or(false)
+				})
+				.count() as u64;
+			Ok(non_canonical.encode())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			use codec::Decode;
+			let _pre: u64 = u64::decode(&mut &state[..])
+				.map_err(|_| "failed to decode pre_upgrade TransferCount alias count")?;
+			let remaining = TransferCount::<T>::iter()
+				.filter(|(key, _)| {
+					<[u8; 32]>::try_from(key.as_ref())
+						.map(|bytes| canonicalize_account_bytes(bytes) != bytes)
+						.unwrap_or(false)
+				})
+				.count();
+			frame_support::ensure!(
+				remaining == 0,
+				"TransferCount must have no non-canonical keys after v2 migration"
+			);
+			Ok(())
+		}
+	}
+}
+
+/// Versioned v1 -> v2 migration. Runs [`v2::CanonicalizeTransferCountKeys`] only when the
+/// on-chain storage version is 1, then bumps the on-chain storage version to 2.
+pub type MigrateV1ToV2<T> = frame_support::migrations::VersionedMigration<
+	1,
+	2,
+	v2::CanonicalizeTransferCountKeys<T>,
 	Pallet<T>,
 	<T as frame_system::Config>::DbWeight,
 >;

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -18,6 +18,7 @@ construct_runtime!(
 		System: frame_system,
 		Balances: pallet_balances,
 		Assets: pallet_assets,
+		ZkTree: pallet_zk_tree,
 		Wormhole: pallet_wormhole,
 	}
 );
@@ -145,6 +146,11 @@ impl frame_support::traits::Contains<AccountId> for ExcludedAccounts {
 	}
 }
 
+impl pallet_zk_tree::Config for Test {
+	type AssetId = u32;
+	type Balance = Balance;
+}
+
 impl pallet_wormhole::Config for Test {
 	type NativeBalance = Balance;
 	type Currency = Balances;
@@ -160,7 +166,9 @@ impl pallet_wormhole::Config for Test {
 	type VolumeFeesAggregatorRate = VolumeFeesAggregatorRate;
 	type WormholeAccountId = AccountId;
 	type WeightInfo = crate::weights::SubstrateWeight<Test>;
-	type ZkTree = (); // Disabled in tests - use () no-op implementation
+	// Real ZK tree so tests exercise the actual leaf hashing (e.g. the
+	// recipient-canonicalization invariant), not the no-op recorder.
+	type ZkTree = ZkTree;
 }
 
 // Helper function to build a genesis configuration

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -808,6 +808,109 @@ mod private_batch_proof_tests {
 		});
 	}
 
+	/// Sets up the on-chain block state so the test proof's cheap bundle checks pass.
+	fn setup_valid_block_state_for_test_proof() {
+		let proof = deserialize_test_proof();
+		let inputs = parse_private_batch_public_inputs(&proof).expect("Should parse");
+		let block_number = inputs.block_data.block_number as u64;
+		let block_hash_bytes: [u8; 32] = inputs.block_data.block_hash.as_ref().try_into().unwrap();
+		frame_system::BlockHash::<Test>::insert(block_number, H256::from(block_hash_bytes));
+		System::set_block_number(block_number + 10);
+		PotentialWormholeBalance::<Test>::put(1_000_000 * UNIT);
+	}
+
+	/// The block-inclusion gate (`pre_dispatch`) must reject a proof that cannot be
+	/// verified. Before this was fixed, `pre_dispatch` was a no-op that returned `Ok(())`
+	/// for any `verify_*` call, so junk rode into blocks as failed `Pays::No` extrinsics;
+	/// this assertion is red against that old behavior.
+	#[test]
+	fn pre_dispatch_rejects_unverifiable_proof() {
+		use sp_runtime::traits::ValidateUnsigned;
+
+		new_test_ext().execute_with(|| {
+			let call = crate::Call::<Test>::verify_private_batch { proof_bytes: vec![0u8; 100] };
+			assert!(
+				<Wormhole as ValidateUnsigned>::pre_dispatch(&call).is_err(),
+				"pre_dispatch must reject an unverifiable proof"
+			);
+		});
+	}
+
+	/// The core of the anti-DoS change: pool admission (`validate_unsigned`) must NOT run
+	/// the expensive ZK verification, while the block-inclusion gate (`pre_dispatch`)
+	/// must. A proof whose public inputs are intact (so the cheap bundle checks pass) but
+	/// whose proof data is corrupted (so ZK verification fails) is therefore *admitted*
+	/// by `validate_unsigned` yet *rejected* by `pre_dispatch`.
+	#[test]
+	fn validate_unsigned_skips_verify_but_pre_dispatch_enforces_it() {
+		use sp_runtime::{traits::ValidateUnsigned, transaction_validity::TransactionSource};
+
+		new_test_ext().execute_with(|| {
+			setup_valid_block_state_for_test_proof();
+
+			// Corrupt the proof data while leaving the public inputs (serialized after the
+			// proof) intact, so the cheap checks still pass but ZK verification fails.
+			let mut tampered = get_test_proof_bytes();
+			for byte in tampered.iter_mut().take(64) {
+				*byte ^= 0xFF;
+			}
+			let call =
+				crate::Call::<Test>::verify_private_batch { proof_bytes: tampered.clone() };
+
+			// Pool admission is verify-free, so it still admits the tampered proof.
+			assert_ok!(<Wormhole as ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&call,
+			));
+
+			// The block-inclusion gate runs the ZK verify and rejects it.
+			assert!(
+				<Wormhole as ValidateUnsigned>::pre_dispatch(&call).is_err(),
+				"pre_dispatch must reject a proof that fails ZK verification"
+			);
+		});
+	}
+
+	/// A valid proof against valid state passes both the pool path and the inclusion gate,
+	/// and the pool dedup tag is derived from the proof's nullifiers (so byte-variants of
+	/// the same logical exit collide instead of each earning a fresh pool entry).
+	#[test]
+	fn validate_unsigned_and_pre_dispatch_accept_valid_proof_with_semantic_tag() {
+		use codec::Encode;
+		use sp_runtime::{traits::ValidateUnsigned, transaction_validity::TransactionSource};
+
+		new_test_ext().execute_with(|| {
+			setup_valid_block_state_for_test_proof();
+
+			let proof = deserialize_test_proof();
+			let inputs = parse_private_batch_public_inputs(&proof).expect("Should parse");
+			let call = crate::Call::<Test>::verify_private_batch {
+				proof_bytes: get_test_proof_bytes(),
+			};
+
+			let valid = <Wormhole as ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&call,
+			)
+			.expect("valid proof must be admitted to the pool");
+			assert!(<Wormhole as ValidateUnsigned>::pre_dispatch(&call).is_ok());
+
+			// The `provides` tag is `(prefix, blake2_256(nullifiers))` — recompute it here
+			// and confirm the pool would dedup on the nullifier set rather than the raw
+			// proof bytes.
+			let mut preimage = Vec::new();
+			for nullifier in &inputs.nullifiers {
+				preimage.extend_from_slice(nullifier.as_ref());
+			}
+			let expected_tag =
+				("WormholePrivateBatch", sp_io::hashing::blake2_256(&preimage)).encode();
+			assert!(
+				valid.provides.contains(&expected_tag),
+				"pool dedup tag must be derived from the bundle nullifiers"
+			);
+		});
+	}
+
 	#[test]
 	fn test_verify_private_batch_emits_miner_volume_fee_paid() {
 		new_test_ext().execute_with(|| {

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -79,10 +79,7 @@ mod wormhole_tests {
 
 			// Genuine native (arrives as `None`) is still recorded and still inflates the pool.
 			<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
-				None,
-				from,
-				to,
-				amount,
+				None, from, to, amount,
 			);
 			assert_eq!(ZkTree::leaf_count(), 1, "a native deposit must insert a leaf");
 			assert_eq!(
@@ -194,8 +191,8 @@ mod wormhole_tests {
 		// pinned constant is circuit-correct, not just self-consistent.
 		let golden_case = (AccountId32::new([0x11u8; 32]), 7u64, 5u32, 1234u32);
 		let golden_hash: [u8; 32] = [
-			195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85,
-			224, 111, 64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
+			195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85, 224,
+			111, 64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
 		];
 		{
 			let (to, transfer_count, asset_id, quantized_amount) = &golden_case;
@@ -221,8 +218,7 @@ mod wormhole_tests {
 				asset_id,
 				// `hash_leaf` quantizes by dividing by AMOUNT_SCALE_DOWN_FACTOR;
 				// the circuit helper takes the already-quantized amount.
-				amount: (quantized_amount as u128) *
-					pallet_zk_tree::tree::AMOUNT_SCALE_DOWN_FACTOR,
+				amount: (quantized_amount as u128) * pallet_zk_tree::tree::AMOUNT_SCALE_DOWN_FACTOR,
 			};
 			let pallet_hash = pallet_zk_tree::tree::hash_leaf::<Test>(&leaf);
 
@@ -854,8 +850,7 @@ mod private_batch_proof_tests {
 			for byte in tampered.iter_mut().take(64) {
 				*byte ^= 0xFF;
 			}
-			let call =
-				crate::Call::<Test>::verify_private_batch { proof_bytes: tampered.clone() };
+			let call = crate::Call::<Test>::verify_private_batch { proof_bytes: tampered.clone() };
 
 			// Pool admission is verify-free, so it still admits the tampered proof.
 			assert_ok!(<Wormhole as ValidateUnsigned>::validate_unsigned(
@@ -884,9 +879,8 @@ mod private_batch_proof_tests {
 
 			let proof = deserialize_test_proof();
 			let inputs = parse_private_batch_public_inputs(&proof).expect("Should parse");
-			let call = crate::Call::<Test>::verify_private_batch {
-				proof_bytes: get_test_proof_bytes(),
-			};
+			let call =
+				crate::Call::<Test>::verify_private_batch { proof_bytes: get_test_proof_bytes() };
 
 			let valid = <Wormhole as ValidateUnsigned>::validate_unsigned(
 				TransactionSource::External,

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -59,12 +59,16 @@ mod wormhole_tests {
 			assert_eq!(Wormhole::potential_wormhole_balance(), 0);
 
 			// A pallet_assets asset-0 mint (arrives as `Some(0)`) must be inert for the
-			// native wormhole: no leaf, no pool inflation.
-			<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
-				Some(0u32),
-				from.clone(),
-				to.clone(),
-				amount,
+			// native wormhole: no leaf, no pool inflation — and must report as not recorded
+			// so weight reconciliation does not treat the drop as a ZK-tree insert.
+			assert!(
+				!<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
+					Some(0u32),
+					from.clone(),
+					to.clone(),
+					amount,
+				),
+				"an asset-0 credit must report as not recorded"
 			);
 			assert_eq!(
 				ZkTree::leaf_count(),
@@ -78,8 +82,11 @@ mod wormhole_tests {
 			);
 
 			// Genuine native (arrives as `None`) is still recorded and still inflates the pool.
-			<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
-				None, from, to, amount,
+			assert!(
+				<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
+					None, from, to, amount,
+				),
+				"a native deposit must report as recorded"
 			);
 			assert_eq!(ZkTree::leaf_count(), 1, "a native deposit must insert a leaf");
 			assert_eq!(

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -49,6 +49,136 @@ mod wormhole_tests {
 		});
 	}
 
+	/// Security regression test (leaf-encoding aliasing).
+	///
+	/// `hash_leaf` encodes the recipient with a lossy 8-byte/felt encoding that reduces
+	/// each limb mod the Goldilocks prime. A "non-canonical alias" of a recipient (some
+	/// limb increased by the prime) therefore encodes to the *same* felts. If the
+	/// transfer-count sequence were keyed on the raw recipient bytes, a deposit to the
+	/// alias would start its own count at 0 and produce a leaf identical to the canonical
+	/// recipient's deposit 0 — the two deposits would then share one nullifier
+	/// (`H(secret, transfer_count)`) and only one of them could ever be exited.
+	///
+	/// This test deposits the same amount to a canonical recipient and to its alias and
+	/// asserts the resulting leaves are distinct.
+	#[test]
+	fn deposits_to_non_canonical_alias_do_not_collide_with_canonical_leaf() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = account_id(1);
+			let amount = 10 * UNIT;
+
+			const GOLDILOCKS_P: u64 = 0xFFFF_FFFF_0000_0001;
+
+			// Canonical recipient: first 8-byte limb small (an alias exists only when a
+			// limb is < 2^32 - 1, so that limb + p still fits in 8 bytes).
+			let mut canonical_bytes = [0x11u8; 32];
+			canonical_bytes[..8].copy_from_slice(&5u64.to_le_bytes());
+			let canonical = AccountId32::new(canonical_bytes);
+
+			// Alias: same account with the first limb increased by the prime. The lossy
+			// leaf encoding reduces it back to 5, so both accounts encode identically.
+			let mut alias_bytes = canonical_bytes;
+			alias_bytes[..8].copy_from_slice(&(5u64 + GOLDILOCKS_P).to_le_bytes());
+			let alias = AccountId32::new(alias_bytes);
+			assert_ne!(canonical, alias);
+
+			Wormhole::record_transfer(0u32, &from, &canonical, amount);
+			Wormhole::record_transfer(0u32, &from, &alias, amount);
+
+			let leaf0 = ZkTree::leaf(0).expect("first deposit must insert a leaf");
+			let leaf1 = ZkTree::leaf(1).expect("second deposit must insert a leaf");
+			let hash0 = pallet_zk_tree::tree::hash_leaf::<Test>(&leaf0);
+			let hash1 = pallet_zk_tree::tree::hash_leaf::<Test>(&leaf1);
+			assert_ne!(
+				hash0, hash1,
+				"a deposit to a non-canonical alias must not produce the same leaf \
+				 (and thus the same nullifier) as a deposit to the canonical recipient"
+			);
+
+			// The alias shares the canonical recipient's count sequence: both deposits
+			// are recorded under the canonical key, and the second leaf continues the
+			// sequence rather than restarting at 0.
+			assert_eq!(Wormhole::transfer_count(&canonical), 2);
+			assert_eq!(Wormhole::transfer_count(&alias), 0);
+			assert_eq!(leaf0.transfer_count, 0);
+			assert_eq!(leaf1.transfer_count, 1);
+
+			// Both leaves store the canonical recipient (what the hash actually
+			// commits to), so leaf data is consistent with the leaf hash.
+			assert_eq!(leaf0.to, canonical);
+			assert_eq!(leaf1.to, canonical);
+		});
+	}
+
+	/// Golden cross-check: the pallet's `hash_leaf` must stay byte-compatible with the
+	/// ZK circuit's leaf hash (`ZkLeafTargets::collect_for_hash`), reproduced here by
+	/// `fixture_gen::compute_zk_leaf_hash` on the real circuit crates. This pins the
+	/// encoding so refactors (e.g. recipient canonicalization) cannot silently change
+	/// the hash of existing canonical leaves.
+	#[test]
+	fn pallet_leaf_hash_matches_circuit_leaf_hash() {
+		// (to, transfer_count, asset_id, quantized_amount). First case uses the
+		// well-known fixture inputs: TEST_ADDRESS = WA([42u8; 32]), count 1, 2000
+		// quantized (the same values the private-batch proof fixture commits to).
+		let cases = [
+			(test_account(), 1u64, 0u32, 2000u32),
+			(account_id(1), 0u64, 0u32, 1000u32),
+			(account_id(424242), 7u64, 5u32, 1u32),
+		];
+
+		// The zk-tree pallet's `hash_leaf_golden_vector` test pins this exact case to a
+		// hardcoded hash; verifying it here against the circuit crates proves that the
+		// pinned constant is circuit-correct, not just self-consistent.
+		let golden_case = (AccountId32::new([0x11u8; 32]), 7u64, 5u32, 1234u32);
+		let golden_hash: [u8; 32] = [
+			195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85,
+			224, 111, 64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
+		];
+		{
+			let (to, transfer_count, asset_id, quantized_amount) = &golden_case;
+			let to_bytes: &[u8; 32] = to.as_ref();
+			assert_eq!(
+				super::fixture_gen::compute_zk_leaf_hash(
+					to_bytes,
+					*transfer_count,
+					*asset_id,
+					*quantized_amount,
+				),
+				golden_hash,
+				"golden vector constant is not circuit-correct"
+			);
+		}
+
+		for (to, transfer_count, asset_id, quantized_amount) in
+			cases.into_iter().chain([golden_case])
+		{
+			let leaf = pallet_zk_tree::ZkLeaf {
+				to: to.clone(),
+				transfer_count,
+				asset_id,
+				// `hash_leaf` quantizes by dividing by AMOUNT_SCALE_DOWN_FACTOR;
+				// the circuit helper takes the already-quantized amount.
+				amount: (quantized_amount as u128) *
+					pallet_zk_tree::tree::AMOUNT_SCALE_DOWN_FACTOR,
+			};
+			let pallet_hash = pallet_zk_tree::tree::hash_leaf::<Test>(&leaf);
+
+			let to_bytes: &[u8; 32] = to.as_ref();
+			let circuit_hash = super::fixture_gen::compute_zk_leaf_hash(
+				to_bytes,
+				transfer_count,
+				asset_id,
+				quantized_amount,
+			);
+
+			assert_eq!(
+				pallet_hash, circuit_hash,
+				"pallet hash_leaf diverged from the circuit leaf hash for {to:?}"
+			);
+		}
+	}
+
 	#[test]
 	fn record_transfer_emits_native_transferred_event() {
 		new_test_ext().execute_with(|| {
@@ -948,8 +1078,11 @@ mod fixture_gen {
 		aggregated_proof
 	}
 
-	/// Helper to compute ZK leaf hash (must match circuit computation)
-	fn compute_zk_leaf_hash(
+	/// Helper to compute ZK leaf hash (must match circuit computation).
+	///
+	/// Also used by `pallet_leaf_hash_matches_circuit_leaf_hash` as the circuit-side
+	/// reference to pin the pallet's `hash_leaf` encoding.
+	pub fn compute_zk_leaf_hash(
 		to_account: &[u8; 32],
 		transfer_count: u64,
 		asset_id: u32,

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -31,6 +31,68 @@ mod wormhole_tests {
 		AccountId32::new(TEST_ADDRESS)
 	}
 
+	/// Security regression test (native/asset-0 conflation).
+	///
+	/// The wormhole tags native leaves with `asset_id == 0`, but `pallet_assets` uses id 0 for
+	/// an unrelated, independently-mintable token. Native deposits reach the recorder as `None`
+	/// (from `Balances` events); a `pallet_assets` asset-0 credit reaches it as `Some(0)` (from
+	/// `Assets::Issued`). These must NOT be conflated: a `Some(0)` credit is not backed by any
+	/// native, so treating it as native would let an asset-0 issuer inflate the native
+	/// `PotentialWormholeBalance` and insert a natively-exitable leaf — minting unbacked native
+	/// out of the wormhole.
+	///
+	/// This asserts that `record_transfer_proof(Some(0), ..)` to an ambiguous recipient neither
+	/// inserts a ZK-tree leaf nor inflates the pool, while genuine native (`None`) still does.
+	#[test]
+	fn asset_zero_credit_is_not_treated_as_native_deposit() {
+		use qp_wormhole::TransferProofRecorder;
+
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let from = account_id(1);
+			// A fresh (nonce 0) recipient that is not excluded: genuinely ambiguous.
+			let to = account_id(9001);
+			assert!(Wormhole::is_ambiguous_account(&to));
+			let amount = 1_000 * UNIT;
+
+			assert_eq!(ZkTree::leaf_count(), 0);
+			assert_eq!(Wormhole::potential_wormhole_balance(), 0);
+
+			// A pallet_assets asset-0 mint (arrives as `Some(0)`) must be inert for the
+			// native wormhole: no leaf, no pool inflation.
+			<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
+				Some(0u32),
+				from.clone(),
+				to.clone(),
+				amount,
+			);
+			assert_eq!(
+				ZkTree::leaf_count(),
+				0,
+				"an asset-0 credit must not insert a native-exitable ZK-tree leaf"
+			);
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				0,
+				"an asset-0 credit must not inflate the native potential-balance pool"
+			);
+
+			// Genuine native (arrives as `None`) is still recorded and still inflates the pool.
+			<Wormhole as TransferProofRecorder<AccountId, u32, u128>>::record_transfer_proof(
+				None,
+				from,
+				to,
+				amount,
+			);
+			assert_eq!(ZkTree::leaf_count(), 1, "a native deposit must insert a leaf");
+			assert_eq!(
+				Wormhole::potential_wormhole_balance(),
+				amount,
+				"a native deposit to an ambiguous recipient must inflate the pool"
+			);
+		});
+	}
+
 	#[test]
 	fn record_transfer_increments_count() {
 		new_test_ext().execute_with(|| {

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -905,6 +905,67 @@ mod private_batch_proof_tests {
 		});
 	}
 
+	/// Pool admission must not derive `priority` from unverified public-input amounts.
+	///
+	/// With verification deferred to `pre_dispatch`, an attacker who sees a victim's
+	/// gossiped exit can mutate the PI amounts (keeping the nullifiers so the semantic
+	/// `provides` tag collides) and submit a higher-priority junk tx that usurps the
+	/// victim's pool slot — the pool replaces same-tag txs only when the newcomer has
+	/// strictly higher priority. A constant priority makes first-seen win and closes
+	/// that free censorship path.
+	#[test]
+	fn validate_unsigned_priority_ignores_unverified_amounts() {
+		use qp_plonky2_verifier::field::types::Field;
+		use sp_runtime::{traits::ValidateUnsigned, transaction_validity::TransactionSource};
+
+		new_test_ext().execute_with(|| {
+			setup_valid_block_state_for_test_proof();
+
+			let original = get_test_proof_bytes();
+			let original_call =
+				crate::Call::<Test>::verify_private_batch { proof_bytes: original.clone() };
+			let original_valid = <Wormhole as ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&original_call,
+			)
+			.expect("valid proof must be admitted");
+
+			// Inflate the first exit-slot amount in the PI section (layout: header of 8
+			// felts, then [sum(1), exit(4)] · 2N). Nullifiers are left untouched so the
+			// semantic provides tag stays identical to the victim's.
+			let mut tampered_proof = deserialize_test_proof();
+			assert!(
+				tampered_proof.public_inputs.len() > 8,
+				"test proof must have exit-slot public inputs"
+			);
+			tampered_proof.public_inputs[8] = F::from_canonical_u32(u32::MAX);
+			let tampered_bytes = tampered_proof.to_bytes();
+			assert_ne!(tampered_bytes, original, "mutation must change the encoded proof");
+
+			let tampered_call =
+				crate::Call::<Test>::verify_private_batch { proof_bytes: tampered_bytes };
+			let tampered_valid = <Wormhole as ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&tampered_call,
+			)
+			.expect("amount-inflated junk still passes cheap pool checks");
+
+			assert_eq!(
+				tampered_valid.provides, original_valid.provides,
+				"same nullifiers must yield the same provides tag"
+			);
+			assert_eq!(
+				tampered_valid.priority, original_valid.priority,
+				"priority must not track unverified PI amounts (else junk can usurp a real exit)"
+			);
+			assert_eq!(
+				original_valid.priority,
+				crate::UNSIGNED_EXIT_PRIORITY,
+				"unsigned exits must use the fixed pool priority"
+			);
+		});
+	}
+
 	#[test]
 	fn test_verify_private_batch_emits_miner_volume_fee_paid() {
 		new_test_ext().execute_with(|| {

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -576,6 +576,50 @@ mod wormhole_tests {
 			);
 		});
 	}
+
+	/// Pre-upgrade `TransferCount` entries keyed on non-canonical recipients must be merged
+	/// into the canonical key (max of the counts) so post-upgrade deposits cannot restart a
+	/// count sequence that collides with already-committed leaves.
+	#[test]
+	fn migration_merges_non_canonical_transfer_count_keys() {
+		use frame_support::traits::UncheckedOnRuntimeUpgrade;
+		use pallet_zk_tree::tree::{canonicalize_account_bytes, GOLDILOCKS_P};
+
+		new_test_ext().execute_with(|| {
+			// Non-canonical: first limb = p + 7 (reduces to 7). Canonical sibling has limb 7.
+			let mut raw_bytes = [0u8; 32];
+			raw_bytes[0..8].copy_from_slice(&(GOLDILOCKS_P + 7).to_le_bytes());
+			let raw = AccountId::from(raw_bytes);
+			let canonical = AccountId::from(canonicalize_account_bytes(raw_bytes));
+			assert_ne!(raw, canonical);
+
+			crate::TransferCount::<Test>::insert(&raw, 5u64);
+			crate::TransferCount::<Test>::insert(&canonical, 3u64);
+
+			crate::migrations::v2::CanonicalizeTransferCountKeys::<Test>::on_runtime_upgrade();
+
+			assert!(
+				!crate::TransferCount::<Test>::contains_key(&raw),
+				"non-canonical TransferCount key must be removed"
+			);
+			assert_eq!(
+				crate::TransferCount::<Test>::get(&canonical),
+				5,
+				"canonical key must keep the max of the alias and canonical counts"
+			);
+
+			// A fresh deposit to either form must continue from the merged count (5), not
+			// restart at 0 under the canonical key.
+			let from = account_id(1);
+			Wormhole::record_transfer(0u32, &from, &canonical, 10 * UNIT);
+			assert_eq!(crate::TransferCount::<Test>::get(&canonical), 6);
+			assert_eq!(
+				crate::TransferCount::<Test>::get(&raw),
+				0,
+				"raw alias must stay empty after merge"
+			);
+		});
+	}
 }
 
 /// Tests for private-batch proof verification

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -162,37 +162,38 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 		Weight::from_parts(685_000_000, proof_size)
 			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// Full private-batch proof verification: ZK verification plus the data-dependent state
-	/// updates that the `verify_private_batch` benchmark intentionally excludes (it only
-	/// measures the ZK verify). Storage is scaled from a calibration of 32 exit mints
-	/// (2 · 16 leaves) to `2 · NUM_LEAF_PROOFS`:
-	/// - `System::BlockHash` (r:1) + `Wormhole::UsedNullifiers` (r:N w:N)
-	/// - `System::Digest` (r:1), `Balances::TotalIssuance` (r:1 w:1)
-	/// - `System::Account` (r:E+1 w:E+1) - exit mints + miner fee
-	/// - `Wormhole::TransferCount` (r:E w:E)
-	/// - `ZkTree` Leaves/Nodes/LeafCount/Depth/Root via `record_transfer`, charged
-	///   per exit at the current tree depth (the walk deepens as the chain ages)
-	/// Keep this augmentation when regenerating.
+	/// Full private-batch proof verification on the inclusion path:
+	/// - `pre_dispatch`: cheap prevalidation + ZK verify
+	/// - dispatch body: cheap prevalidation again (to recover the bundle) + state updates
+	///
+	/// The ZK-verify benchmark is the `16_661_000_000` base (verify + one deserialize).
+	/// Storage is scaled from a calibration of 32 exit mints (2 · 16 leaves) to
+	/// `2 · NUM_LEAF_PROOFS`, plus a second [`Self::pre_validate_proof`] for the dispatch
+	/// body's re-deserialize / nullifier scan (which the base does not cover). Keep this
+	/// augmentation when regenerating.
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
 		// Minimum execution time: 15_336_000_000 picoseconds (ZK verification only).
-		// Adding deserialization (~0.7ms) for total compute ~16.7ms.
+		// Adding one deserialization (~0.7ms) for the pre_dispatch path ~16.7ms; the
+		// second prevalidation (dispatch body) is added explicitly below.
 		Weight::from_parts(16_661_000_000, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_proof())
 	}
-	/// Public-batch ZK verification is heavier than private-batch (recursively verifies
-	/// N inner private-batch proofs). Storage scales with every exit slot across all
-	/// inner segments: `2 · NUM_LEAF_PROOFS · NUM_PRIVATE_BATCH_PROOFS`, plus one
-	/// account touch for the aggregator fee rebate.
+	/// Public-batch inclusion path: same double-prevalidation shape as
+	/// [`Self::verify_private_batch`], with heavier ZK time and storage scaled across
+	/// all inner segments plus the aggregator rebate. The second
+	/// [`Self::pre_validate_public_batch_proof`] covers the dispatch-body re-scan.
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
 		Weight::from_parts(25_000_000_000, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_public_batch_proof())
 	}
 }
 
@@ -213,27 +214,25 @@ impl WeightInfo for () {
 		Weight::from_parts(685_000_000, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// Full private-batch proof verification: ZK verification plus the data-dependent state
-	/// updates that the benchmark excludes. Storage scaled to `2 · NUM_LEAF_PROOFS` exits
-	/// from a 32-exit calibration. This impl has no runtime type to read the live tree
-	/// depth from, so the ZK-tree component is charged at `MAX_TREE_DEPTH` (worst case).
-	/// Keep this augmentation when regenerating.
+	/// See `SubstrateWeight::verify_private_batch`. Tree component priced at
+	/// `MAX_TREE_DEPTH` (no runtime type to read live depth).
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
-		// Minimum execution time: 15_336_000_000 picoseconds (ZK verification only).
-		// Adding deserialization (~0.7ms) for total compute ~16.7ms.
 		Weight::from_parts(16_661_000_000, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_proof())
 	}
+	/// See `SubstrateWeight::verify_public_batch`.
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
 		Weight::from_parts(25_000_000_000, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_public_batch_proof())
 	}
 }
 
@@ -295,6 +294,39 @@ mod tests {
 			let at_max = W::verify_private_batch();
 			let unit = <() as WeightInfo>::verify_private_batch();
 			assert!(unit.proof_size() >= at_max.proof_size());
+		});
+	}
+
+	/// Inclusion runs cheap prevalidation twice (`pre_dispatch` via full validate, then
+	/// again in the dispatch body to recover the bundle). The declared verify weight must
+	/// cover that second prevalidation on top of the ZK+storage base.
+	#[test]
+	fn verify_weights_cover_second_prevalidation() {
+		crate::mock::new_test_ext().execute_with(|| {
+			type W = SubstrateWeight<crate::mock::Test>;
+			pallet_zk_tree::Depth::<crate::mock::Test>::put(1);
+
+			let pre_private = W::pre_validate_proof();
+			let verify_private = W::verify_private_batch();
+			assert!(
+				verify_private.ref_time() >= 16_661_000_000 + pre_private.ref_time(),
+				"private verify must include a second pre_validate_proof compute cost"
+			);
+			assert!(
+				verify_private.proof_size() >= pre_private.proof_size(),
+				"private verify must include pre_validate PoV"
+			);
+
+			let pre_public = W::pre_validate_public_batch_proof();
+			let verify_public = W::verify_public_batch();
+			assert!(
+				verify_public.ref_time() >= 25_000_000_000 + pre_public.ref_time(),
+				"public verify must include a second pre_validate_public_batch_proof compute cost"
+			);
+			assert!(
+				verify_public.proof_size() >= pre_public.proof_size(),
+				"public verify must include public pre_validate PoV"
+			);
 		});
 	}
 }

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -109,15 +109,19 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `System::BlockHash` (r:1 w:0)
 	/// Proof: `System::BlockHash` (`max_values`: None, `max_size`: Some(44), added: 2519, mode: `MaxEncodedLen`)
-	/// Storage: `Wormhole::UsedNullifiers` (r:32 w:0)
+	/// Storage: `Wormhole::UsedNullifiers` (r:NUM_LEAF_PROOFS w:0)
 	/// Proof: `Wormhole::UsedNullifiers` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+	///
+	/// The nullifier existence scan reads one `UsedNullifiers` key per leaf proof, so
+	/// reads and PoV are derived from `circuit_config::NUM_LEAF_PROOFS` (a build-time
+	/// knob) rather than baked in from the benchmark's aggregation size.
 	fn pre_validate_proof() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `1846`
-		//  Estimated: `81758`
+		let nullifier_reads = circuit_config::NUM_LEAF_PROOFS as u64;
+		// PoV: 2519 per benchmarked `BlockHash` key + 2524 per `UsedNullifiers` key.
+		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
 		// Minimum execution time: 650_000_000 picoseconds.
-		Weight::from_parts(685_000_000, 81758)
-			.saturating_add(T::DbWeight::get().reads(33_u64))
+		Weight::from_parts(685_000_000, proof_size)
+			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
 	/// Public-batch pre-validation (hand-augmented from `pre_validate_proof`, which is
 	/// benchmarked for the private batch): same deserialize/parse cost profile, but the
@@ -165,17 +169,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
-	/// Storage: `System::BlockHash` (r:1 w:0)
-	/// Proof: `System::BlockHash` (`max_values`: None, `max_size`: Some(44), added: 2519, mode: `MaxEncodedLen`)
-	/// Storage: `Wormhole::UsedNullifiers` (r:32 w:0)
-	/// Proof: `Wormhole::UsedNullifiers` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+	/// See `SubstrateWeight::pre_validate_proof`.
 	fn pre_validate_proof() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `1846`
-		//  Estimated: `81758`
-		// Minimum execution time: 650_000_000 picoseconds.
-		Weight::from_parts(685_000_000, 81758)
-			.saturating_add(RocksDbWeight::get().reads(33_u64))
+		let nullifier_reads = circuit_config::NUM_LEAF_PROOFS as u64;
+		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
+		Weight::from_parts(685_000_000, proof_size)
+			.saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
 	/// See `SubstrateWeight::pre_validate_public_batch_proof`.
 	fn pre_validate_public_batch_proof() -> Weight {

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -80,23 +80,44 @@ fn public_batch_max_exits() -> u64 {
 		.saturating_mul(circuit_config::NUM_PRIVATE_BATCH_PROOFS as u64)
 }
 
-/// Scale the calibrated storage tail to `exits` exit mints.
+/// Conservative PoV bound per ZK-tree storage key touched during a path update.
+/// Tree entries are 32-byte hashes with small keys; the comparable benchmarked
+/// `UsedNullifiers` map (49-byte entries) has an `added` figure of 2524 per key.
+const TREE_KEY_POV: u64 = 2600;
+
+/// Scale the calibrated storage tail to `exits` exit mints, adding the
+/// depth-dependent ZK-tree update cost per exit.
+///
+/// `process_exit_bundle` calls `record_transfer` once per exit mint, and each call
+/// walks the ZK tree leaf-to-root (`tree_ops_per_exit` reads/writes, growing with
+/// tree depth). The historical calibration was measured against a near-empty tree,
+/// so the depth-dependent walk is charged explicitly on top; the small tree
+/// component already embedded in the calibration is deliberately not deducted
+/// (over-charging is the safe direction).
 ///
 /// Adds one extra account read/write for the public-batch aggregator rebate when
 /// `include_aggregator` is set.
-fn storage_tail(exits: u64, include_aggregator: bool) -> (u64, u64, u64) {
+fn storage_tail(
+	exits: u64,
+	include_aggregator: bool,
+	tree_ops_per_exit: (u64, u64),
+) -> (u64, u64, u64) {
+	let (tree_reads, tree_writes) = tree_ops_per_exit;
 	let reads = STORAGE_CALIBRATION_READS
 		.saturating_mul(exits)
 		.saturating_div(STORAGE_CALIBRATION_EXITS)
-		.max(1);
+		.max(1)
+		.saturating_add(exits.saturating_mul(tree_reads));
 	let writes = STORAGE_CALIBRATION_WRITES
 		.saturating_mul(exits)
 		.saturating_div(STORAGE_CALIBRATION_EXITS)
-		.max(1);
+		.max(1)
+		.saturating_add(exits.saturating_mul(tree_writes));
 	let proof_size = STORAGE_CALIBRATION_PROOF_SIZE
 		.saturating_mul(exits)
 		.saturating_div(STORAGE_CALIBRATION_EXITS)
-		.max(1);
+		.max(1)
+		.saturating_add(exits.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV));
 	if include_aggregator {
 		(reads.saturating_add(1), writes.saturating_add(1), proof_size)
 	} else {
@@ -105,8 +126,12 @@ fn storage_tail(exits: u64, include_aggregator: bool) -> (u64, u64, u64) {
 }
 
 /// Weights for `pallet_wormhole` using the Substrate node and recommended hardware.
+///
+/// Bounded on `pallet_zk_tree::Config` because the exit-verification weights read the
+/// current tree depth: every processed exit inserts a ZK-tree leaf, whose storage cost
+/// grows with depth.
 pub struct SubstrateWeight<T>(PhantomData<T>);
-impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `System::BlockHash` (r:1 w:0)
 	/// Proof: `System::BlockHash` (`max_values`: None, `max_size`: Some(44), added: 2519, mode: `MaxEncodedLen`)
 	/// Storage: `Wormhole::UsedNullifiers` (r:NUM_LEAF_PROOFS w:0)
@@ -145,10 +170,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// - `System::Digest` (r:1), `Balances::TotalIssuance` (r:1 w:1)
 	/// - `System::Account` (r:E+1 w:E+1) - exit mints + miner fee
 	/// - `Wormhole::TransferCount` (r:E w:E)
-	/// - `ZkTree` Leaves/Nodes/LeafCount/Depth/Root via `record_transfer`
+	/// - `ZkTree` Leaves/Nodes/LeafCount/Depth/Root via `record_transfer`, charged
+	///   per exit at the current tree depth (the walk deepens as the chain ages)
 	/// Keep this augmentation when regenerating.
 	fn verify_private_batch() -> Weight {
-		let (reads, writes, proof_size) = storage_tail(private_batch_max_exits(), false);
+		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
+		let (reads, writes, proof_size) =
+			storage_tail(private_batch_max_exits(), false, tree_ops);
 		// Minimum execution time: 15_336_000_000 picoseconds (ZK verification only).
 		// Adding deserialization (~0.7ms) for total compute ~16.7ms.
 		Weight::from_parts(16_661_000_000, proof_size)
@@ -160,7 +188,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// inner segments: `2 · NUM_LEAF_PROOFS · NUM_PRIVATE_BATCH_PROOFS`, plus one
 	/// account touch for the aggregator fee rebate.
 	fn verify_public_batch() -> Weight {
-		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true);
+		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
+		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
 		Weight::from_parts(25_000_000_000, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
@@ -186,9 +215,13 @@ impl WeightInfo for () {
 	}
 	/// Full private-batch proof verification: ZK verification plus the data-dependent state
 	/// updates that the benchmark excludes. Storage scaled to `2 · NUM_LEAF_PROOFS` exits
-	/// from a 32-exit calibration. Keep this augmentation when regenerating.
+	/// from a 32-exit calibration. This impl has no runtime type to read the live tree
+	/// depth from, so the ZK-tree component is charged at `MAX_TREE_DEPTH` (worst case).
+	/// Keep this augmentation when regenerating.
 	fn verify_private_batch() -> Weight {
-		let (reads, writes, proof_size) = storage_tail(private_batch_max_exits(), false);
+		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		let (reads, writes, proof_size) =
+			storage_tail(private_batch_max_exits(), false, tree_ops);
 		// Minimum execution time: 15_336_000_000 picoseconds (ZK verification only).
 		// Adding deserialization (~0.7ms) for total compute ~16.7ms.
 		Weight::from_parts(16_661_000_000, proof_size)
@@ -196,7 +229,8 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(writes))
 	}
 	fn verify_public_batch() -> Weight {
-		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true);
+		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
 		Weight::from_parts(25_000_000_000, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
@@ -215,8 +249,9 @@ mod tests {
 				.saturating_mul(circuit_config::NUM_PRIVATE_BATCH_PROOFS as u64)
 		);
 
-		let (priv_r, priv_w, _) = storage_tail(private_batch_max_exits(), false);
-		let (pub_r, pub_w, _) = storage_tail(public_batch_max_exits(), true);
+		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(0);
+		let (priv_r, priv_w, _) = storage_tail(private_batch_max_exits(), false, tree_ops);
+		let (pub_r, pub_w, _) = storage_tail(public_batch_max_exits(), true, tree_ops);
 
 		// Public must charge strictly more DB weight than a single private batch
 		// whenever more than one inner segment is configured.
@@ -224,5 +259,42 @@ mod tests {
 			assert!(pub_r > priv_r);
 			assert!(pub_w > priv_w);
 		}
+	}
+
+	/// The exit-verification storage tail must grow with ZK-tree depth: every
+	/// processed exit walks the tree leaf-to-root, so a deeper tree means more real
+	/// database work per exit and the declared weight has to track it.
+	#[test]
+	fn exit_storage_tail_scales_with_tree_depth() {
+		let exits = private_batch_max_exits();
+		let shallow = storage_tail(exits, false, pallet_zk_tree::insert_leaf_db_ops_at_depth(1));
+		let deep = storage_tail(exits, false, pallet_zk_tree::insert_leaf_db_ops_at_depth(20));
+
+		assert!(deep.0 > shallow.0, "reads must grow with tree depth");
+		assert!(deep.1 > shallow.1, "writes must grow with tree depth");
+		assert!(deep.2 > shallow.2, "proof size must grow with tree depth");
+	}
+
+	/// `SubstrateWeight` must price the tree component from the *live* depth, and the
+	/// depth-blind `()` impl (which prices at `MAX_TREE_DEPTH`) must never charge less
+	/// than `SubstrateWeight` at any live depth. The mock's `DbWeight` is zero, so the
+	/// depth sensitivity is observed through the PoV component.
+	#[test]
+	fn substrate_weight_reads_live_depth_and_unit_impl_is_worst_case() {
+		crate::mock::new_test_ext().execute_with(|| {
+			type W = SubstrateWeight<crate::mock::Test>;
+
+			pallet_zk_tree::Depth::<crate::mock::Test>::put(1);
+			let shallow = W::verify_private_batch();
+
+			pallet_zk_tree::Depth::<crate::mock::Test>::put(20);
+			let deep = W::verify_private_batch();
+			assert!(deep.proof_size() > shallow.proof_size());
+
+			pallet_zk_tree::Depth::<crate::mock::Test>::put(pallet_zk_tree::MAX_TREE_DEPTH);
+			let at_max = W::verify_private_batch();
+			let unit = <() as WeightInfo>::verify_private_batch();
+			assert!(unit.proof_size() >= at_max.proof_size());
+		});
 	}
 }

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -49,8 +49,8 @@ pub const MAX_TREE_DEPTH: u8 = 32;
 /// `depth + 1` (capped at [`MAX_TREE_DEPTH`]) so an insert that triggers tree growth is
 /// covered. At effective depth `d`:
 /// - reads: `LeafCount` + `Depth` (twice) + `grow_tree`'s `Root` + `3·d` siblings
-/// - writes: `Leaves` + `LeafCount` + `Root` + `d − 1` internal nodes, plus
-///   `grow_tree`'s `Nodes`/`Root`/`Depth` writes
+/// - writes: `Leaves` + `LeafCount` + `Root` + `d − 1` internal nodes, plus `grow_tree`'s
+///   `Nodes`/`Root`/`Depth` writes
 ///
 /// Weight/fee metering for anything that inserts leaves must use this (via
 /// [`Pallet::insert_leaf_db_ops`]) rather than a flat constant, otherwise the declared

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -41,6 +41,25 @@ mod tests;
 /// A tree of depth 32 can hold 4^32 leaves (more than enough).
 pub const MAX_TREE_DEPTH: u8 = 32;
 
+/// Worst-case `(reads, writes)` storage-operation counts for one [`Pallet::insert_leaf`]
+/// call when the tree is currently at `depth`.
+///
+/// The insert is depth-dependent: `update_path` reads the 3 sibling hashes at every
+/// level and writes one internal node per level below the root. Costing is done at
+/// `depth + 1` (capped at [`MAX_TREE_DEPTH`]) so an insert that triggers tree growth is
+/// covered. At effective depth `d`:
+/// - reads: `LeafCount` + `Depth` (twice) + `grow_tree`'s `Root` + `3·d` siblings
+/// - writes: `Leaves` + `LeafCount` + `Root` + `d − 1` internal nodes, plus
+///   `grow_tree`'s `Nodes`/`Root`/`Depth` writes
+///
+/// Weight/fee metering for anything that inserts leaves must use this (via
+/// [`Pallet::insert_leaf_db_ops`]) rather than a flat constant, otherwise the declared
+/// weight silently falls behind the real database work as the tree deepens.
+pub fn insert_leaf_db_ops_at_depth(depth: u8) -> (u64, u64) {
+	let d = depth.saturating_add(1).min(MAX_TREE_DEPTH) as u64;
+	(3 * d + 4, d + 5)
+}
+
 /// Branching factor of the tree.
 pub const ARITY: usize = 4;
 
@@ -170,6 +189,14 @@ pub mod pallet {
 			// Set ZK Merkle tree root in frame_system for inclusion in block header
 			let root: Hash256 = Root::<T>::get();
 			<frame_system::Pallet<T>>::set_zk_tree_root(root.into());
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Worst-case `(reads, writes)` for one `insert_leaf` at the tree's *current*
+		/// depth. See [`insert_leaf_db_ops_at_depth`].
+		pub fn insert_leaf_db_ops() -> (u64, u64) {
+			crate::insert_leaf_db_ops_at_depth(Depth::<T>::get())
 		}
 	}
 

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -126,6 +126,58 @@ fn hash_leaf_golden_vector() {
 	assert_eq!(tree::hash_leaf::<Test>(&leaf), expected);
 }
 
+/// Helper for the amount-commitment tests: a fixed leaf varying only in `amount`.
+fn amount_leaf(amount: u128) -> ZkLeaf<AccountId, u32, u128> {
+	ZkLeaf { to: make_account(0x11), transfer_count: 7, asset_id: 5, amount }
+}
+
+/// Oversized amounts must not alias small amounts in the leaf commitment.
+///
+/// The leaf commits the quantized amount (`amount / AMOUNT_SCALE_DOWN_FACTOR`) as a
+/// u32. Quantized values above `u32::MAX` are unrepresentable and must saturate to
+/// `u32::MAX` rather than wrap — otherwise a transfer of `X + 2^32·SCALE` commits to
+/// exactly the same leaf data as a transfer of `X`, making the authoritative Merkle
+/// root ambiguous between economically different transfers. This is unreachable for
+/// the native token (the supply cap keeps quantized amounts below u32::MAX) but fully
+/// reachable for permissionlessly minted pallet-assets amounts.
+#[test]
+fn hash_leaf_oversized_amount_does_not_alias_small_amount() {
+	let small = 1234 * tree::AMOUNT_SCALE_DOWN_FACTOR;
+	// Quantizes to 1234 + 2^32, which truncates back to a committed amount of 1234
+	// if the encoding wraps instead of saturating.
+	let wrapping_alias = small + (1u128 << 32) * tree::AMOUNT_SCALE_DOWN_FACTOR;
+
+	assert_ne!(
+		tree::hash_leaf::<Test>(&amount_leaf(small)),
+		tree::hash_leaf::<Test>(&amount_leaf(wrapping_alias)),
+		"an oversized amount must not commit to the same leaf as a small amount"
+	);
+}
+
+/// Pins the saturation semantics: every quantized amount at or above `u32::MAX`
+/// commits to the same capped value, `u32::MAX`.
+#[test]
+fn hash_leaf_saturates_oversized_amounts_at_u32_max() {
+	let cap = (u32::MAX as u128) * tree::AMOUNT_SCALE_DOWN_FACTOR;
+	let at_cap = tree::hash_leaf::<Test>(&amount_leaf(cap));
+
+	assert_eq!(
+		at_cap,
+		tree::hash_leaf::<Test>(&amount_leaf(cap + tree::AMOUNT_SCALE_DOWN_FACTOR)),
+		"one quantized unit above the cap must saturate to the cap commitment"
+	);
+	assert_eq!(
+		at_cap,
+		tree::hash_leaf::<Test>(&amount_leaf(u128::MAX)),
+		"u128::MAX must saturate to the cap commitment"
+	);
+	assert_ne!(
+		at_cap,
+		tree::hash_leaf::<Test>(&amount_leaf(cap - tree::AMOUNT_SCALE_DOWN_FACTOR)),
+		"amounts below the cap must still commit to their true value"
+	);
+}
+
 #[test]
 fn insert_first_leaf_works() {
 	new_test_ext().execute_with(|| {

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -99,6 +99,33 @@ fn test_hash_node() {
 	assert_ne!(hash, hash3);
 }
 
+/// Golden vector for the leaf hash.
+///
+/// Pins the exact `hash_leaf` output for a fixed canonical leaf so that any change to
+/// the encoding (felt layout, quantization, recipient handling) fails loudly. The leaf
+/// encoding must stay byte-compatible with the ZK circuit's
+/// `ZkLeafTargets::collect_for_hash()`; a cross-check against the real circuit crates
+/// lives in `pallet-wormhole`'s `pallet_leaf_hash_matches_circuit_leaf_hash` test.
+/// If this value ever needs to change, the deployed withdrawal circuit must change
+/// with it — do not update the constant casually.
+#[test]
+fn hash_leaf_golden_vector() {
+	let leaf = ZkLeaf::<AccountId, u32, u128> {
+		to: make_account(0x11),
+		transfer_count: 7,
+		asset_id: 5,
+		// 1234 quantized units (hash_leaf divides by AMOUNT_SCALE_DOWN_FACTOR).
+		amount: 1234 * tree::AMOUNT_SCALE_DOWN_FACTOR,
+	};
+	// Cross-checked against the circuit-side computation by
+	// `hash_leaf_golden_vector_matches_circuit` in pallet-wormhole's tests.
+	let expected: [u8; 32] = [
+		195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85, 224,
+		111, 64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
+	];
+	assert_eq!(tree::hash_leaf::<Test>(&leaf), expected);
+}
+
 #[test]
 fn insert_first_leaf_works() {
 	new_test_ext().execute_with(|| {

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -120,8 +120,8 @@ fn hash_leaf_golden_vector() {
 	// Cross-checked against the circuit-side computation by
 	// `hash_leaf_golden_vector_matches_circuit` in pallet-wormhole's tests.
 	let expected: [u8; 32] = [
-		195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85, 224,
-		111, 64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
+		195, 94, 210, 27, 96, 177, 127, 68, 16, 231, 47, 227, 104, 21, 175, 254, 219, 85, 224, 111,
+		64, 162, 32, 119, 226, 89, 143, 126, 203, 254, 51, 93,
 	];
 	assert_eq!(tree::hash_leaf::<Test>(&leaf), expected);
 }

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -123,17 +123,30 @@ where
 	felts.extend(u64_to_felts(leaf.transfer_count));
 
 	// asset_id: 1 felt (u32 -> u64 -> 8 bytes LE -> 1 felt via compact encoding)
-	// Convert via u128 then truncate to u32 (asset IDs should always fit in u32)
+	// The circuit commits asset IDs as u32. The runtime's asset ID type is u32, so the
+	// narrowing is lossless today; saturate (rather than truncate) as hardening for any
+	// future runtime with a wider type, so distinct assets can never wrap onto each
+	// other's low 32 bits. The debug_assert keeps dev builds loud about it.
 	let asset_id_u128: u128 = leaf.asset_id.into();
-	let asset_id_u32 = asset_id_u128 as u32;
+	let asset_id_u32 = u32::try_from(asset_id_u128).unwrap_or(u32::MAX);
 	debug_assert_eq!(asset_id_u128, asset_id_u32 as u128, "Asset ID must fit in u32");
 	felts.extend(bytes_to_felts_compact_lossy(&(asset_id_u32 as u64).to_le_bytes()));
 
 	// amount: 1 felt (u32 quantized -> u64 -> 8 bytes LE -> 1 felt via compact encoding)
 	// Quantize by dividing by AMOUNT_SCALE_DOWN_FACTOR (10^10)
 	// This gives 2 decimal places of precision (1 DEV = 100 quantized units)
+	//
+	// The circuit commits amounts as u32, so quantized values above u32::MAX are
+	// unrepresentable. Saturate instead of truncating: a wrapping cast would let an
+	// oversized transfer commit to the same leaf data as a small one (amount mod 2^32),
+	// making the authoritative root ambiguous between economically different transfers.
+	// Saturation pins every oversized amount to the same transparent cap, from which a
+	// prover can only ever claim *at most* the cap. Unreachable for the native token
+	// (the 2.1e19-planck supply cap quantizes to ~2.1e9 < u32::MAX) but reachable for
+	// permissionlessly minted pallet-assets amounts, which are also recorded here.
 	let amount_u128: u128 = leaf.amount.into();
-	let amount_quantized = (amount_u128 / AMOUNT_SCALE_DOWN_FACTOR) as u32;
+	let amount_quantized =
+		u32::try_from(amount_u128 / AMOUNT_SCALE_DOWN_FACTOR).unwrap_or(u32::MAX);
 	felts.extend(bytes_to_felts_compact_lossy(&(amount_quantized as u64).to_le_bytes()));
 
 	debug_assert_eq!(felts.len(), 8, "Leaf preimage must be exactly 8 felts");

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -113,8 +113,7 @@ where
 	debug_assert!(
 		to_bytes
 			.chunks_exact(8)
-			.all(|limb| u64::from_le_bytes(limb.try_into().expect("8-byte limb")) <
-				GOLDILOCKS_P),
+			.all(|limb| u64::from_le_bytes(limb.try_into().expect("8-byte limb")) < GOLDILOCKS_P),
 		"recipient account is non-canonical for the 8-byte/felt leaf encoding"
 	);
 	felts.extend(bytes_to_felts_compact_lossy(to_bytes));

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -33,6 +33,30 @@ pub fn capacity_at_depth(depth: u8) -> u64 {
 /// 10^10 means 1 DEV (10^12 planck) becomes 100 in the leaf.
 pub const AMOUNT_SCALE_DOWN_FACTOR: u128 = 10_000_000_000;
 
+/// The Goldilocks prime `p = 2^64 - 2^32 + 1`.
+pub const GOLDILOCKS_P: u64 = 0xFFFF_FFFF_0000_0001;
+
+/// Reduce each 8-byte little-endian limb of a 32-byte account mod the Goldilocks prime.
+///
+/// This is the same reduction the lossy leaf encoding applies inside [`hash_leaf`], so
+/// the returned bytes are the canonical representative of the input's leaf-encoding
+/// class: two accounts produce the same `to_account` felts iff they canonicalize
+/// identically. Callers that key state on the leaf recipient (e.g. the wormhole's
+/// per-recipient transfer count) must key on this canonical form so that two distinct
+/// deposits can never commit to identical leaves (see the encoding-safety invariant on
+/// [`hash_leaf`]).
+pub fn canonicalize_account_bytes(bytes: [u8; 32]) -> [u8; 32] {
+	let mut out = bytes;
+	for limb in out.chunks_exact_mut(8) {
+		let value = u64::from_le_bytes(limb.try_into().expect("8-byte limb"));
+		if value >= GOLDILOCKS_P {
+			// A u64 is < 2p, so a single subtraction fully reduces.
+			limb.copy_from_slice(&(value - GOLDILOCKS_P).to_le_bytes());
+		}
+	}
+	out
+}
+
 /// Compact 8-byte/felt encoding that *reduces* non-canonical limbs mod P.
 ///
 /// The circuit encodes compact bytes with plonky2's `from_noncanonical_u64`, i.e.
@@ -62,15 +86,16 @@ fn bytes_to_felts_compact_lossy(input: &[u8]) -> impl Iterator<Item = Goldilocks
 ///
 /// The 8-byte/felt compact encoding is *non-injective*: an 8-byte limb `≥ p`
 /// (the Goldilocks prime) is reduced mod `p`, so `to` bytes and their canonical
-/// reduction hash identically. `to` is an arbitrary recipient (this runs on every
-/// transfer), so it need not be canonical. This is safe **only** because the
-/// withdrawal circuit binds the leaf's `to_account` felts to `WA(secret)`, a
-/// canonical Poseidon output, and range-checks the numeric fields — so the leaf
-/// hash commits to the canonical *reduction* of the recipient, never the bytes.
-/// If you ever need to recover the exact recipient bytes from a leaf, or relax
-/// the `to_account = WA(s)` binding, this invariant breaks. The `debug_assert`
-/// below documents (and in test/dev builds enforces) that production deposits use
-/// canonical recipients.
+/// reduction hash identically. Callers must therefore pass a recipient that is
+/// already canonical — i.e. run arbitrary recipients through
+/// [`canonicalize_account_bytes`] first, and key any per-recipient state (such as
+/// the wormhole's transfer count) on that canonical form. Otherwise a recipient
+/// and its non-canonical alias get independent count sequences and two distinct
+/// deposits can commit to the *same* leaf, which in the wormhole means a shared
+/// nullifier and one permanently unexitable deposit. The withdrawal circuit binds
+/// the leaf's `to_account` felts to `WA(secret)` (a canonical Poseidon output), so
+/// canonicalizing the recipient never changes who can exit a leaf. The
+/// `debug_assert` below enforces the caller contract in test/dev builds.
 pub fn hash_leaf<T: Config>(leaf: &ZkLeaf<AccountIdOf<T>, T::AssetId, T::Balance>) -> Hash256
 where
 	AccountIdOf<T>: AsRef<[u8]>,
@@ -89,7 +114,7 @@ where
 		to_bytes
 			.chunks_exact(8)
 			.all(|limb| u64::from_le_bytes(limb.try_into().expect("8-byte limb")) <
-				0xFFFF_FFFF_0000_0001),
+				GOLDILOCKS_P),
 		"recipient account is non-canonical for the 8-byte/felt leaf encoding"
 	);
 	felts.extend(bytes_to_felts_compact_lossy(to_bytes));
@@ -342,5 +367,42 @@ mod tests {
 	fn test_empty_hash() {
 		let h = empty_hash();
 		assert_eq!(h, [0u8; 32]);
+	}
+
+	#[test]
+	fn canonicalize_is_identity_on_canonical_accounts() {
+		// All limbs < p (largest canonical limb is p - 1).
+		let mut bytes = [0x11u8; 32];
+		bytes[24..32].copy_from_slice(&(GOLDILOCKS_P - 1).to_le_bytes());
+		assert_eq!(canonicalize_account_bytes(bytes), bytes);
+	}
+
+	#[test]
+	fn canonicalize_reduces_each_non_canonical_limb() {
+		// Each limb i holds p + i (fits in u64 since i < 2^32 - 1) and must reduce to i.
+		let mut bytes = [0u8; 32];
+		for i in 0..4u64 {
+			let start = (i as usize) * 8;
+			bytes[start..start + 8].copy_from_slice(&(GOLDILOCKS_P + i).to_le_bytes());
+		}
+		let mut expected = [0u8; 32];
+		for i in 0..4u64 {
+			let start = (i as usize) * 8;
+			expected[start..start + 8].copy_from_slice(&i.to_le_bytes());
+		}
+		assert_eq!(canonicalize_account_bytes(bytes), expected);
+	}
+
+	#[test]
+	fn canonicalize_reduces_max_limb() {
+		// u64::MAX = p + (2^32 - 2): the largest possible limb still reduces correctly.
+		let mut bytes = [0u8; 32];
+		bytes[0..8].copy_from_slice(&u64::MAX.to_le_bytes());
+		let out = canonicalize_account_bytes(bytes);
+		let reduced = u64::from_le_bytes(out[0..8].try_into().unwrap());
+		assert_eq!(reduced, u64::MAX - GOLDILOCKS_P);
+		assert!(reduced < GOLDILOCKS_P);
+		// Other limbs untouched.
+		assert_eq!(&out[8..], &bytes[8..]);
 	}
 }

--- a/primitives/wormhole/src/lib.rs
+++ b/primitives/wormhole/src/lib.rs
@@ -76,15 +76,22 @@ pub const MINTING_ACCOUNT: sp_core::crypto::AccountId32 =
 /// Trait giving other pallets a handle into the wormhole pallet's bookkeeping, without taking a
 /// hard dependency on `pallet-wormhole` itself.
 pub trait TransferProofRecorder<AccountId, AssetId, Balance> {
-	/// Record a transfer proof for native or asset tokens
-	/// - `None` for native tokens (asset_id = 0)
+	/// Record a transfer proof for native or asset tokens.
+	///
+	/// - `None` for native tokens (internally tagged as asset_id = 0)
 	/// - `Some(asset_id)` for specific assets
+	///
+	/// Returns `true` if a proof was actually recorded (ZK-tree leaf insert / bookkeeping
+	/// work performed), and `false` if the credit was deliberately dropped (e.g. a
+	/// `pallet_assets` asset-0 credit, which must not be conflated with native). Callers
+	/// that reconcile weight against recorded work must use this return value — counting
+	/// the call itself over-charges dropped credits.
 	fn record_transfer_proof(
 		asset_id: Option<AssetId>,
 		from: AccountId,
 		to: AccountId,
 		amount: Balance,
-	);
+	) -> bool;
 
 	/// Reveal `account` to the wormhole soundness counter, removing its current balance from the
 	/// pool of value that could be exited via the wormhole.

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -153,8 +153,14 @@ fn planck_tech_collective_seed() -> Vec<AccountId> {
 
 /// Returns the genesis config populated with given parameters. Treasury is per-profile.
 ///
-/// The treasury account is also the `pallet-assets` owner for **asset id 0** (native-in-assets path
-/// for wormhole). It is not FRAME `Root`.
+/// The treasury account is also the `pallet-assets` owner for **asset id 0**. It is not FRAME
+/// `Root`.
+///
+/// NOTE: `pallet-assets` asset id 0 is a distinct, unbacked token that merely shares the integer
+/// the wormhole uses internally to tag *native* leaves. It is NOT the native token, and minting it
+/// does not create or back any native value. The wormhole proof recorder deliberately does not
+/// treat asset-0 credits as native deposits (see `record_transfer_proof`); if that ever changes,
+/// the asset-0 issuer could mint unbacked native out of the wormhole.
 ///
 /// All endowed addresses automatically get transfer proofs recorded, enabling them to
 /// spend their funds via ZK proofs. The chain doesn't distinguish between "wormhole

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -166,6 +166,8 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, TxExtension>;
 pub type Migrations = (
 	// v0 -> v1: seed the wormhole soundness counters so pre-upgrade deposits remain exitable.
 	pallet_wormhole::migrations::MigrateV0ToV1<Runtime>,
+	// v1 -> v2: merge pre-upgrade non-canonical TransferCount keys into their canonical form.
+	pallet_wormhole::migrations::MigrateV1ToV2<Runtime>,
 	// v0 -> v1: set the treasury portion to 50% (50/50 treasury/miner reward split).
 	pallet_treasury::migrations::MigrateV0ToV1<Runtime>,
 );

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -121,10 +121,8 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	/// storage here, so the charge tracks the tree as it deepens over the chain's life).
 	fn per_transfer_weight() -> Weight {
 		let (tree_reads, tree_writes) = pallet_zk_tree::Pallet::<Runtime>::insert_leaf_db_ops();
-		T::DbWeight::get().reads_writes(
-			5u64.saturating_add(tree_reads),
-			2u64.saturating_add(tree_writes),
-		)
+		T::DbWeight::get()
+			.reads_writes(5u64.saturating_add(tree_reads), 2u64.saturating_add(tree_writes))
 	}
 
 	fn count_transfers(call: &RuntimeCall) -> u64 {

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -125,12 +125,26 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 			.reads_writes(5u64.saturating_add(tree_reads), 2u64.saturating_add(tree_writes))
 	}
 
+	/// Whether a `pallet_assets` credit with this id is actually recorded by the wormhole.
+	/// Asset id 0 is reserved for the wormhole's *internal* native tag and is dropped by
+	/// `record_transfer_proof` — it must not be charged as a proof-recording transfer.
+	fn asset_transfer_counts(id: &codec::Compact<AssetId>) -> u64 {
+		let asset_id: AssetId = (*id).into();
+		if asset_id == 0 {
+			0
+		} else {
+			1
+		}
+	}
+
 	fn count_transfers(call: &RuntimeCall) -> u64 {
 		// NOTE: this must stay in sync with the events matched by `record_proofs_from_events_since`
 		// — we only weight calls whose emitted events we actually record. In particular
 		// `Balances::force_set_balance` is deliberately NOT counted here: it emits `BalanceSet`
 		// (an absolute set, not a transfer/mint), which we cannot turn into a transfer proof and
 		// therefore never record. See the soundness-counter caveat on `reduce_potential_balance`.
+		// Likewise, `pallet_assets` credits of asset id 0 are dropped by `record_transfer_proof`
+		// (they must not be conflated with native) and are therefore not counted here.
 		//
 		// Wrappers whose inner call is stored on-chain rather than in the submitted call
 		// (`Multisig::execute`, `ReversibleTransfers::recover_funds`, ...) cannot be counted
@@ -141,12 +155,13 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 			RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::transfer_all { .. }) |
-			RuntimeCall::Balances(pallet_balances::Call::force_transfer { .. }) |
-			RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) |
-			RuntimeCall::Assets(pallet_assets::Call::transfer_keep_alive { .. }) |
-			RuntimeCall::Assets(pallet_assets::Call::transfer_approved { .. }) |
-			RuntimeCall::Assets(pallet_assets::Call::force_transfer { .. }) |
-			RuntimeCall::Assets(pallet_assets::Call::mint { .. }) => 1,
+			RuntimeCall::Balances(pallet_balances::Call::force_transfer { .. }) => 1,
+
+			RuntimeCall::Assets(pallet_assets::Call::transfer { id, .. }) |
+			RuntimeCall::Assets(pallet_assets::Call::transfer_keep_alive { id, .. }) |
+			RuntimeCall::Assets(pallet_assets::Call::transfer_approved { id, .. }) |
+			RuntimeCall::Assets(pallet_assets::Call::force_transfer { id, .. }) |
+			RuntimeCall::Assets(pallet_assets::Call::mint { id, .. }) => Self::asset_transfer_counts(id),
 
 			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
 			RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
@@ -219,12 +234,18 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 				})
 				.collect();
 
-		// Now record the proofs - this is safe because we're no longer iterating over Events
-		let recorded = transfers_to_record.len() as u64;
+		// Now record the proofs - this is safe because we're no longer iterating over Events.
+		// Count only credits that were actually recorded: `record_transfer_proof` returns
+		// `false` for deliberately dropped credits (notably `pallet_assets` asset-0), and
+		// counting those as recorded would over-reserve fees and falsely register extra
+		// block weight on opaque paths.
+		let mut recorded = 0u64;
 		for (asset_id, from, to, amount) in transfers_to_record {
-			<Wormhole as TransferProofRecorder<AccountId, AssetId, Balance>>::record_transfer_proof(
+			if <Wormhole as TransferProofRecorder<AccountId, AssetId, Balance>>::record_transfer_proof(
 				asset_id, from, to, amount,
-			);
+			) {
+				recorded = recorded.saturating_add(1);
+			}
 		}
 		recorded
 	}
@@ -834,6 +855,88 @@ mod tests {
 				weight_after.saturating_sub(weight_before),
 				WormholeProofRecorderExtension::<Runtime>::per_transfer_weight(),
 				"the uncounted recorded transfer must be registered as extra block weight"
+			);
+		});
+	}
+
+	/// `pallet_assets` asset id 0 is dropped by `record_transfer_proof` (it must not be
+	/// conflated with native). Static weight and the post_dispatch recorded-count must
+	/// both treat it as a non-recording credit — otherwise fees are over-reserved and
+	/// opaque paths falsely register extra block weight for work that never happened.
+	#[test]
+	fn asset_zero_credit_is_not_counted_as_recorded_transfer() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			// Static matcher: asset-0 mint/transfer must charge zero proof-recording weight.
+			let asset_zero_mint = RuntimeCall::Assets(pallet_assets::Call::mint {
+				id: 0u32.into(),
+				beneficiary: MultiAddress::Id(bob()),
+				amount: 100,
+			});
+			let asset_one_mint = RuntimeCall::Assets(pallet_assets::Call::mint {
+				id: 1u32.into(),
+				beneficiary: MultiAddress::Id(bob()),
+				amount: 100,
+			});
+			assert_eq!(
+				WormholeProofRecorderExtension::<Runtime>::count_transfers(&asset_zero_mint),
+				0,
+				"asset-0 mint must not be statically charged as a recorded proof"
+			);
+			assert_eq!(
+				WormholeProofRecorderExtension::<Runtime>::count_transfers(&asset_one_mint),
+				1,
+				"non-zero asset mint must still be statically charged"
+			);
+
+			// Create asset 0 and mint — emits `Assets::Issued { asset_id: 0, ... }`.
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				0u32.into(),
+				MultiAddress::Id(alice()),
+				true,
+				1,
+			));
+			let bob_count_before = Wormhole::transfer_count(&bob());
+			let weight_before = frame_system::Pallet::<Runtime>::block_weight().total();
+
+			// Opaque presented call (charged_transfers = 0) whose dispatch mints asset 0.
+			// Pre-fix, `record_proofs_from_events_since` counted the event and registered
+			// a full per-transfer weight shortfall even though the credit was dropped.
+			let opaque_call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+			run_lifecycle(&alice(), opaque_call, || {
+				assert_ok!(Assets::mint(
+					RuntimeOrigin::signed(alice()),
+					0u32.into(),
+					MultiAddress::Id(bob()),
+					100,
+				));
+			});
+
+			assert_eq!(
+				Wormhole::transfer_count(&bob()),
+				bob_count_before,
+				"asset-0 mint must not insert a wormhole transfer proof"
+			);
+			assert_eq!(
+				frame_system::Pallet::<Runtime>::block_weight().total(),
+				weight_before,
+				"dropped asset-0 credit must not register extra block weight"
+			);
+
+			// Direct scan: the Issued event is present but must report zero recordings.
+			System::reset_events();
+			assert_ok!(Assets::mint(
+				RuntimeOrigin::signed(alice()),
+				0u32.into(),
+				MultiAddress::Id(bob()),
+				50,
+			));
+			assert_eq!(
+				WormholeProofRecorderExtension::<Runtime>::record_proofs_from_events_since(0),
+				0,
+				"record_proofs_from_events_since must not count dropped asset-0 credits"
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -114,10 +114,17 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	///           `NonWormholeAccounts` membership checks `Multisigs` (1), the utility
 	///           pallet's `KnownDerivatives` (1) and the configured `TreasuryAccount` (1)
 	///           => 5 reads.
-	///   writes: TransferProof / ZK-tree leaf (1) + TransferCount (1) + the conditional
-	///           `PotentialWormholeBalance` deposit add (1) => 3 writes.
+	///   writes: TransferCount (1) + the conditional `PotentialWormholeBalance`
+	///           deposit add (1) => 2 writes.
+	/// plus the ZK-tree leaf insert, whose path update walks the tree leaf-to-root and
+	/// therefore costs reads/writes proportional to the *current* tree depth (read from
+	/// storage here, so the charge tracks the tree as it deepens over the chain's life).
 	fn per_transfer_weight() -> Weight {
-		T::DbWeight::get().reads_writes(5, 3)
+		let (tree_reads, tree_writes) = pallet_zk_tree::Pallet::<Runtime>::insert_leaf_db_ops();
+		T::DbWeight::get().reads_writes(
+			5u64.saturating_add(tree_reads),
+			2u64.saturating_add(tree_writes),
+		)
 	}
 
 	fn count_transfers(call: &RuntimeCall) -> u64 {
@@ -781,6 +788,24 @@ mod tests {
 					.saturating_mul(2)
 					.saturating_add(reveal_weight),
 				"as_derivative-wrapped transfers must be statically counted"
+			);
+		});
+	}
+
+	#[test]
+	fn per_transfer_weight_scales_with_tree_depth() {
+		new_test_ext().execute_with(|| {
+			// Recording a transfer inserts a ZK-tree leaf, and the path update walks the
+			// tree leaf-to-root — the charged weight must track the live tree depth.
+			pallet_zk_tree::Depth::<Runtime>::put(1);
+			let shallow = WormholeProofRecorderExtension::<Runtime>::per_transfer_weight();
+
+			pallet_zk_tree::Depth::<Runtime>::put(20);
+			let deep = WormholeProofRecorderExtension::<Runtime>::per_transfer_weight();
+
+			assert!(
+				deep.ref_time() > shallow.ref_time(),
+				"per-transfer weight must grow with ZK-tree depth"
 			);
 		});
 	}


### PR DESCRIPTION
## Summary

Security hardening for wormhole / ZK-tree metering and commitment paths, plus related leaf-keying and deposit-tracking fixes.

- **Canonical leaf recipients** — key ZK-tree leaves and transfer counts on the Goldilocks-canonical form of the recipient so non-canonical aliases cannot share a nullifier / leave a deposit permanently unexitable.
- **Native-only potential-balance credits** — do not treat `pallet_assets` asset-0 credits as native wormhole deposits for the soundness pool.
- **Private-batch prevalidation weight** — derive `pre_validate_proof` DB reads / PoV from `circuit_config::NUM_LEAF_PROOFS` (and size the benchmark the same way) instead of a hardcoded 32-nullifier assumption that can drift from `QP_NUM_LEAF_PROOFS`.
- **Depth-aware ZK-tree insert metering** — charge `per_transfer_weight` and wormhole exit `storage_tail` using the live tree depth (`insert_leaf` / `update_path` scale with depth), so declared weight tracks real storage work as the tree deepens.
- **Saturating leaf encoding** — commit quantized amount and asset_id as saturating `u32`s instead of truncating wraps, so oversized (e.g. permissionlessly minted) asset transfers cannot alias small amounts in the Merkle leaf.
- **Unsigned exit DoS gate** — move full plonky2 verification off `validate_unsigned` (pool admission) onto `pre_dispatch` (block inclusion); keep pool path at cheap pre-validation; dedup by nullifier set instead of raw proof bytes; stop re-verifying in the dispatch body so charged weight matches actual work.

## Test plan

- [ ] `cargo test -p pallet-zk-tree`
- [ ] `cargo test -p pallet-wormhole`
- [ ] `cargo test -p quantus-runtime transaction_extensions`
- [ ] Confirm new wormhole tests:
  - [ ] `pre_dispatch_rejects_unverifiable_proof`
  - [ ] `validate_unsigned_skips_verify_but_pre_dispatch_enforces_it`
  - [ ] `validate_unsigned_and_pre_dispatch_accept_valid_proof_with_semantic_tag`
- [ ] Confirm zk-tree amount-saturation tests:
  - [ ] `hash_leaf_oversized_amount_does_not_alias_small_amount`
  - [ ] `hash_leaf_saturates_oversized_amounts_at_u32_max`
- [ ] Confirm weights / extension depth tests (wormhole `weights::tests::*`, runtime `per_transfer_weight_scales_with_tree_depth`)
- [ ] Manual / review: unsigned exit with valid PIs but corrupted proof data is pool-admissible but rejected at `pre_dispatch` / block import
- [ ] Manual / review: regenerating wormhole benchmarks after changing `QP_NUM_LEAF_PROOFS` still aligns with the derived nullifier / depth logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes wormhole soundness accounting, nullifier/leaf commitment semantics, and where unsigned proofs are cryptographically verified—any bug could affect exits or enable DoS/unbacked native; mitigated by extensive new tests.
> 
> **Overview**
> **Hardens wormhole and ZK-tree deposit/exit correctness** and closes several ways deposits or pool traffic could be abused.
> 
> **Deposit / leaf keying:** `record_transfer` now keys `TransferCount` and ZK-tree leaves on **Goldilocks-canonical recipients** (`canonical_leaf_recipient`), so byte aliases of the same leaf encoding cannot share a transfer-count sequence or collide on nullifiers. **`record_transfer_proof`** treats **`None` as native** and **ignores `Some(0)`** (`pallet_assets` id 0), so asset-0 mints cannot inflate `PotentialWormholeBalance` or insert natively exitable leaves.
> 
> **Unsigned exit traffic:** Pool admission (`validate_unsigned`) runs only **cheap pre-validation**; **full plonky2 verify** runs in **`pre_dispatch`** (block inclusion). Dispatch no longer re-verifies (avoids double ZK cost vs declared weight). Pool **`provides`** tags hash **nullifiers**, not raw proof bytes.
> 
> **Leaf hashing:** `hash_leaf` **saturates** quantized amount and `asset_id` to `u32` (no wrap aliases). `canonicalize_account_bytes` is shared from `pallet-zk-tree`.
> 
> **Weights:** Pre-validate nullifier reads/PoV follow **`NUM_LEAF_PROOFS`**; exit and per-transfer weights add **depth-dependent** ZK-tree insert cost (`insert_leaf_db_ops`). Benchmark `MAX_NULLIFIERS` tracks circuit config.
> 
> Tests wire a real `ZkTree` in the wormhole mock and add regression coverage for the above; genesis docs note asset id 0 is not native.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bed485c315e9f0cd1c6e961b4f5583de684e45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->