### PR TITLE
V12 e2e wormhole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8853,6 +8853,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "primitive-types 0.13.1",
+ "qp-header",
  "sc-client-api",
  "sc-consensus",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,6 +5941,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-treasury",
+ "pallet-zk-tree",
  "parity-scale-codec",
  "qp-wormhole",
  "scale-info",

--- a/client/consensus/qpow/Cargo.toml
+++ b/client/consensus/qpow/Cargo.toml
@@ -33,6 +33,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"primitive-types/std",
+	"qp-header/serde",
 	"qp-header/std",
 	"sp-api/std",
 	"sp-consensus-qpow/std",

--- a/client/consensus/qpow/Cargo.toml
+++ b/client/consensus/qpow/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = true }
 primitive-types = { workspace = true, default-features = false }
 prometheus-endpoint = { workspace = true, default-features = true }
+qp-header = { workspace = true }
 sc-client-api = { workspace = true, default-features = false }
 sc-consensus = { workspace = true }
 sp-api = { workspace = true, default-features = false }
@@ -32,6 +33,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"primitive-types/std",
+	"qp-header/std",
 	"sp-api/std",
 	"sp-consensus-qpow/std",
 	"sp-runtime/std",

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -70,10 +70,8 @@ pub enum Error<B: BlockT> {
 	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
 	#[error("Multiple pre-runtime digests")]
 	MultiplePreRuntimeDigests,
-	#[error(
-		"Header {0:?} has an encoded digest of {1} bytes, exceeding the {2}-byte commitment window"
-	)]
-	DigestTooLong(B::Hash, usize, usize),
+	#[error("Header has an encoded digest of {0} bytes, exceeding the {1}-byte commitment window")]
+	DigestTooLong(usize, usize),
 	#[error(transparent)]
 	Client(sp_blockchain::Error),
 	#[error(transparent)]
@@ -226,6 +224,21 @@ where
 		&self,
 		mut block_import_params: BlockImportParams<B>,
 	) -> Result<ImportResult, Self::Error> {
+		// Reject any header whose canonical (post-seal) digest encodes to more
+		// than the fixed window committed by `Header::hash()`. Past that window
+		// the digest bytes are not covered by the block hash, so silently
+		// truncating (as `hash()` does defensively) would let two distinct
+		// sealed headers collide on the same block hash. Fail closed before
+		// *any* `hash()` call on this header — hashing an oversized digest
+		// trips a debug assertion in `qp-header` — and, for the same reason,
+		// without embedding a hash of the malformed header in the error. The
+		// pre-seal digest is a prefix of the post-seal one, so this bound also
+		// covers the pre-seal `header.hash()` calls below.
+		let encoded_digest_len = block_import_params.post_header().digest().encode().len();
+		if encoded_digest_len > DIGEST_LOGS_SIZE {
+			return Err(Error::<B>::DigestTooLong(encoded_digest_len, DIGEST_LOGS_SIZE).into());
+		}
+
 		let parent_hash = *block_import_params.header.parent_hash();
 
 		if let Some(inner_body) = block_import_params.body.take() {
@@ -251,23 +264,6 @@ where
 		)?;
 
 		let pre_hash = block_import_params.header.hash();
-
-		// Reject any header whose canonical (post-seal) digest encodes to more
-		// than the fixed window committed by `Header::hash()`. Past that window
-		// the digest bytes are not covered by the block hash, so silently
-		// truncating (as `hash()` does defensively) would let two distinct
-		// sealed headers collide on the same block hash. Fail closed here
-		// instead, on the same digest that `post_header().hash()` commits below.
-		let post_header = block_import_params.post_header();
-		let encoded_digest_len = post_header.digest().encode().len();
-		if encoded_digest_len > DIGEST_LOGS_SIZE {
-			return Err(Error::<B>::DigestTooLong(
-				post_header.hash(),
-				encoded_digest_len,
-				DIGEST_LOGS_SIZE,
-			)
-			.into());
-		}
 
 		// Convert seal to nonce
 		let nonce: [u8; 64] = inner_seal
@@ -401,6 +397,19 @@ async fn extract_pow_seal<B>(
 where
 	B: BlockT<Hash = H256>,
 {
+	// This is the first point in the import pipeline that hashes a
+	// network-supplied header, and hashing a digest longer than the committed
+	// window trips a debug assertion in `qp-header` (the hash would silently
+	// truncate it). Reject the oversized digest before any `hash()` call; the
+	// authoritative check lives in `import_block`, this one only keeps the
+	// hashing below panic-free in debug builds.
+	let encoded_digest_len = block.header.digest().encode().len();
+	if encoded_digest_len > DIGEST_LOGS_SIZE {
+		return Err(format!(
+			"Header has an encoded digest of {encoded_digest_len} bytes, exceeding the {DIGEST_LOGS_SIZE}-byte commitment window"
+		));
+	}
+
 	let hash = block.header.hash();
 	let header = &mut block.header;
 	let block_hash = hash;

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -13,6 +13,9 @@ use sp_consensus_qpow::{QPoWApi, Seal as RawSeal};
 use sp_runtime::traits::Block as BlockT;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
+use codec::Encode;
+use qp_header::DIGEST_LOGS_SIZE;
+
 use crate::worker::UntilImportedOrTransaction;
 pub use crate::worker::{MiningBuild, MiningHandle, MiningMetadata, RebuildTrigger};
 use futures::{Future, Stream, StreamExt};
@@ -67,6 +70,10 @@ pub enum Error<B: BlockT> {
 	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
 	#[error("Multiple pre-runtime digests")]
 	MultiplePreRuntimeDigests,
+	#[error(
+		"Header {0:?} has an encoded digest of {1} bytes, exceeding the {2}-byte commitment window"
+	)]
+	DigestTooLong(B::Hash, usize, usize),
 	#[error(transparent)]
 	Client(sp_blockchain::Error),
 	#[error(transparent)]
@@ -244,6 +251,23 @@ where
 		)?;
 
 		let pre_hash = block_import_params.header.hash();
+
+		// Reject any header whose canonical (post-seal) digest encodes to more
+		// than the fixed window committed by `Header::hash()`. Past that window
+		// the digest bytes are not covered by the block hash, so silently
+		// truncating (as `hash()` does defensively) would let two distinct
+		// sealed headers collide on the same block hash. Fail closed here
+		// instead, on the same digest that `post_header().hash()` commits below.
+		let post_header = block_import_params.post_header();
+		let encoded_digest_len = post_header.digest().encode().len();
+		if encoded_digest_len > DIGEST_LOGS_SIZE {
+			return Err(Error::<B>::DigestTooLong(
+				post_header.hash(),
+				encoded_digest_len,
+				DIGEST_LOGS_SIZE,
+			)
+			.into());
+		}
 
 		// Convert seal to nonce
 		let nonce: [u8; 64] = inner_seal

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -699,3 +699,82 @@ where
 		.get_difficulty(parent)
 		.map_err(|_| Error::Runtime("Failed to fetch difficulty".into()))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_consensus::BlockOrigin;
+	use sp_runtime::{traits::BlakeTwo256, OpaqueExtrinsic};
+
+	type TestHeader = qp_header::Header<u32, BlakeTwo256>;
+	type TestBlock = sp_runtime::generic::Block<TestHeader, OpaqueExtrinsic>;
+
+	fn sealed_header(digest: Digest) -> TestHeader {
+		<TestHeader as HeaderT>::new(
+			1,
+			Default::default(),
+			Default::default(),
+			Default::default(),
+			digest,
+		)
+	}
+
+	/// The canonical QPoW digest: a 32-byte author preimage plus a 64-byte
+	/// seal, which together encode to exactly `DIGEST_LOGS_SIZE` bytes.
+	fn canonical_digest() -> Digest {
+		Digest {
+			logs: vec![
+				DigestItem::PreRuntime(POW_ENGINE_ID, vec![1u8; 32]),
+				DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64]),
+			],
+		}
+	}
+
+	/// Regression test for the remotely triggerable debug panic: the verifier
+	/// must reject a header whose encoded digest overflows the commitment
+	/// window with a clean error, *without* ever hashing it (`Header::hash()`
+	/// silently truncates past the window, so hashing must not be relied on —
+	/// and used to `debug_assert!` on exactly this input).
+	#[test]
+	fn verifier_rejects_oversized_digest_cleanly() {
+		let mut digest = canonical_digest();
+		// Push the encoded digest past the window while keeping a valid seal
+		// last, so only the length check can be the thing that rejects it.
+		digest.logs.insert(1, DigestItem::Other(vec![0u8; 64]));
+		assert!(digest.encode().len() > DIGEST_LOGS_SIZE);
+
+		let params = BlockImportParams::<TestBlock>::new(
+			BlockOrigin::NetworkBroadcast,
+			sealed_header(digest),
+		);
+		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
+
+		let err = result.err().expect("oversized digest must be rejected");
+		assert!(err.contains("exceeding the"), "expected the digest-length rejection, got: {err}");
+	}
+
+	/// The canonical digest fits the window exactly and must pass the length
+	/// check, with the seal popped into `post_digests`.
+	#[test]
+	fn verifier_accepts_window_sized_digest_and_extracts_seal() {
+		let digest = canonical_digest();
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE);
+
+		let params = BlockImportParams::<TestBlock>::new(
+			BlockOrigin::NetworkBroadcast,
+			sealed_header(digest),
+		);
+		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params))
+			.expect("window-sized sealed header must pass");
+
+		assert_eq!(
+			result.post_digests.last(),
+			Some(&DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64])),
+			"seal must be moved into post_digests"
+		);
+		assert!(
+			!result.header.digest().logs.iter().any(|l| matches!(l, DigestItem::Seal(..))),
+			"seal must be removed from the pre-seal header"
+		);
+	}
+}

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,10 +1,41 @@
 use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
+	sanitize_git_commit_hash_override();
+
 	generate_cargo_keys();
 
 	rerun_if_git_head_changed();
 
 	// Note: Wormhole circuit binaries are now generated at build time by pallet-wormhole's
 	// build.rs. Validation happens there and at runtime when the verifier is initialized.
+}
+
+/// Neutralize Cargo-directive injection through `SUBSTRATE_CLI_GIT_COMMIT_HASH`.
+///
+/// `generate_cargo_keys()` (upstream `substrate-build-script-utils`) trusts this
+/// override after only trimming it and interpolates it into `cargo:rustc-env=`
+/// lines. Cargo's build-script protocol is line-oriented, so a value containing
+/// an embedded newline followed by another `cargo:` instruction (`rustc-cfg`,
+/// `rustc-link-arg`, ...) would be executed as an additional directive — giving
+/// whoever sets the variable (e.g. a CI job sourcing it from release metadata)
+/// authority over the compiled node artifact instead of just its version text.
+///
+/// The value's only legitimate shape is a (short or full) hex Git commit hash,
+/// so enforce that allowlist here, before the helper reads the variable. An
+/// empty value is also inert and kept as-is (upstream then omits the commit
+/// suffix entirely). Anything else is replaced with `unknown`, matching the
+/// helper's own fallback when no hash is available.
+fn sanitize_git_commit_hash_override() {
+	const VAR: &str = "SUBSTRATE_CLI_GIT_COMMIT_HASH";
+	// Longest accepted value: a full SHA-256 Git object name.
+	const MAX_LEN: usize = 64;
+
+	let Ok(hash) = std::env::var(VAR) else { return };
+	let hash = hash.trim();
+	let is_hex = hash.len() <= MAX_LEN && hash.bytes().all(|b| b.is_ascii_hexdigit());
+	if !is_hex {
+		println!("cargo:warning={VAR} is not a hex Git commit hash; using 'unknown'");
+		std::env::set_var(VAR, "unknown");
+	}
 }

--- a/pallets/mining-rewards/Cargo.toml
+++ b/pallets/mining-rewards/Cargo.toml
@@ -23,6 +23,7 @@ frame-support.workspace = true
 frame-system.workspace = true
 log.workspace = true
 pallet-treasury = { path = "../treasury", default-features = false }
+pallet-zk-tree.workspace = true
 qp-wormhole.workspace = true
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-consensus-qpow.workspace = true
@@ -47,6 +48,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-treasury/std",
+	"pallet-zk-tree/std",
 	"qp-wormhole/std",
 	"scale-info/std",
 	"sp-consensus-qpow/std",
@@ -54,4 +56,5 @@ std = [
 ]
 try-runtime = [
 	"frame-support/try-runtime",
+	"pallet-zk-tree/try-runtime",
 ]

--- a/pallets/mining-rewards/src/lib.rs
+++ b/pallets/mining-rewards/src/lib.rs
@@ -203,7 +203,7 @@ pub mod pallet {
 		/// Extract miner wormhole address by hashing the preimage from pre-runtime digest
 		fn extract_miner_from_digest() -> Option<T::AccountId> {
 			let digest = <frame_system::Pallet<T>>::digest();
-			qp_wormhole::extract_author_from_digest(digest.logs.iter().cloned())
+			qp_wormhole::extract_author_from_digest(digest.logs.iter())
 		}
 
 		pub fn collect_transaction_fees(fees: BalanceOf<T>) {

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -53,65 +53,94 @@ pub trait WeightInfo {
 	fn on_finalize_rewarded_miner() -> Weight;
 }
 
+/// Maximum number of ZK-tree leaf inserts a single `on_finalize` can trigger.
+///
+/// `on_finalize` mints up to three rewards — transaction fees and the block
+/// reward to the miner, plus the treasury portion — and each successful mint
+/// records a wormhole transfer proof that inserts one leaf. Priced as three
+/// independent inserts (no cross-insert storage dedup) for a conservative
+/// worst case.
+const MAX_LEAF_INSERTS: u64 = 3;
+
+/// Non-Zk-tree storage measured by the benchmark, split out from the leaf-insert
+/// cost so the latter can be priced at the live tree depth. Covers
+/// `MiningRewards::CollectedFees` (r1 w1), `TreasuryPallet::TreasuryPortion`
+/// (r1), `TreasuryPallet::TreasuryAccount` (r1), `System::Account` (r2 w2) and
+/// `Wormhole::TransferCount` (r2 w2).
+const BASE_READS: u64 = 7;
+const BASE_WRITES: u64 = 5;
+
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
-impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	/// Storage: `MiningRewards::CollectedFees` (r:1 w:1)
-	/// Proof: `MiningRewards::CollectedFees` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	/// Storage: `TreasuryPallet::TreasuryPortion` (r:1 w:0)
-	/// Proof: `TreasuryPallet::TreasuryPortion` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
-	/// Storage: `TreasuryPallet::TreasuryAccount` (r:1 w:0)
-	/// Proof: `TreasuryPallet::TreasuryAccount` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
-	/// Storage: `System::Account` (r:2 w:2)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
-	/// Storage: `Wormhole::TransferCount` (r:2 w:2)
-	/// Proof: `Wormhole::TransferCount` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::LeafCount` (r:1 w:1)
-	/// Proof: `ZkTree::LeafCount` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Depth` (r:1 w:1)
-	/// Proof: `ZkTree::Depth` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Leaves` (r:3 w:3)
-	/// Proof: `ZkTree::Leaves` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Root` (r:0 w:1)
-	/// Proof: `ZkTree::Root` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateWeight<T> {
+	/// `on_finalize` mints up to three rewards, each recording a wormhole transfer
+	/// proof whose ZK-tree leaf insert walks the tree leaf-to-root. That insert
+	/// cost grows with the *current* tree depth, so it is priced from live storage
+	/// (`insert_leaf_db_ops`) rather than the shallow value the benchmark measured —
+	/// otherwise this mandatory hook silently under-charges as the shared tree
+	/// deepens. The compute time and proof size stay at the benchmarked values; the
+	/// depth-sensitive cost is the extra tree reads/writes, mirroring the runtime's
+	/// per-transfer proof metering.
 	fn on_finalize_rewarded_miner() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `568`
-		//  Estimated: `8619`
 		// Minimum execution time: 161_000_000 picoseconds.
+		let (tree_reads, tree_writes) = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		Weight::from_parts(163_000_000, 8619)
-			.saturating_add(T::DbWeight::get().reads(12_u64))
-			.saturating_add(T::DbWeight::get().writes(11_u64))
+			.saturating_add(T::DbWeight::get().reads(
+				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
+			))
+			.saturating_add(T::DbWeight::get().writes(
+				BASE_WRITES.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_writes)),
+			))
 	}
 }
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
-	/// Storage: `MiningRewards::CollectedFees` (r:1 w:1)
-	/// Proof: `MiningRewards::CollectedFees` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	/// Storage: `TreasuryPallet::TreasuryPortion` (r:1 w:0)
-	/// Proof: `TreasuryPallet::TreasuryPortion` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
-	/// Storage: `TreasuryPallet::TreasuryAccount` (r:1 w:0)
-	/// Proof: `TreasuryPallet::TreasuryAccount` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
-	/// Storage: `System::Account` (r:2 w:2)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
-	/// Storage: `Wormhole::TransferCount` (r:2 w:2)
-	/// Proof: `Wormhole::TransferCount` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::LeafCount` (r:1 w:1)
-	/// Proof: `ZkTree::LeafCount` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Depth` (r:1 w:1)
-	/// Proof: `ZkTree::Depth` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Leaves` (r:3 w:3)
-	/// Proof: `ZkTree::Leaves` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
-	/// Storage: `ZkTree::Root` (r:0 w:1)
-	/// Proof: `ZkTree::Root` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	/// Depth-blind fallback: the leaf inserts are priced at `MAX_TREE_DEPTH` so this
+	/// can never charge less than `SubstrateWeight` at any live tree depth.
 	fn on_finalize_rewarded_miner() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `568`
-		//  Estimated: `8619`
 		// Minimum execution time: 161_000_000 picoseconds.
+		let (tree_reads, tree_writes) =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		Weight::from_parts(163_000_000, 8619)
-			.saturating_add(RocksDbWeight::get().reads(12_u64))
-			.saturating_add(RocksDbWeight::get().writes(11_u64))
+			.saturating_add(RocksDbWeight::get().reads(
+				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
+			))
+			.saturating_add(RocksDbWeight::get().writes(
+				BASE_WRITES.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_writes)),
+			))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The depth-blind fallback must price its leaf inserts at `MAX_TREE_DEPTH`,
+	/// so it can never charge less than the live-depth `SubstrateWeight`.
+	#[test]
+	fn fallback_prices_leaf_inserts_at_max_depth() {
+		let (tree_reads, tree_writes) =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		let expected = Weight::from_parts(163_000_000, 8619)
+			.saturating_add(RocksDbWeight::get().reads(
+				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
+			))
+			.saturating_add(RocksDbWeight::get().writes(
+				BASE_WRITES.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_writes)),
+			));
+		assert_eq!(<() as WeightInfo>::on_finalize_rewarded_miner(), expected);
+	}
+
+	/// The mandatory hook's reserved weight must grow with tree depth — that is the
+	/// whole point of pricing the leaf inserts from live depth rather than a flat
+	/// benchmark constant.
+	#[test]
+	fn reserved_weight_grows_with_tree_depth() {
+		let (shallow_r, shallow_w) = pallet_zk_tree::insert_leaf_db_ops_at_depth(1);
+		let (deep_r, deep_w) =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		assert!(deep_r > shallow_r, "leaf-insert reads must grow with depth");
+		assert!(deep_w > shallow_w, "leaf-insert writes must grow with depth");
 	}
 }

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -72,18 +72,21 @@ const BASE_WRITES: u64 = 5;
 
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
-impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateWeight<T> {
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// `on_finalize` mints up to three rewards, each recording a wormhole transfer
-	/// proof whose ZK-tree leaf insert walks the tree leaf-to-root. That insert
-	/// cost grows with the *current* tree depth, so it is priced from live storage
-	/// (`insert_leaf_db_ops`) rather than the shallow value the benchmark measured —
-	/// otherwise this mandatory hook silently under-charges as the shared tree
-	/// deepens. The compute time and proof size stay at the benchmarked values; the
-	/// depth-sensitive cost is the extra tree reads/writes, mirroring the runtime's
-	/// per-transfer proof metering.
+	/// proof whose ZK-tree leaf insert walks the tree leaf-to-root, so its cost
+	/// grows with the tree depth *at finalize*. This weight is reserved in
+	/// `on_initialize`, before any extrinsics run, and the tree can grow by several
+	/// depths in between (a single public-batch exit bundle inserts hundreds of
+	/// leaves), so the start-of-block depth — even plus one — is not a bound on the
+	/// depth the hook will walk. Mandatory finalization cannot correct its consumed
+	/// weight afterwards, so the leaf inserts are priced at `MAX_TREE_DEPTH`, the
+	/// only provable upper bound. The compute time and proof size stay at the
+	/// benchmarked values; the depth-sensitive cost is the tree reads/writes.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 161_000_000 picoseconds.
-		let (tree_reads, tree_writes) = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
+		let (tree_reads, tree_writes) =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		Weight::from_parts(163_000_000, 8619)
 			.saturating_add(T::DbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
@@ -96,8 +99,8 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
-	/// Depth-blind fallback: the leaf inserts are priced at `MAX_TREE_DEPTH` so this
-	/// can never charge less than `SubstrateWeight` at any live tree depth.
+	/// Same worst-case (`MAX_TREE_DEPTH`) pricing as `SubstrateWeight`, with
+	/// `RocksDbWeight` in place of the runtime's configured `DbWeight`.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 161_000_000 picoseconds.
 		let (tree_reads, tree_writes) =
@@ -116,31 +119,49 @@ impl WeightInfo for () {
 mod tests {
 	use super::*;
 
-	/// The depth-blind fallback must price its leaf inserts at `MAX_TREE_DEPTH`,
-	/// so it can never charge less than the live-depth `SubstrateWeight`.
-	#[test]
-	fn fallback_prices_leaf_inserts_at_max_depth() {
-		let (tree_reads, tree_writes) =
-			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
-		let expected = Weight::from_parts(163_000_000, 8619)
+	/// The finalize cost the hook actually incurs when the tree sits at `depth`
+	/// while it runs: the benchmarked base plus three leaf inserts at that depth.
+	fn finalize_cost_at_depth(depth: u8) -> Weight {
+		let (tree_reads, tree_writes) = pallet_zk_tree::insert_leaf_db_ops_at_depth(depth);
+		Weight::from_parts(163_000_000, 8619)
 			.saturating_add(RocksDbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
 			.saturating_add(RocksDbWeight::get().writes(
 				BASE_WRITES.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_writes)),
-			));
-		assert_eq!(<() as WeightInfo>::on_finalize_rewarded_miner(), expected);
+			))
 	}
 
-	/// The mandatory hook's reserved weight must grow with tree depth — that is the
-	/// whole point of pricing the leaf inserts from live depth rather than a flat
-	/// benchmark constant.
+	/// Regression test for the stale-depth hole: the weight is reserved in
+	/// `on_initialize` (shallow tree), but intervening extrinsics can grow the tree
+	/// by any number of depths before `on_finalize` walks it — a single public-batch
+	/// exit bundle alone inserts hundreds of leaves. The reserved weight must
+	/// therefore cover the finalize cost at *every* depth the tree can reach by
+	/// end of block, up to the hard `MAX_TREE_DEPTH` cap, not just the
+	/// start-of-block depth plus one.
 	#[test]
-	fn reserved_weight_grows_with_tree_depth() {
-		let (shallow_r, shallow_w) = pallet_zk_tree::insert_leaf_db_ops_at_depth(1);
-		let (deep_r, deep_w) =
-			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
-		assert!(deep_r > shallow_r, "leaf-insert reads must grow with depth");
-		assert!(deep_w > shallow_w, "leaf-insert writes must grow with depth");
+	fn reserved_weight_covers_any_end_of_block_depth() {
+		// The reservation is depth-independent (it never reads the live tree), so
+		// what it returns at the shallow start-of-block state is what the block got.
+		let reserved = <() as WeightInfo>::on_finalize_rewarded_miner();
+
+		for end_depth in 0..=pallet_zk_tree::MAX_TREE_DEPTH {
+			let cost = finalize_cost_at_depth(end_depth);
+			assert!(
+				reserved.all_gte(cost),
+				"reserved weight {reserved:?} must cover finalize at depth {end_depth} ({cost:?})"
+			);
+		}
+	}
+
+	/// The weight must price its leaf inserts at `MAX_TREE_DEPTH`: it is the only
+	/// upper bound on the tree depth at finalize that holds regardless of what runs
+	/// earlier in the block. (`SubstrateWeight` is the identical formula with the
+	/// runtime's configured `DbWeight`; the mock's zero `DbWeight` makes asserting
+	/// on it vacuous, so only the RocksDb fallback is pinned here.)
+	#[test]
+	fn weight_is_priced_at_max_tree_depth() {
+		let expected = finalize_cost_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		assert_eq!(<() as WeightInfo>::on_finalize_rewarded_miner(), expected);
 	}
 }

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -770,11 +770,10 @@ pub mod pallet {
 				// summed, inflated exit. `insert` returns false the first time a value
 				// repeats, so `all` is false iff any duplicate exists.
 				let mut seen = alloc::collections::BTreeSet::<[u8; 32]>::new();
-				let intra_segment_unique =
-					nullifier_bytes.iter().all(|bytes| seen.insert(*bytes));
+				let intra_segment_unique = nullifier_bytes.iter().all(|bytes| seen.insert(*bytes));
 
-				let valid = intra_segment_unique
-					&& nullifier_bytes.iter().all(|bytes| {
+				let valid = intra_segment_unique &&
+					nullifier_bytes.iter().all(|bytes| {
 						!UsedNullifiers::<T>::contains_key(bytes) && !claimed.contains(bytes)
 					});
 
@@ -1099,8 +1098,7 @@ pub mod pallet {
 			// value out of the total cannot enable a double-mint. The soundness bound
 			// `exits_after <= potential_balance` was checked above against the full total,
 			// which is an upper bound on this committed value.
-			let committed_exits =
-				TotalWormholeExits::<T>::get().saturating_add(minted_exit_amount);
+			let committed_exits = TotalWormholeExits::<T>::get().saturating_add(minted_exit_amount);
 			debug_assert!(committed_exits <= exits_after);
 			TotalWormholeExits::<T>::put(committed_exits);
 

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -232,11 +232,12 @@ pub mod pallet {
 	///   `TotalWormholeExits`). The v0 -> v1 migration seeds `PotentialWormholeBalance` so that
 	///   wormhole deposits made before the soundness tracking existed can still be exited (see
 	///   `migrations::v1`).
-	/// - v2 re-keys `TransferCount` onto the Goldilocks-canonical recipient form. The v1 -> v2
-	///   migration merges any pre-upgrade raw-keyed entries into their canonical key (see
-	///   `migrations::v2`) so prospective deposits cannot restart a count sequence that collides
-	///   with pre-upgrade leaves.
-	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	///
+	/// `TransferCount` is keyed on the Goldilocks-canonical recipient form, but that is enforced
+	/// in `record_transfer` at write time (see `canonical_leaf_recipient` and the test
+	/// `deposits_to_non_canonical_alias_do_not_collide_with_canonical_leaf`), not by a storage
+	/// migration — the layout is unchanged — so it does not carry its own storage version.
+	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -991,7 +991,7 @@ pub mod pallet {
 				if let Some(author) = qp_wormhole::extract_author_from_digest::<
 					<T as frame_system::Config>::AccountId,
 					_,
-				>(digest.logs.iter().cloned())
+				>(digest.logs.iter())
 				{
 					<T::Currency as Unbalanced<_>>::increase_balance(
 						&author,

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -721,10 +721,15 @@ pub mod pallet {
 
 		/// Compute per-segment validity for an exit bundle.
 		///
-		/// A segment is valid iff none of its nullifiers is already used on-chain and none
-		/// appeared in an earlier valid segment of the same bundle. Duplicates *within* a
-		/// segment are allowed: the private-batch circuit's exit dedup zeroes the repeated
-		/// exit slots (so they mint nothing) and re-inserting a nullifier is idempotent.
+		/// A segment is valid iff none of its real nullifiers is already used on-chain,
+		/// none appeared in an earlier valid segment of the same bundle, and none is
+		/// repeated *within* the segment itself. Intra-segment duplicates are rejected
+		/// because the private-batch circuit's exit grouping sums a replayed leaf's amount
+		/// into a single inflated exit while only one shared nullifier would be marked
+		/// spent — accepting the duplicate would mint value backed by a single spend. A
+		/// well-formed batch never repeats a real nullifier, so this only rejects replays.
+		/// (The circuit now also enforces this, but the check is cheap and kept here as an
+		/// in-consensus defense that does not trust the aggregation circuit's constraints.)
 		/// Zero nullifiers (from dummy leaf padding inside a real private batch) mint
 		/// nothing and are exempt from the collision checks entirely.
 		pub(crate) fn segment_validity(bundle: &ExitBundle) -> Result<Vec<bool>, Error<T>> {
@@ -749,9 +754,18 @@ pub mod pallet {
 					nullifier_bytes.push(bytes);
 				}
 
-				let valid = nullifier_bytes.iter().all(|bytes| {
-					!UsedNullifiers::<T>::contains_key(bytes) && !claimed.contains(bytes)
-				});
+				// A real nullifier repeated within this segment can only be a leaf proof
+				// replayed across slots; reject the whole segment before it can mint the
+				// summed, inflated exit. `insert` returns false the first time a value
+				// repeats, so `all` is false iff any duplicate exists.
+				let mut seen = alloc::collections::BTreeSet::<[u8; 32]>::new();
+				let intra_segment_unique =
+					nullifier_bytes.iter().all(|bytes| seen.insert(*bytes));
+
+				let valid = intra_segment_unique
+					&& nullifier_bytes.iter().all(|bytes| {
+						!UsedNullifiers::<T>::contains_key(bytes) && !claimed.contains(bytes)
+					});
 
 				if valid {
 					claimed.extend(nullifier_bytes);

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -503,6 +503,16 @@ pub mod pallet {
 		SegmentsDenied {
 			indices: Vec<u32>,
 		},
+		/// An exit slot could not be minted (e.g. a below-existential-deposit credit to
+		/// a fresh account) and was skipped so the rest of the bundle still processed.
+		/// The skipped exit's nullifier stays marked, so this exit cannot be retried.
+		///
+		/// NOTE: keep new variants appended at the end — indexers decode events by their
+		/// position in this enum, so existing variants must never be reordered.
+		ExitMintFailed {
+			account: <T as frame_system::Config>::AccountId,
+			amount: BalanceOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -993,15 +1003,30 @@ pub mod pallet {
 					_,
 				>(digest.logs.iter())
 				{
-					<T::Currency as Unbalanced<_>>::increase_balance(
+					// A failed miner-fee mint (e.g. the author account doesn't exist and
+					// the fee is below the existential deposit) must not revert the whole
+					// bundle and drag users' exits down with it. Burn it instead, exactly
+					// like the no-author branch below and the aggregator-rebate fallback.
+					match <T::Currency as Unbalanced<_>>::increase_balance(
 						&author,
 						miner_fee,
 						frame_support::traits::tokens::Precision::Exact,
-					)?;
-					Self::deposit_event(Event::MinerVolumeFeePaid {
-						miner: author,
-						amount: miner_fee,
-					});
+					) {
+						Ok(_) => {
+							Self::deposit_event(Event::MinerVolumeFeePaid {
+								miner: author,
+								amount: miner_fee,
+							});
+						},
+						Err(e) => {
+							log::warn!(
+								"Miner fee of {:?} could not be minted ({:?}); burning it instead",
+								miner_fee,
+								e
+							);
+							burn_amount_u128 = burn_amount_u128.saturating_add(miner_fee_u128);
+						},
+					}
 				} else {
 					// No block author found - add miner fee to burn amount
 					log::warn!(
@@ -1025,13 +1050,38 @@ pub mod pallet {
 			}
 
 			// Process transfers and record proofs
+			let mut minted_exit_amount: BalanceOf<T> = Zero::zero();
 			for (exit_account, exit_balance) in &processed_accounts {
-				// Native token transfer - mint tokens to the exit account
-				<T::Currency as Unbalanced<_>>::increase_balance(
+				// Native token transfer - mint tokens to the exit account.
+				//
+				// A single exit that can't be minted (e.g. a below-existential-deposit
+				// credit to a fresh account) must not revert the whole bundle and deny
+				// every co-bundled user's exit — that is the per-segment isolation
+				// documented on `ExitSegment`. Skip just this slot; its nullifier is
+				// already marked so the deposit cannot be re-exited, and the skipped
+				// value is left out of the committed exit total below.
+				match <T::Currency as Unbalanced<_>>::increase_balance(
 					exit_account,
 					*exit_balance,
 					frame_support::traits::tokens::Precision::Exact,
-				)?;
+				) {
+					Ok(_) => {},
+					Err(e) => {
+						log::warn!(
+							"Exit mint of {:?} to {:?} failed ({:?}); skipping this exit",
+							*exit_balance,
+							exit_account,
+							e
+						);
+						Self::deposit_event(Event::ExitMintFailed {
+							account: exit_account.clone(),
+							amount: *exit_balance,
+						});
+						continue;
+					},
+				}
+
+				minted_exit_amount = minted_exit_amount.saturating_add(*exit_balance);
 
 				// Record transfer proof for the minted tokens
 				let from_account: <T as Config>::WormholeAccountId = mint_account.clone().into();
@@ -1044,9 +1094,15 @@ pub mod pallet {
 				);
 			}
 
-			// Commit the new cumulative exit total now that all exits succeeded. The invariant
-			// `exits_after <= potential_balance` was checked above before any minting.
-			TotalWormholeExits::<T>::put(exits_after);
+			// Commit only the exits that actually minted. Skipped exits keep their
+			// nullifiers marked (their deposits can never be re-exited), so leaving their
+			// value out of the total cannot enable a double-mint. The soundness bound
+			// `exits_after <= potential_balance` was checked above against the full total,
+			// which is an upper bound on this committed value.
+			let committed_exits =
+				TotalWormholeExits::<T>::get().saturating_add(minted_exit_amount);
+			debug_assert!(committed_exits <= exits_after);
+			TotalWormholeExits::<T>::put(committed_exits);
 
 			// Success - use declared weight (actual_weight: None means use declared weight)
 			Ok(PostDispatchInfo { actual_weight: None, pays_fee: Pays::No })

--- a/pallets/wormhole/src/migrations.rs
+++ b/pallets/wormhole/src/migrations.rs
@@ -2,7 +2,8 @@
 
 extern crate alloc;
 
-use crate::{Config, Pallet, PotentialWormholeBalance, TransferCount};
+use crate::{Config, Pallet, PotentialWormholeBalance};
+#[cfg(feature = "try-runtime")]
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use frame_support::{
@@ -70,113 +71,15 @@ pub type MigrateV0ToV1<T> = frame_support::migrations::VersionedMigration<
 	<T as frame_system::Config>::DbWeight,
 >;
 
-/// v1 -> v2: re-key `TransferCount` onto the Goldilocks-canonical recipient form.
-pub mod v2 {
-	use super::*;
-	use pallet_zk_tree::tree::canonicalize_account_bytes;
-
-	fn max_count<T: Config>(a: T::TransferCount, b: T::TransferCount) -> T::TransferCount {
-		if a.into() >= b.into() {
-			a
-		} else {
-			b
-		}
-	}
-
-	/// Merges any pre-upgrade `TransferCount` entries keyed on non-canonical recipients into
-	/// their canonical key (max of the counts), then removes the raw keys.
-	///
-	/// Prospective `record_transfer` calls key on the canonical form. Without this merge, a
-	/// pre-upgrade deposit to a non-canonical alias leaves count state under the raw key while
-	/// post-upgrade deposits to that leaf-encoding class restart from the (empty) canonical
-	/// key — recreating the leaf/nullifier collision the canonical re-keying was meant to
-	/// fix. Taking the max count ensures the next deposit uses a fresh index past every
-	/// already-committed leaf in the class. Already-colliding pre-upgrade leaves (if any)
-	/// cannot be rewritten here; this only prevents *new* collisions.
-	pub struct CanonicalizeTransferCountKeys<T>(PhantomData<T>);
-
-	impl<T: Config> UncheckedOnRuntimeUpgrade for CanonicalizeTransferCountKeys<T> {
-		fn on_runtime_upgrade() -> Weight {
-			let mut reads: u64 = 0;
-			let mut writes: u64 = 0;
-			let mut merged: u64 = 0;
-
-			// Collect first — mutating the map while iterating is unsafe.
-			let mut aliases: Vec<(T::WormholeAccountId, T::TransferCount)> = Vec::new();
-			for (key, count) in TransferCount::<T>::iter() {
-				reads = reads.saturating_add(1);
-				let Ok(bytes) = <[u8; 32]>::try_from(key.as_ref()) else {
-					continue;
-				};
-				let canonical = canonicalize_account_bytes(bytes);
-				if canonical != bytes {
-					aliases.push((key, count));
-				}
-			}
-
-			for (raw_key, raw_count) in aliases {
-				let Ok(bytes) = <[u8; 32]>::try_from(raw_key.as_ref()) else {
-					continue;
-				};
-				let canonical_key: T::WormholeAccountId = canonicalize_account_bytes(bytes).into();
-				let existing = TransferCount::<T>::get(&canonical_key);
-				reads = reads.saturating_add(1);
-				let merged_count = max_count::<T>(existing, raw_count);
-				TransferCount::<T>::insert(&canonical_key, merged_count);
-				TransferCount::<T>::remove(&raw_key);
-				writes = writes.saturating_add(2);
-				merged = merged.saturating_add(1);
-			}
-
-			log::info!(
-				target: "runtime::wormhole",
-				"Canonicalized TransferCount keys: merged {} non-canonical entries",
-				merged,
-			);
-
-			T::DbWeight::get().reads_writes(reads, writes)
-		}
-
-		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
-			use codec::Encode;
-			let non_canonical = TransferCount::<T>::iter()
-				.filter(|(key, _)| {
-					<[u8; 32]>::try_from(key.as_ref())
-						.map(|bytes| canonicalize_account_bytes(bytes) != bytes)
-						.unwrap_or(false)
-				})
-				.count() as u64;
-			Ok(non_canonical.encode())
-		}
-
-		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-			use codec::Decode;
-			let _pre: u64 = u64::decode(&mut &state[..])
-				.map_err(|_| "failed to decode pre_upgrade TransferCount alias count")?;
-			let remaining = TransferCount::<T>::iter()
-				.filter(|(key, _)| {
-					<[u8; 32]>::try_from(key.as_ref())
-						.map(|bytes| canonicalize_account_bytes(bytes) != bytes)
-						.unwrap_or(false)
-				})
-				.count();
-			frame_support::ensure!(
-				remaining == 0,
-				"TransferCount must have no non-canonical keys after v2 migration"
-			);
-			Ok(())
-		}
-	}
-}
-
-/// Versioned v1 -> v2 migration. Runs [`v2::CanonicalizeTransferCountKeys`] only when the
-/// on-chain storage version is 1, then bumps the on-chain storage version to 2.
-pub type MigrateV1ToV2<T> = frame_support::migrations::VersionedMigration<
-	1,
-	2,
-	v2::CanonicalizeTransferCountKeys<T>,
-	Pallet<T>,
-	<T as frame_system::Config>::DbWeight,
->;
+// There is intentionally no v1 -> v2 migration. `TransferCount` is keyed on the
+// Goldilocks-canonical recipient form, but that is enforced in `record_transfer` at write time
+// (see `Pallet::canonical_leaf_recipient`), not by a storage migration — the layout is
+// unchanged. An earlier design added a v1 -> v2 migration that merged any pre-upgrade entries
+// keyed on a non-canonical recipient into their canonical key; it iterated the entire
+// `TransferCount` map (an unbounded, permissionlessly-grown `StorageMap`) and collected matches
+// into a `Vec`, all in a single upgrade block with no batching, cursor, or weight bound. Because
+// the map size is attacker-controlled, an inflated map could push that migration past the block
+// execution/memory budget and stall the upgrade. It was removed rather than bounded because it
+// had no work to do on any real deployment: a live audit of the only pre-v2 chain (Planck
+// testnet) found 0 non-canonical keys out of 2738 entries, fresh chains never run it, and
+// `record_transfer` canonicalizes at write time so no new non-canonical keys can appear.

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -1713,6 +1713,57 @@ mod exit_bundle_tests {
 	}
 
 	#[test]
+	fn process_exit_bundle_skips_below_ed_exit_without_reverting_others() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			PotentialWormholeBalance::<Test>::put(1_000_000 * UNIT);
+
+			// Raise the ED so a small exit to a fresh account cannot be minted, while a
+			// larger co-bundled exit clears it. AMOUNT_A (20 QUAN) stays below the ED;
+			// AMOUNT_B (30 QUAN) is above it. The bundle total still clears the 10 QUAN
+			// MinimumTransferAmount.
+			ExistentialDeposit::set(scaled(2500));
+
+			let dust_exit = AccountId32::new([10u8; 32]);
+			let good_exit = AccountId32::new([11u8; 32]);
+
+			// Two independent segments (as in a public batch): a dust-to-fresh-account
+			// exit and an honest above-ED exit. The dust one must be skipped, not abort
+			// the whole bundle.
+			let b = bundle(
+				vec![segment(&[1], &[(10, AMOUNT_A)]), segment(&[2], &[(11, AMOUNT_B)])],
+				None,
+			);
+			assert_ok!(Wormhole::process_exit_bundle(b));
+
+			// The honest exit landed; the below-ED exit was skipped (account not created).
+			assert_eq!(Balances::balance(&good_exit), scaled(AMOUNT_B));
+			assert_eq!(
+				Balances::balance(&dust_exit),
+				0,
+				"below-ED exit must be skipped, not create the account"
+			);
+
+			// A skip event was surfaced for the dust exit.
+			System::assert_has_event(
+				crate::Event::<Test>::ExitMintFailed {
+					account: dust_exit.clone(),
+					amount: scaled(AMOUNT_A),
+				}
+				.into(),
+			);
+
+			// Only the successfully minted exit is committed to the cumulative total.
+			assert_eq!(TotalWormholeExits::<Test>::get(), scaled(AMOUNT_B));
+
+			// Both segments' nullifiers are marked used: the skipped exit's deposit
+			// cannot be re-exited (isolation, not a free retry).
+			assert!(UsedNullifiers::<Test>::contains_key(nullifier_bytes(1)));
+			assert!(UsedNullifiers::<Test>::contains_key(nullifier_bytes(2)));
+		});
+	}
+
+	#[test]
 	fn process_exit_bundle_burns_rebate_when_aggregator_mint_fails() {
 		new_test_ext().execute_with(|| {
 			System::set_block_number(1);

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -576,7 +576,6 @@ mod wormhole_tests {
 			);
 		});
 	}
-
 }
 
 /// Tests for private-batch proof verification

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -577,49 +577,6 @@ mod wormhole_tests {
 		});
 	}
 
-	/// Pre-upgrade `TransferCount` entries keyed on non-canonical recipients must be merged
-	/// into the canonical key (max of the counts) so post-upgrade deposits cannot restart a
-	/// count sequence that collides with already-committed leaves.
-	#[test]
-	fn migration_merges_non_canonical_transfer_count_keys() {
-		use frame_support::traits::UncheckedOnRuntimeUpgrade;
-		use pallet_zk_tree::tree::{canonicalize_account_bytes, GOLDILOCKS_P};
-
-		new_test_ext().execute_with(|| {
-			// Non-canonical: first limb = p + 7 (reduces to 7). Canonical sibling has limb 7.
-			let mut raw_bytes = [0u8; 32];
-			raw_bytes[0..8].copy_from_slice(&(GOLDILOCKS_P + 7).to_le_bytes());
-			let raw = AccountId::from(raw_bytes);
-			let canonical = AccountId::from(canonicalize_account_bytes(raw_bytes));
-			assert_ne!(raw, canonical);
-
-			crate::TransferCount::<Test>::insert(&raw, 5u64);
-			crate::TransferCount::<Test>::insert(&canonical, 3u64);
-
-			crate::migrations::v2::CanonicalizeTransferCountKeys::<Test>::on_runtime_upgrade();
-
-			assert!(
-				!crate::TransferCount::<Test>::contains_key(&raw),
-				"non-canonical TransferCount key must be removed"
-			);
-			assert_eq!(
-				crate::TransferCount::<Test>::get(&canonical),
-				5,
-				"canonical key must keep the max of the alias and canonical counts"
-			);
-
-			// A fresh deposit to either form must continue from the merged count (5), not
-			// restart at 0 under the canonical key.
-			let from = account_id(1);
-			Wormhole::record_transfer(0u32, &from, &canonical, 10 * UNIT);
-			assert_eq!(crate::TransferCount::<Test>::get(&canonical), 6);
-			assert_eq!(
-				crate::TransferCount::<Test>::get(&raw),
-				0,
-				"raw alias must stay empty after merge"
-			);
-		});
-	}
 }
 
 /// Tests for private-batch proof verification

--- a/primitives/header/src/lib.rs
+++ b/primitives/header/src/lib.rs
@@ -249,21 +249,17 @@ where
 		));
 
 		// digest – SCALE encode then pad to the fixed DIGEST_LOGS_SIZE window to
-		// match circuit expectation. An encoded digest longer than the window
-		// is a malformed header that the import path rejects before this point
-		// (see the digest length check in `sc-consensus-qpow`); truncating here
-		// would drop the tail from the committed hash and let two distinct
-		// headers collide. `hash()` itself must stay infallible even on
-		// adversarial bytes, so we keep the saturating copy as a backstop and
-		// only assert the invariant in debug builds.
+		// match circuit expectation. Bytes past the window are NOT committed by
+		// this hash: an encoded digest longer than the window would let two
+		// distinct headers collide, which is why the import path rejects such
+		// headers outright (see the digest length checks in `sc-consensus-qpow`).
+		// No assertion here, not even a debug one: generic network code hashes
+		// completely unverified headers long before any consensus check runs
+		// (e.g. block-announce validation in `sc-network-sync` hashes the
+		// announced header on receipt), so `hash()` must accept arbitrary
+		// adversarial input and the saturating copy below is the required
+		// behavior, not a backstop.
 		let digest_encoded = self.digest.encode();
-		debug_assert!(
-			digest_encoded.len() <= DIGEST_LOGS_SIZE,
-			"encoded digest ({} bytes) exceeds DIGEST_LOGS_SIZE ({}); header should have been \
-			 rejected before hashing",
-			digest_encoded.len(),
-			DIGEST_LOGS_SIZE,
-		);
 		let mut digest_padded = [0u8; DIGEST_LOGS_SIZE];
 		let copy_len = digest_encoded.len().min(DIGEST_LOGS_SIZE);
 		digest_padded[..copy_len].copy_from_slice(&digest_encoded[..copy_len]);
@@ -471,20 +467,8 @@ mod tests {
 		);
 	}
 
-	/// A digest larger than the window must trip the invariant in `hash()`
-	/// rather than silently truncate. `hash()` keeps a saturating backstop in
-	/// release, so this only asserts in debug builds (where `debug_assert`
-	/// fires); the real rejection for release is the import-path length check
-	/// in `sc-consensus-qpow`.
-	#[cfg(debug_assertions)]
-	#[test]
-	#[should_panic(expected = "exceeds DIGEST_LOGS_SIZE")]
-	fn oversized_digest_trips_hash_invariant() {
-		let mut digest = canonical_pow_digest();
-		// One extra item pushes the encoded digest past the 110-byte window.
-		digest.logs.push(DigestItem::Other(vec![0u8; 8]));
-
-		let header = Header::<u32, BlakeTwo256> {
+	fn header_with_digest(digest: Digest) -> Header<u32, BlakeTwo256> {
+		Header::<u32, BlakeTwo256> {
 			parent_hash: Default::default(),
 			number: 1,
 			state_root: Default::default(),
@@ -492,8 +476,43 @@ mod tests {
 			zk_tree_root: Default::default(),
 			digest,
 			_marker: core::marker::PhantomData,
-		};
+		}
+	}
 
-		let _ = header.hash();
+	/// `hash()` must accept an oversized digest without panicking, even in
+	/// debug builds: generic network code (e.g. block-announce validation in
+	/// `sc-network-sync`) hashes completely unverified headers before any
+	/// consensus check runs, so any assertion here would be a remotely
+	/// triggerable node crash. This test also documents the consequence of
+	/// that infallibility — bytes past the window are not committed, so two
+	/// headers differing only there collide — which is exactly why the import
+	/// path in `sc-consensus-qpow` rejects oversized digests outright.
+	#[test]
+	fn oversized_digest_hashes_infallibly_but_is_not_committed_past_window() {
+		// The canonical digest fills the window exactly, so a third item's
+		// payload lands entirely past `DIGEST_LOGS_SIZE` (the extra item does
+		// not change the compact length prefix: 3 < 64 still encodes in one
+		// byte, so the first two items' bytes keep their offsets).
+		let mut digest_a = canonical_pow_digest();
+		digest_a.logs.push(DigestItem::Other(vec![0x00u8; 8]));
+		let mut digest_b = canonical_pow_digest();
+		digest_b.logs.push(DigestItem::Other(vec![0xffu8; 8]));
+
+		assert!(digest_a.encode().len() > DIGEST_LOGS_SIZE);
+		assert_eq!(digest_a.encode().len(), digest_b.encode().len());
+
+		// Infallible: no panic on either. Colliding: the differing tails are
+		// past the committed window.
+		let hash_a = header_with_digest(digest_a).hash();
+		let hash_b = header_with_digest(digest_b).hash();
+		assert_eq!(
+			hash_a, hash_b,
+			"digest bytes past the window are not committed by the hash; such headers \
+			 must be rejected at import instead"
+		);
+
+		// Sanity: a within-window digest change does alter the hash.
+		let hash_canonical = header_with_digest(canonical_pow_digest()).hash();
+		assert_ne!(hash_a, hash_canonical);
 	}
 }

--- a/primitives/header/src/lib.rs
+++ b/primitives/header/src/lib.rs
@@ -31,6 +31,20 @@ use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// Size of the fixed digest window (in bytes) committed by [`Header::hash`].
+///
+/// The SCALE-encoded digest is folded into the Poseidon preimage through a
+/// buffer of exactly this size, and the wormhole circuit hashes a digest field
+/// of the same width. It is sized to hold exactly one 32-byte pre-runtime
+/// preimage plus one 64-byte PoW seal (the canonical post-seal digest), so a
+/// well-formed header uses the whole window with no slack.
+///
+/// Headers whose encoded digest exceeds this bound must be **rejected** before
+/// import rather than silently truncated; see the digest length check in
+/// `sc-consensus-qpow`. Truncation would let two distinct headers share a block
+/// hash on the bytes past this window.
+pub const DIGEST_LOGS_SIZE: usize = 110;
+
 /// Extension trait for headers that support ZK tree root.
 ///
 /// This trait allows frame_system to set the ZK Merkle tree root on headers
@@ -193,9 +207,6 @@ where
 	/// Convenience helper for computing the hash of the header without having
 	/// to import the trait.
 	pub fn hash(&self) -> H256 {
-		/// Fixed size for digest encoding - must match circuit expectation
-		const DIGEST_LOGS_SIZE: usize = 110;
-
 		// 4 hash fields (4 felts each) + 1 u32 + 28 felts for injective digest encoding
 		let max_encoded_felts = 4 * 4 + 1 + 28;
 		let mut felts = Vec::with_capacity(max_encoded_felts);
@@ -237,8 +248,22 @@ where
 			self.zk_tree_root.as_ref().try_into().expect("hash is 32 bytes"),
 		));
 
-		// digest – SCALE encode then pad to fixed 110 bytes to match circuit expectation
+		// digest – SCALE encode then pad to the fixed DIGEST_LOGS_SIZE window to
+		// match circuit expectation. An encoded digest longer than the window
+		// is a malformed header that the import path rejects before this point
+		// (see the digest length check in `sc-consensus-qpow`); truncating here
+		// would drop the tail from the committed hash and let two distinct
+		// headers collide. `hash()` itself must stay infallible even on
+		// adversarial bytes, so we keep the saturating copy as a backstop and
+		// only assert the invariant in debug builds.
 		let digest_encoded = self.digest.encode();
+		debug_assert!(
+			digest_encoded.len() <= DIGEST_LOGS_SIZE,
+			"encoded digest ({} bytes) exceeds DIGEST_LOGS_SIZE ({}); header should have been \
+			 rejected before hashing",
+			digest_encoded.len(),
+			DIGEST_LOGS_SIZE,
+		);
 		let mut digest_padded = [0u8; DIGEST_LOGS_SIZE];
 		let copy_len = digest_encoded.len().min(DIGEST_LOGS_SIZE);
 		digest_padded[..copy_len].copy_from_slice(&digest_encoded[..copy_len]);
@@ -422,5 +447,53 @@ mod tests {
 			expected_hash,
 			"Header hash changed! This would break consensus."
 		);
+	}
+
+	/// The canonical post-seal digest (one 32-byte pre-runtime preimage plus a
+	/// 64-byte PoW seal) must encode to exactly `DIGEST_LOGS_SIZE`: the hash
+	/// window is sized with no slack, so anything larger overflows it and must
+	/// be rejected rather than truncated.
+	fn canonical_pow_digest() -> Digest {
+		Digest {
+			logs: vec![
+				DigestItem::PreRuntime([112, 111, 119, 95], vec![0u8; 32]),
+				DigestItem::Seal([112, 111, 119, 95], vec![0u8; 64]),
+			],
+		}
+	}
+
+	#[test]
+	fn canonical_pow_digest_fills_hash_window_exactly() {
+		assert_eq!(
+			canonical_pow_digest().encode().len(),
+			DIGEST_LOGS_SIZE,
+			"a well-formed pre-runtime + seal digest must fill the window exactly"
+		);
+	}
+
+	/// A digest larger than the window must trip the invariant in `hash()`
+	/// rather than silently truncate. `hash()` keeps a saturating backstop in
+	/// release, so this only asserts in debug builds (where `debug_assert`
+	/// fires); the real rejection for release is the import-path length check
+	/// in `sc-consensus-qpow`.
+	#[cfg(debug_assertions)]
+	#[test]
+	#[should_panic(expected = "exceeds DIGEST_LOGS_SIZE")]
+	fn oversized_digest_trips_hash_invariant() {
+		let mut digest = canonical_pow_digest();
+		// One extra item pushes the encoded digest past the 110-byte window.
+		digest.logs.push(DigestItem::Other(vec![0u8; 8]));
+
+		let header = Header::<u32, BlakeTwo256> {
+			parent_hash: Default::default(),
+			number: 1,
+			state_root: Default::default(),
+			extrinsics_root: Default::default(),
+			zk_tree_root: Default::default(),
+			digest,
+			_marker: core::marker::PhantomData,
+		};
+
+		let _ = header.hash();
 	}
 }

--- a/primitives/wormhole/src/lib.rs
+++ b/primitives/wormhole/src/lib.rs
@@ -142,25 +142,33 @@ pub fn derive_wormhole_address(inner_digest: [u8; 32]) -> Result<[u8; 32], &'sta
 /// Returns `None` if no valid pre-runtime digest is found, the preimage is not a
 /// canonical field-element encoding (the preimage is miner-supplied, so this must
 /// not panic), or decoding fails.
-pub fn extract_author_from_digest<AccountId, Digest>(digest: Digest) -> Option<AccountId>
+pub fn extract_author_from_digest<'a, AccountId, I>(digest: I) -> Option<AccountId>
 where
 	AccountId: Decode,
-	Digest: IntoIterator<Item = DigestItem>,
+	I: IntoIterator<Item = &'a DigestItem>,
 {
 	for log in digest {
-		if let DigestItem::PreRuntime(engine_id, data) = log {
-			if engine_id == POW_ENGINE_ID && data.len() == 32 {
-				let preimage: [u8; 32] = match data.as_slice().try_into() {
-					Ok(arr) => arr,
-					Err(_) => continue,
-				};
-				let address_bytes = match derive_wormhole_address(preimage) {
-					Ok(bytes) => bytes,
-					Err(_) => continue,
-				};
-				return AccountId::decode(&mut &address_bytes[..]).ok();
-			}
+		let DigestItem::PreRuntime(engine_id, data) = log else {
+			continue;
+		};
+		if *engine_id != POW_ENGINE_ID {
+			continue;
 		}
+
+		// The QPoW author preimage is the first POW pre-runtime item — and,
+		// under the header digest-size bound enforced at block import (see
+		// `DIGEST_LOGS_SIZE` in `qp-header` / the length check in
+		// `sc-consensus-qpow`), the only one that fits. Evaluate just this item
+		// and stop: a malformed or padded digest can never force extra
+		// scan work, so extraction stays O(1) in the digest length regardless
+		// of any upstream bound. Items are borrowed, so no payloads are cloned
+		// during the scan either.
+		if data.len() != 32 {
+			return None;
+		}
+		let preimage: [u8; 32] = data.as_slice().try_into().ok()?;
+		let address_bytes = derive_wormhole_address(preimage).ok()?;
+		return AccountId::decode(&mut &address_bytes[..]).ok();
 	}
 	None
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -166,8 +166,6 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, TxExtension>;
 pub type Migrations = (
 	// v0 -> v1: seed the wormhole soundness counters so pre-upgrade deposits remain exitable.
 	pallet_wormhole::migrations::MigrateV0ToV1<Runtime>,
-	// v1 -> v2: merge pre-upgrade non-canonical TransferCount keys into their canonical form.
-	pallet_wormhole::migrations::MigrateV1ToV2<Runtime>,
 	// v0 -> v1: set the treasury portion to 50% (50/50 treasury/miner reward split).
 	pallet_treasury::migrations::MigrateV0ToV1<Runtime>,
 );


### PR DESCRIPTION
# Security hardening: header hashing, exit-bundle settlement, and hook metering

This PR fixes a batch of security-review findings across consensus, the wormhole
pallet, mining rewards, and the node build. Each fix is a separate commit with a
regression test where the behavior is testable.

## Consensus / header integrity

### Reject headers whose digest overflows the hash window (`22052b7`)

`Header::hash()` commits the digest through a fixed 110-byte window
(`DIGEST_LOGS_SIZE`, mirrored by the ZK circuit) and silently truncated anything
beyond it, so two distinct sealed headers could share the same canonical block
hash once their encoded digest exceeded the cap — breaking the assumption that
the block hash commits to the full header.

- `sc-consensus-qpow` now rejects any block at import whose post-seal encoded
  digest exceeds `DIGEST_LOGS_SIZE` (new `DigestTooLong` error), so no header
  whose hash would truncate can ever enter the chain.
- `DIGEST_LOGS_SIZE` is now a `pub const` in `qp-header`, shared by the client
  check, with a `debug_assert!` in `Header::hash()` guarding the invariant in
  tests while keeping hashing infallible in release.
- Tests pin that the canonical PoW digest (preimage + seal) fills the window
  exactly, and that an oversized digest trips the assertion.

## Wormhole pallet

### Don't revert an exit bundle when a single mint fails (`81ffa0b`)

Exit-account and miner-fee credits used `increase_balance(Precision::Exact)?`,
so one below-existential-deposit mint to a fresh account aborted the dispatch
and rolled back every co-bundled user's exit. Since `MinimumTransferAmount`
only bounds the summed total and the extrinsic is unsigned with `Pays::No`,
anyone could grief a public batch for free with one dust-to-fresh-account
segment. The aggregator rebate was already hardened against exactly this
failure; the same isolation now covers the other two mints:

- **Miner fee**: on mint failure the fee is burned, mirroring the existing
  no-author branch.
- **Exit slot**: a failed mint skips just that slot, emits a new
  `ExitMintFailed` event (appended last in the enum, existing indexer positions
  unchanged), records no transfer proof, and is left out of the committed
  `TotalWormholeExits`. The skipped slot's nullifier stays marked, so the
  deposit can never be re-exited and the accounting cannot enable a
  double-mint.

### Reject intra-segment duplicate nullifiers before minting exits (`8ac966e`)

The private-batch exit grouping summed a replayed leaf into one inflated exit
while its shared nullifier would only be marked once. `segment_validity` now
denies any segment containing duplicate real nullifiers, so settlement cannot
mint the inflated value.

### Remove the unbounded v1→v2 TransferCount migration (`cdcf14d`)

`CanonicalizeTransferCountKeys` iterated the entire `TransferCount` map — an
unbounded, permissionlessly-grown storage map — into memory in a single
`on_runtime_upgrade`, so its work was attacker-controlled and could stall the
network at the upgrade boundary. The migration was also pointless: canonical
keying is enforced at write time and a live audit of the only pre-v2 chain
(Planck testnet) found zero non-canonical keys. Removed, with the storage
version rolled back to 1.

## Mining rewards / weight metering

### Bound miner-digest extraction to O(1) scan (`a4c67a7`)

`extract_author_from_digest` cloned and scanned arbitrarily many
author-controlled digest items before finding the QPoW preimage, doing
unmetered work inside `on_finalize` (mining rewards) and `process_exit_bundle`
(miner fee). It now takes borrowed digest items (no payload clones) and
evaluates only the first `PreRuntime(POW_ENGINE_ID, ..)` item, so extraction is
O(1) in digest length regardless of any upstream bound.

### Price the mining-reward finalize hook by live ZK-tree depth (`083b449`)

`on_finalize` mints up to three rewards, each recording a wormhole transfer
proof that inserts a ZK-tree leaf whose DB cost grows with tree depth, but the
hook reserved a flat shallow-tree benchmark weight and under-charged as the
shared tree deepened. The weight now prices the leaf inserts from live depth
(`insert_leaf_db_ops`), matching the runtime's per-transfer proof metering; the
depth-blind `()` fallback prices at `MAX_TREE_DEPTH` so it can never
under-charge.

## Node build

### Reject non-hex `SUBSTRATE_CLI_GIT_COMMIT_HASH` in the build script (`cac2a89`)

The vendored `generate_cargo_keys()` interpolates this env override into
line-oriented `cargo:` build-script output after only trimming it, so a value
with an embedded newline could smuggle an extra cargo directive
(`rustc-env`/`cfg`/`link-arg`) and gain authority over the compiled artifact.
The node build script now accepts only a short/full hex git hash (empty stays
inert) and falls back to `unknown` otherwise.

## Testing

- New/updated unit tests accompany each fix: digest-window fit and overflow
  assertions (`qp-header`), below-ED exit isolation and duplicate-nullifier
  denial (`pallet-wormhole`), depth-aware weight formulas (`pallet-mining-rewards`
  and `pallet-wormhole` weights), and build-script hash sanitization.
- Full `pallet-wormhole` (62), `pallet-mining-rewards`, and `qp-header` suites
  pass; `quantus-runtime` compiles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches consensus import rules, wormhole minting/accounting, runtime migrations removal, and mandatory block hooks—errors could fork nodes, strand deposits, or mis-meter blocks.
> 
> **Overview**
> Security hardening across **consensus**, **wormhole settlement**, **mining rewards**, and the **node build**.
> 
> **Consensus:** `sc-consensus-qpow` now rejects blocks whose post-seal SCALE-encoded digest exceeds the shared **`DIGEST_LOGS_SIZE` (110)** window (`DigestTooLong`), so headers that would be truncated in `Header::hash()` cannot be imported. The constant is published from `qp-header` with tests and a debug assertion backing the invariant.
> 
> **Wormhole:** Exit bundles no longer roll back when a single **exit** or **miner fee** mint fails (e.g. below existential deposit)—failed slots emit **`ExitMintFailed`**, skip minting, and only successfully minted amounts update **`TotalWormholeExits`** while nullifiers stay spent. **`segment_validity`** now rejects **duplicate real nullifiers within a segment** to block inflated exits from replayed leaves. The unbounded **v1→v2 `TransferCount` migration** is removed and storage version stays at **1** (canonical keys enforced at write time). **`extract_author_from_digest`** takes borrowed digest items and only inspects the first PoW pre-runtime entry (O(1), no clones).
> 
> **Mining rewards:** **`on_finalize`** weight prices up to three ZK-tree leaf inserts using **live tree depth** via `pallet-zk-tree`, with a max-depth fallback and unit tests.
> 
> **Node build:** **`SUBSTRATE_CLI_GIT_COMMIT_HASH`** is sanitized to hex-only (or `unknown`) before `generate_cargo_keys()` to block cargo-directive injection via newlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5d5c32c0fcb452505a3b119ef8783de002e9ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->