### PR TITLE
fix(litep2p): make system DNS resolver the default

### DIFF
--- a/client/litep2p/src/config.rs
+++ b/client/litep2p/src/config.rs
@@ -112,9 +112,6 @@ pub struct ConfigBuilder {
 
 	/// Close the connection if no substreams are open within this time frame.
 	keep_alive_timeout: Duration,
-
-	/// Use system's DNS config.
-	use_system_dns_config: bool,
 }
 
 impl Default for ConfigBuilder {
@@ -144,7 +141,6 @@ impl ConfigBuilder {
 			known_addresses: Vec::new(),
 			connection_limits: ConnectionLimitsConfig::default(),
 			keep_alive_timeout: KEEP_ALIVE_TIMEOUT,
-			use_system_dns_config: false,
 		}
 	}
 
@@ -254,12 +250,6 @@ impl ConfigBuilder {
 		self
 	}
 
-	/// Set DNS resolver according to system configuration instead of default (Google).
-	pub fn with_system_resolver(mut self) -> Self {
-		self.use_system_dns_config = true;
-		self
-	}
-
 	/// Build [`Litep2pConfig`].
 	pub fn build(mut self) -> Litep2pConfig {
 		let keypair = match self.keypair {
@@ -285,7 +275,6 @@ impl ConfigBuilder {
 			known_addresses: self.known_addresses,
 			connection_limits: self.connection_limits,
 			keep_alive_timeout: self.keep_alive_timeout,
-			use_system_dns_config: self.use_system_dns_config,
 		}
 	}
 }
@@ -340,7 +329,4 @@ pub struct Litep2pConfig {
 
 	/// Close the connection if no substreams are open within this time frame.
 	pub(crate) keep_alive_timeout: Duration,
-
-	/// Use system's DNS config.
-	pub(crate) use_system_dns_config: bool,
 }

--- a/client/litep2p/src/lib.rs
+++ b/client/litep2p/src/lib.rs
@@ -51,7 +51,7 @@ use crate::{
 use crate::transport::websocket::WebSocketTransport;
 
 use hickory_resolver::{
-	config::{ResolverConfig, GOOGLE},
+	config::{ResolverConfig, ResolverOpts, GOOGLE},
 	TokioResolver,
 };
 use multiaddr::{Multiaddr, Protocol};
@@ -157,24 +157,8 @@ impl Litep2p {
 		let bandwidth_sink = BandwidthSink::new();
 		let mut listen_addresses = vec![];
 
-		let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
-			// `ResolverConfig::default()` has no nameservers since hickory 0.26, so on a
-			// failed system read fall back to public DNS rather than leave the node unable
-			// to resolve `/dns/` peers.
-			match hickory_resolver::system_conf::read_system_conf() {
-				Ok(conf) => conf,
-				Err(error) => {
-					tracing::error!(
-						target: LOG_TARGET,
-						?error,
-						"failed to read system DNS config; falling back to public DNS",
-					);
-					(ResolverConfig::udp_and_tcp(&GOOGLE), Default::default())
-				},
-			}
-		} else {
-			(Default::default(), Default::default())
-		};
+		let (resolver_config, resolver_opts) =
+			resolver_config_or_fallback(hickory_resolver::system_conf::read_system_conf());
 		let resolver = Arc::new(
 			TokioResolver::builder_with_config(resolver_config, Default::default())
 				.with_options(resolver_opts)
@@ -494,17 +478,55 @@ impl Litep2p {
 	}
 }
 
+fn resolver_config_or_fallback<E: std::fmt::Debug>(
+	system_config: std::result::Result<(ResolverConfig, ResolverOpts), E>,
+) -> (ResolverConfig, ResolverOpts) {
+	match system_config {
+		Ok((config, options)) if !config.name_servers().is_empty() => (config, options),
+		Ok(_) => {
+			tracing::error!(
+				target: LOG_TARGET,
+				"system DNS config contains no nameservers; falling back to public DNS",
+			);
+			(ResolverConfig::udp_and_tcp(&GOOGLE), Default::default())
+		},
+		Err(error) => {
+			tracing::error!(
+				target: LOG_TARGET,
+				?error,
+				"failed to read system DNS config; falling back to public DNS",
+			);
+			(ResolverConfig::udp_and_tcp(&GOOGLE), Default::default())
+		},
+	}
+}
+
 #[cfg(test)]
 mod tests {
+	use super::resolver_config_or_fallback;
 	use crate::{
 		config::ConfigBuilder,
 		protocol::{libp2p::ping, notification::Config as NotificationConfig},
 		types::protocol::ProtocolName,
 		Litep2p, Litep2pEvent, PeerId,
 	};
+	use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 	use multiaddr::{Multiaddr, Protocol};
 	use multihash::Multihash;
 	use std::net::Ipv4Addr;
+
+	#[test]
+	fn resolver_config_falls_back_when_system_config_is_unavailable_or_empty() {
+		let (config, _) =
+			resolver_config_or_fallback(Err::<(ResolverConfig, ResolverOpts), _>("unavailable"));
+		assert!(!config.name_servers().is_empty());
+
+		let (config, _) = resolver_config_or_fallback(Ok::<_, &str>((
+			ResolverConfig::default(),
+			ResolverOpts::default(),
+		)));
+		assert!(!config.name_servers().is_empty());
+	}
 
 	#[tokio::test]
 	async fn initialize_litep2p() {

--- a/client/network/src/litep2p/mod.rs
+++ b/client/network/src/litep2p/mod.rs
@@ -324,7 +324,6 @@ impl Litep2pNetworkBackend {
 			.unzip();
 
 		config_builder
-			.with_system_resolver()
 			.with_websocket(WebSocketTransportConfig {
 				listen_addresses: websocket.into_iter().flatten().map(Into::into).collect(),
 				yamux_config: litep2p::yamux::Config::default(),


### PR DESCRIPTION
## Summary

Make system DNS resolution the default for every consumer of the vendored litep2p configuration.

This change:

- reads the system resolver configuration unconditionally when `Litep2p` is created
- preserves a valid system resolver configuration and its resolver options
- falls back to the populated Google UDP and TCP resolver configuration when reading the system configuration fails
- also falls back when the system configuration is read successfully but contains no nameservers
- removes the `use_system_dns_config` flag and `with_system_resolver()` builder method
- removes the now redundant opt-in from the current network backend

## Root cause

hickory-resolver 0.26 changed `ResolverConfig::default()` so that it contains no nameservers. The vendored litep2p builder still defaulted `use_system_dns_config` to `false`, which selected that empty resolver configuration unless each caller remembered to invoke `with_system_resolver()`.

PR #586 added the opt-in at the current production call site, but the unsafe builder default remained available to future consumers. PR #613 made system configuration read failures fall back to a populated public resolver, but a successful read that returned an empty nameserver list could still leave DNS resolution unusable.

The result was a configuration footgun where new callers could compile successfully while all `/dns/` peer resolution silently failed.

## Proposed solution

Resolver selection now belongs to `Litep2p::new()` instead of an optional builder flag. Construction always attempts to load the system DNS configuration.

A valid system configuration is used unchanged. If the system read fails, or if it succeeds with zero nameservers, litep2p logs the condition and uses `ResolverConfig::udp_and_tcp(&GOOGLE)` with default resolver options. This preserves the startup resilience introduced by PR #613 while ensuring that the resolver never receives the known empty default configuration.

Removing the flag and builder method makes the safe behavior automatic for current and future consumers. The existing network backend no longer needs to opt in explicitly.

## Impact

- Future litep2p consumers cannot accidentally construct a resolver with zero nameservers by omitting a builder call.
- Existing system DNS behavior remains unchanged when the operating system provides a valid configuration.
- Nodes still start with a populated fallback resolver when the operating system configuration cannot be read.
- No user-facing configuration is removed because the deleted switch was an internal vendored builder API.

## Verification

- `cargo test -p litep2p resolver_config_falls_back_when_system_config_is_unavailable_or_empty -- --nocapture`
- `cargo test -p litep2p`: 322 passed, 2 ignored
- `cargo check -p sc-network`
- `cargo clippy -p litep2p --lib`: completed successfully with existing warnings
- `git diff --check`

## Baseline notes

- `cargo fmt --all -- --check` reports formatting differences across untouched upstream files with the pinned stable toolchain. The changed hunk identified by the formatter was corrected.
- Strict all-target clippy with `-D warnings` remains blocked by existing `unwrap`, `expect`, `panic`, and other lint findings in the vendored package. The normal library clippy command completes successfully and does not identify a warning in the added production code.

Fixes #587

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default peer dialing DNS for all litep2p users (now OS-first with public fallback), which affects networking reliability but removes a footgun that could silently break `/dns/` resolution.
> 
> **Overview**
> **DNS setup is no longer optional** when constructing `Litep2p`. The `use_system_dns_config` flag and `with_system_resolver()` builder API are removed; `Litep2p::new()` always loads the OS resolver and keeps its options when nameservers are present.
> 
> A new `resolver_config_or_fallback` helper centralizes behavior: failed system reads or configs with **zero nameservers** log an error and use Google public DNS instead of hickory’s empty default (which broke `/dns/` dials after hickory 0.26). Unit tests cover unavailable and empty system configs.
> 
> The Substrate network backend drops its explicit `with_system_resolver()` call because the safe path is now automatic for all litep2p consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefc25745a14ff89d177f63ab4b071e22f2a8203. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->