### PR TITLE
V12 audit: fix referenda, scheduler, and frame-system findings

### DIFF
--- a/docs/TECH_REFERENDA_FEATURES.md
+++ b/docs/TECH_REFERENDA_FEATURES.md
@@ -54,7 +54,7 @@ Referenda's `Tally = pallet_ranked_collective::TallyOf<Runtime>` and
 | `submit` | Root or member | Create a referendum |
 | `place_decision_deposit` / `refund_decision_deposit` | signed | 1000 UNIT decision bond |
 | `refund_submission_deposit` | signed | 100 UNIT submission bond |
-| `nudge_referendum` | **permissionless** | Force the state machine to re-evaluate now (the "fast resolution" lever, §6) |
+| `nudge_referendum` | **Root** (dispatched via governance) | Force the state machine to re-evaluate now (§6) |
 | `cancel` | Root | Stop; refunds deposits |
 | `kill` | Root | Stop; slashes deposits (`Slash = ()` → burned) |
 | `one_fewer_deciding` | signed | Free a deciding slot |
@@ -157,7 +157,8 @@ Phases: `prepare_period` → **deciding** (≤ `decision_period`) → **confirmi
 (`confirm_period`) → enactment (`min_enactment_period`).
 
 There is no dedicated fast-resolve call. Early resolution comes from the
-**confirming** mechanism plus the permissionless **`nudge_referendum`** poke.
+**confirming** mechanism; the Root-only **`nudge_referendum`** (dispatched via
+governance) can additionally force a re-evaluation.
 Once both curves are satisfied the referendum enters confirming; if it stays
 passing for `confirm_period` it is approved **without waiting out the full
 decision period**:
@@ -181,8 +182,9 @@ support_needed.passing(x, tally.support(id)) && approval_needed.passing(x, tally
 
 If support drops below threshold during confirming, confirmation aborts
 (`ConfirmAborted`) and must restart — so it is not a one-way ratchet, which is
-what makes `confirm_period` a defense window. `nudge_referendum` lets anyone
-force a re-evaluation immediately instead of waiting for the scheduled alarm.
+what makes `confirm_period` a defense window. `nudge_referendum` (Root only, so
+in practice dispatched via governance) forces a re-evaluation immediately
+instead of waiting for the scheduled alarm.
 
 ---
 

--- a/frame/system-benchmarking/src/inner.rs
+++ b/frame/system-benchmarking/src/inner.rs
@@ -83,8 +83,10 @@ mod benchmarks {
 
 	#[benchmark]
 	fn set_heap_pages() -> Result<(), BenchmarkError> {
+		// V12 audit #162546: `set_heap_pages` now enforces a `64..=65536` range, so the
+		// benchmark must use a value within it.
 		#[extrinsic_call]
-		set_heap_pages(RawOrigin::Root, Default::default());
+		set_heap_pages(RawOrigin::Root, 64);
 
 		Ok(())
 	}

--- a/pallets/frame-system/src/lib.rs
+++ b/pallets/frame-system/src/lib.rs
@@ -730,6 +730,10 @@ pub mod pallet {
 		#[pallet::weight((T::SystemWeightInfo::set_heap_pages(), DispatchClass::Operational))]
 		pub fn set_heap_pages(origin: OriginFor<T>, pages: u64) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
+			// V12 audit #162546: reject values that would prevent the executor from
+			// instantiating the runtime. 64 pages (4 MiB) is the practical executor minimum,
+			// 65536 pages (4 GiB) is the wasm32 linear-memory hard maximum.
+			ensure!((64..=65536).contains(&pages), Error::<T>::InvalidHeapPages);
 			storage::unhashed::put_raw(well_known_keys::HEAP_PAGES, &pages.encode());
 			Self::deposit_log(generic::DigestItem::RuntimeEnvironmentUpdated);
 			Ok(().into())
@@ -988,6 +992,8 @@ pub mod pallet {
 		NothingAuthorized,
 		/// The submitted code is not authorized.
 		Unauthorized,
+		/// The provided number of heap pages is outside the supported range of `64..=65536`.
+		InvalidHeapPages,
 	}
 
 	/// Exposed trait-generic origin type.
@@ -1165,7 +1171,10 @@ pub mod pallet {
 		fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
 			if let Call::apply_authorized_upgrade { ref code } = call {
 				if let Ok(res) = Self::validate_code_is_authorized(&code[..]) {
-					if Self::can_set_code(&code, false).is_ok() {
+					// V12 audit #162411: honor the authorization's `check_version` flag so pool
+					// validation rejects code that dispatch would reject (upstream hardcodes
+					// `false` here).
+					if Self::can_set_code(&code, res.check_version).is_ok() {
 						return Ok(ValidTransaction {
 							priority: u64::max_value(),
 							requires: Vec::new(),

--- a/pallets/frame-system/src/mock.rs
+++ b/pallets/frame-system/src/mock.rs
@@ -117,7 +117,7 @@ pub type SysEvent = frame_system::Event<Test>;
 
 /// A simple call, which one doesn't matter.
 pub const CALL: &<Test as Config>::RuntimeCall =
-	&RuntimeCall::System(frame_system::Call::set_heap_pages { pages: 0u64 });
+	&RuntimeCall::System(frame_system::Call::set_heap_pages { pages: 64u64 });
 
 /// Create new externalities for `System` module tests.
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/frame-system/src/tests.rs
+++ b/pallets/frame-system/src/tests.rs
@@ -691,6 +691,70 @@ fn set_code_drains_remaining_block_weight() {
 	});
 }
 
+#[test]
+fn validate_unsigned_apply_authorized_upgrade_honors_check_version() {
+	struct ReadRuntimeVersion(Vec<u8>);
+
+	impl sp_core::traits::ReadRuntimeVersion for ReadRuntimeVersion {
+		fn read_runtime_version(
+			&self,
+			_wasm_code: &[u8],
+			_ext: &mut dyn sp_externalities::Externalities,
+		) -> Result<Vec<u8>, String> {
+			Ok(self.0.clone())
+		}
+	}
+
+	let code = vec![1, 2, 3, 4];
+	let code_hash = BlakeTwo256::hash(&code);
+	let call = Call::<Test>::apply_authorized_upgrade { code };
+
+	// The mock runtime runs `spec_name: "test"` at `spec_version: 1`, so a candidate that
+	// does not increase the spec version fails the version check.
+	let bad_version =
+		RuntimeVersion { spec_name: "test".into(), spec_version: 1, ..Default::default() };
+	let good_version =
+		RuntimeVersion { spec_name: "test".into(), spec_version: 2, ..Default::default() };
+
+	let test_data = vec![
+		// The authorization requires the version check and it fails -> invalid.
+		(bad_version.clone(), true, false),
+		// Same failing version, but the authorization skips the check -> valid.
+		(bad_version, false, true),
+		// The authorization requires the version check and it passes -> valid.
+		(good_version, true, true),
+	];
+
+	for (version, check_version, expect_valid) in test_data.into_iter() {
+		let read_runtime_version = ReadRuntimeVersion(version.encode());
+
+		let mut ext = new_test_ext();
+		ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(read_runtime_version));
+		ext.execute_with(|| {
+			if check_version {
+				assert_ok!(System::authorize_upgrade(RawOrigin::Root.into(), code_hash));
+			} else {
+				assert_ok!(System::authorize_upgrade_without_checks(
+					RawOrigin::Root.into(),
+					code_hash
+				));
+			}
+
+			let res = <System as sp_runtime::traits::ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&call,
+			);
+
+			if expect_valid {
+				let valid = res.expect("transaction should be valid");
+				assert_eq!(valid.provides, vec![code_hash.encode()]);
+			} else {
+				assert_eq!(res, Err(InvalidTransaction::Call.into()));
+			}
+		});
+	}
+}
+
 fn assert_runtime_updated_digest(num: usize) {
 	assert_eq!(
 		System::digest()
@@ -750,8 +814,30 @@ fn runtime_updated_digest_emitted_when_heap_pages_changed() {
 	new_test_ext().execute_with(|| {
 		System::reset_events();
 		System::initialize(&1, &[0u8; 32].into(), &Default::default());
-		System::set_heap_pages(RawOrigin::Root.into(), 5).unwrap();
+		System::set_heap_pages(RawOrigin::Root.into(), 64).unwrap();
 		assert_runtime_updated_digest(1);
+	});
+}
+
+#[test]
+fn set_heap_pages_validates_range() {
+	new_test_ext().execute_with(|| {
+		System::reset_events();
+		System::initialize(&1, &[0u8; 32].into(), &Default::default());
+
+		// V12 audit #162546: values below the 4 MiB executor minimum and above the 4 GiB
+		// wasm32 linear-memory maximum are rejected.
+		for pages in [0u64, 63, 65537] {
+			assert_noop!(
+				System::set_heap_pages(RawOrigin::Root.into(), pages),
+				Error::<Test>::InvalidHeapPages
+			);
+		}
+
+		// Both bounds of the allowed range are accepted and still emit the digest item.
+		assert_ok!(System::set_heap_pages(RawOrigin::Root.into(), 64));
+		assert_ok!(System::set_heap_pages(RawOrigin::Root.into(), 65536));
+		assert_runtime_updated_digest(2);
 	});
 }
 

--- a/pallets/referenda/src/branch.rs
+++ b/pallets/referenda/src/branch.rs
@@ -18,8 +18,24 @@
 //! Helpers for managing the different weights in various algorithmic branches.
 
 use super::Config;
-use crate::weights::WeightInfo;
-use frame_support::weights::Weight;
+use crate::{weights::WeightInfo, Pallet};
+use frame_support::{traits::Get, weights::Weight};
+
+/// Worst-case overhead of the `set_alarm` full-agenda retry loop (V12 audit #161704 /
+/// #162455): every failed `T::Scheduler::schedule` attempt reads the candidate block's
+/// `Scheduler::Agenda` before sliding forward one block. Nothing is written until an
+/// attempt succeeds (and `Preimages::drop` of the inline nudge call is storage-free), and
+/// the succeeding attempt's cost is already part of the benchmarked base weight, so only
+/// the extra attempts are charged here.
+///
+/// This is added to every branch that can (re)schedule a referendum alarm or defer
+/// `one_fewer_deciding` through `set_alarm`. Kept in this hand-written module so it
+/// survives regeneration of the benchmarked `weights.rs`.
+pub fn alarm_retry_weight<T: Config<I>, I: 'static>() -> Weight {
+	T::DbWeight::get()
+		.reads(1)
+		.saturating_mul(Pallet::<T, I>::MAX_ALARM_SCHEDULE_RETRIES as u64)
+}
 
 /// Branches within the `begin_deciding` function.
 pub enum BeginDecidingBranch {
@@ -62,7 +78,7 @@ impl ServiceBranch {
 	/// Return the weight of the `nudge` function when it takes the branch denoted by `self`.
 	pub fn weight_of_nudge<T: Config<I>, I: 'static>(self) -> frame_support::weights::Weight {
 		use ServiceBranch::*;
-		match self {
+		let base = match self {
 			NoDeposit => T::WeightInfo::nudge_referendum_no_deposit(),
 			Preparing => T::WeightInfo::nudge_referendum_preparing(),
 			Queued => T::WeightInfo::nudge_referendum_queued(),
@@ -78,6 +94,24 @@ impl ServiceBranch {
 			Approved => T::WeightInfo::nudge_referendum_approved(),
 			Rejected => T::WeightInfo::nudge_referendum_rejected(),
 			TimedOut | Fail => T::WeightInfo::nudge_referendum_timed_out(),
+		};
+		match self {
+			// Branches that (re)schedule the referendum's alarm, or defer
+			// `one_fewer_deciding` via `set_alarm` (`Approved`/`Rejected`), bear the
+			// worst-case retry overhead.
+			NoDeposit |
+			Preparing |
+			NotQueued |
+			BeginDecidingPassing |
+			BeginDecidingFailing |
+			BeginConfirming |
+			ContinueConfirming |
+			EndConfirming |
+			ContinueNotConfirming |
+			Approved |
+			Rejected => base.saturating_add(alarm_retry_weight::<T, I>()),
+			// These branches leave the referendum without an alarm (or only cancel one).
+			Queued | RequeuedInsertion | RequeuedSlide | TimedOut | Fail => base,
 		}
 	}
 
@@ -99,6 +133,7 @@ impl ServiceBranch {
 			.max(T::WeightInfo::nudge_referendum_approved())
 			.max(T::WeightInfo::nudge_referendum_rejected())
 			.max(T::WeightInfo::nudge_referendum_timed_out())
+			.saturating_add(alarm_retry_weight::<T, I>())
 	}
 
 	/// Return the weight of the `place_decision_deposit` function when it takes the branch denoted
@@ -108,11 +143,18 @@ impl ServiceBranch {
 	) -> Option<frame_support::weights::Weight> {
 		use ServiceBranch::*;
 		let ref_time_weight = match self {
-			Preparing => T::WeightInfo::place_decision_deposit_preparing(),
+			// `Preparing`, `NotQueued` and `BeginDeciding*` (re)schedule the referendum's
+			// alarm and so bear the worst-case `set_alarm` retry overhead; `Queued` leaves
+			// the referendum alarm-less.
+			Preparing => T::WeightInfo::place_decision_deposit_preparing()
+				.saturating_add(alarm_retry_weight::<T, I>()),
 			Queued => T::WeightInfo::place_decision_deposit_queued(),
-			NotQueued => T::WeightInfo::place_decision_deposit_not_queued(),
-			BeginDecidingPassing => T::WeightInfo::place_decision_deposit_passing(),
-			BeginDecidingFailing => T::WeightInfo::place_decision_deposit_failing(),
+			NotQueued => T::WeightInfo::place_decision_deposit_not_queued()
+				.saturating_add(alarm_retry_weight::<T, I>()),
+			BeginDecidingPassing => T::WeightInfo::place_decision_deposit_passing()
+				.saturating_add(alarm_retry_weight::<T, I>()),
+			BeginDecidingFailing => T::WeightInfo::place_decision_deposit_failing()
+				.saturating_add(alarm_retry_weight::<T, I>()),
 			BeginConfirming |
 			ContinueConfirming |
 			EndConfirming |
@@ -137,6 +179,7 @@ impl ServiceBranch {
 			.max(T::WeightInfo::place_decision_deposit_not_queued())
 			.max(T::WeightInfo::place_decision_deposit_passing())
 			.max(T::WeightInfo::place_decision_deposit_failing())
+			.saturating_add(alarm_retry_weight::<T, I>())
 	}
 }
 
@@ -165,8 +208,12 @@ impl OneFewerDecidingBranch {
 		use OneFewerDecidingBranch::*;
 		match self {
 			QueueEmpty => T::WeightInfo::one_fewer_deciding_queue_empty(),
-			BeginDecidingPassing => T::WeightInfo::one_fewer_deciding_passing(),
-			BeginDecidingFailing => T::WeightInfo::one_fewer_deciding_failing(),
+			// `begin_deciding` schedules the promoted referendum's alarm, bearing the
+			// worst-case `set_alarm` retry overhead.
+			BeginDecidingPassing => T::WeightInfo::one_fewer_deciding_passing()
+				.saturating_add(alarm_retry_weight::<T, I>()),
+			BeginDecidingFailing => T::WeightInfo::one_fewer_deciding_failing()
+				.saturating_add(alarm_retry_weight::<T, I>()),
 		}
 	}
 
@@ -176,5 +223,6 @@ impl OneFewerDecidingBranch {
 			.max(T::WeightInfo::one_fewer_deciding_queue_empty())
 			.max(T::WeightInfo::one_fewer_deciding_passing())
 			.max(T::WeightInfo::one_fewer_deciding_failing())
+			.saturating_add(alarm_retry_weight::<T, I>())
 	}
 }

--- a/pallets/referenda/src/lib.rs
+++ b/pallets/referenda/src/lib.rs
@@ -916,6 +916,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// old permissionless pre-fill.
 	const MAX_ENACTMENT_SCHEDULE_RETRIES: u32 = 16;
 
+	/// How many subsequent blocks to try if the preferred alarm block's agenda is full.
+	///
+	/// Alarms are "not earlier than", so sliding forward is semantically safe; the caller
+	/// stores the actually-scheduled block in `status.alarm`.
+	const MAX_ALARM_SCHEDULE_RETRIES: u32 = 16;
+
 	// Enqueue a proposal from a referendum which has presumably passed.
 	fn schedule_enactment(
 		index: ReferendumIndex,
@@ -961,6 +967,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// Set an alarm to dispatch `call` at block number `when`.
+	///
+	/// If the agenda at `when` is full, the alarm slides forward one block at a time (up to
+	/// `MAX_ALARM_SCHEDULE_RETRIES` extra attempts) instead of being dropped, and the block
+	/// that was actually scheduled is returned.
 	fn set_alarm(
 		call: BoundedCallOf<T, I>,
 		when: BlockNumberFor<T, I>,
@@ -968,29 +978,45 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let alarm_interval = T::AlarmInterval::get().max(One::one());
 		// Alarm must go off no earlier than `when`.
 		// This rounds `when` upwards to the next multiple of `alarm_interval`.
-		let when = (when.saturating_add(alarm_interval.saturating_sub(One::one())) /
+		let initial_when = (when.saturating_add(alarm_interval.saturating_sub(One::one())) /
 			alarm_interval)
 			.saturating_mul(alarm_interval);
-		let result = T::Scheduler::schedule(
-			DispatchTime::At(when),
-			None,
-			128u8,
-			frame_system::RawOrigin::Root.into(),
-			call,
-		);
-		if let Err(e) = result.as_ref() {
-			// #91210: never fail silently. A missing alarm means the referendum will not be
-			// serviced (confirm/timeout/queue progression) until something else nudges it.
-			log::error!(
-				target: "runtime::referenda",
-				"unable to schedule referendum alarm at #{:?} (now #{:?}): {:?}",
-				when,
-				T::BlockNumberProvider::current_block_number(),
-				e,
-			);
-			debug_assert!(false, "scheduler alarm scheduling failed: {:?}", e);
+		let mut when = initial_when;
+
+		// V12 audit #161704+#162455: retry on a full agenda, sliding forward one block at a
+		// time (mirrors `schedule_enactment`). A silently dropped alarm can permanently stall
+		// the referendum — and with `max_deciding = 1`, deadlock the whole governance lane.
+		// The caller stores the returned block in `status.alarm` and compares against it, so
+		// the block that actually succeeded must be returned.
+		let mut last_err = None;
+		for _ in 0..=Self::MAX_ALARM_SCHEDULE_RETRIES {
+			match T::Scheduler::schedule(
+				DispatchTime::At(when),
+				None,
+				128u8,
+				frame_system::RawOrigin::Root.into(),
+				call.clone(),
+			) {
+				Ok(address) => return Some((when, address)),
+				Err(e) => {
+					last_err = Some(e);
+					when = when.saturating_add(One::one());
+				},
+			}
 		}
-		result.ok().map(|x| (when, x))
+
+		// #91210: never fail silently. A missing alarm means the referendum will not be
+		// serviced (confirm/timeout/queue progression) until something else nudges it.
+		log::error!(
+			target: "runtime::referenda",
+			"unable to schedule referendum alarm at #{:?} after {} retries (now #{:?}): {:?}",
+			initial_when,
+			Self::MAX_ALARM_SCHEDULE_RETRIES,
+			T::BlockNumberProvider::current_block_number(),
+			last_err,
+		);
+		debug_assert!(false, "scheduler alarm scheduling failed after retries: {:?}", last_err);
+		None
 	}
 
 	/// Mutate a referendum's `status` into the correct deciding state.
@@ -1182,6 +1208,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						queue.slide(old_pos, new_pos);
 						ServiceBranch::RequeuedSlide
 					} else {
+						// V12 audit #161743: `in_queue` is set but the referendum is absent from
+						// `TrackQueue` — it was evicted from a full queue by
+						// `force_insert_keep_right`. Clear the flag and mark dirty so the next
+						// service re-routes it through `ready_for_deciding` (or the undeciding
+						// timeout below, which is gated on `!in_queue`) instead of stranding it
+						// forever with no alarm.
+						status.in_queue = false;
+						dirty = true;
 						ServiceBranch::NotQueued
 					};
 					TrackQueue::<T, I>::insert(status.track, queue);

--- a/pallets/referenda/src/lib.rs
+++ b/pallets/referenda/src/lib.rs
@@ -505,6 +505,11 @@ pub mod pallet {
 			let now = T::BlockNumberProvider::current_block_number();
 			let nudge_call =
 				T::Preimages::bound(CallOf::<T, I>::from(Call::nudge_referendum { index }))?;
+			let alarm =
+				Self::set_alarm(nudge_call, now.saturating_add(T::UndecidingTimeout::get()));
+			// A referendum without its undeciding-timeout alarm is not serviced (#91210)
+			// and nothing here can recover from that, so flag it loudly under debug.
+			debug_assert!(alarm.is_some(), "unable to schedule the undeciding-timeout alarm");
 			let status = ReferendumStatus {
 				track,
 				origin: proposal_origin,
@@ -516,7 +521,7 @@ pub mod pallet {
 				deciding: None,
 				tally: TallyOf::<T, I>::new(track),
 				in_queue: false,
-				alarm: Self::set_alarm(nudge_call, now.saturating_add(T::UndecidingTimeout::get())),
+				alarm,
 			};
 			ReferendumInfoFor::<T, I>::insert(index, ReferendumInfo::Ongoing(status));
 
@@ -979,6 +984,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// If the agenda at `when` is full, the alarm slides forward one block at a time (up to
 	/// `MAX_ALARM_SCHEDULE_RETRIES` extra attempts) instead of being dropped, and the block
 	/// that was actually scheduled is returned.
+	///
+	/// Returns `None` if every attempt failed; it is the caller's responsibility to recover
+	/// (or to `debug_assert` if it cannot - see V12 audit #162455).
 	fn set_alarm(
 		call: BoundedCallOf<T, I>,
 		when: BlockNumberFor<T, I>,
@@ -1023,7 +1031,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			T::BlockNumberProvider::current_block_number(),
 			last_err,
 		);
-		debug_assert!(false, "scheduler alarm scheduling failed after retries: {:?}", last_err);
 		None
 	}
 
@@ -1127,7 +1134,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				return
 			},
 		};
-		Self::set_alarm(call, next_block);
+		if Self::set_alarm(call, next_block).is_none() {
+			// V12 audit #162455: the deferred `one_fewer_deciding` could not be scheduled
+			// even after sliding forward. Never lose the accounting: release the deciding
+			// slot inline so the track is not recorded as full forever (with
+			// `max_deciding = 1` that would deadlock the whole lane). Queued referenda are
+			// not promoted here; they are pulled as usual by the `one_fewer_deciding` of
+			// the next referendum to finish deciding on this track, or by a direct
+			// (Root-dispatched) `one_fewer_deciding` call.
+			DecidingCount::<T, I>::mutate(track, |x| x.saturating_dec());
+		}
 	}
 
 	/// Ensure that a `service_referendum` alarm happens for the referendum `index` at `alarm`.
@@ -1155,6 +1171,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					},
 				};
 			status.alarm = Self::set_alarm(call, alarm);
+			// A referendum with no alarm is not serviced (#91210) and nothing here can
+			// recover from that, so flag it loudly under debug.
+			debug_assert!(
+				status.alarm.is_some(),
+				"unable to schedule the referendum's service alarm",
+			);
 			true
 		} else {
 			false

--- a/pallets/referenda/src/lib.rs
+++ b/pallets/referenda/src/lib.rs
@@ -1210,12 +1210,15 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					} else {
 						// V12 audit #161743: `in_queue` is set but the referendum is absent from
 						// `TrackQueue` — it was evicted from a full queue by
-						// `force_insert_keep_right`. Clear the flag and mark dirty so the next
-						// service re-routes it through `ready_for_deciding` (or the undeciding
-						// timeout below, which is gated on `!in_queue`) instead of stranding it
-						// forever with no alarm.
+						// `force_insert_keep_right`. Clear the flag and mark dirty so this and
+						// subsequent services see consistent state, and set the timeout alarm
+						// (mirroring the `NoDeposit` branch) so the referendum re-routes itself
+						// through `ready_for_deciding` — or the undeciding timeout below, which
+						// is gated on `!in_queue` — without requiring a further external nudge
+						// (`nudge_referendum` is a privileged call).
 						status.in_queue = false;
 						dirty = true;
+						alarm = timeout;
 						ServiceBranch::NotQueued
 					};
 					TrackQueue::<T, I>::insert(status.track, queue);

--- a/pallets/referenda/src/lib.rs
+++ b/pallets/referenda/src/lib.rs
@@ -93,7 +93,9 @@ pub mod migration;
 mod types;
 pub mod weights;
 
-use self::branch::{BeginDecidingBranch, OneFewerDecidingBranch, ServiceBranch};
+use self::branch::{
+	alarm_retry_weight, BeginDecidingBranch, OneFewerDecidingBranch, ServiceBranch,
+};
 pub use self::{
 	pallet::*,
 	types::{
@@ -470,7 +472,9 @@ pub mod pallet {
 		///
 		/// Emits `Submitted`.
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::submit())]
+		// `submit` schedules the undeciding-timeout alarm, bearing the worst-case
+		// `set_alarm` retry overhead.
+		#[pallet::weight(T::WeightInfo::submit().saturating_add(alarm_retry_weight::<T, I>()))]
 		pub fn submit(
 			origin: OriginFor<T>,
 			proposal_origin: Box<PalletsOriginOf<T>>,
@@ -587,7 +591,9 @@ pub mod pallet {
 		///
 		/// Emits `Cancelled`.
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::cancel())]
+		// May defer `one_fewer_deciding` via `set_alarm`, bearing its worst-case retry
+		// overhead.
+		#[pallet::weight(T::WeightInfo::cancel().saturating_add(alarm_retry_weight::<T, I>()))]
 		pub fn cancel(origin: OriginFor<T>, index: ReferendumIndex) -> DispatchResult {
 			T::CancelOrigin::ensure_origin(origin)?;
 			let status = Self::ensure_ongoing(index)?;
@@ -618,7 +624,9 @@ pub mod pallet {
 		///
 		/// Emits `Killed` and `DepositSlashed`.
 		#[pallet::call_index(4)]
-		#[pallet::weight(T::WeightInfo::kill())]
+		// May defer `one_fewer_deciding` via `set_alarm`, bearing its worst-case retry
+		// overhead.
+		#[pallet::weight(T::WeightInfo::kill().saturating_add(alarm_retry_weight::<T, I>()))]
 		pub fn kill(origin: OriginFor<T>, index: ReferendumIndex) -> DispatchResult {
 			T::KillOrigin::ensure_origin(origin)?;
 			let status = Self::ensure_ongoing(index)?;

--- a/pallets/referenda/src/tests.rs
+++ b/pallets/referenda/src/tests.rs
@@ -120,6 +120,89 @@ fn full_enactment_block_agenda_retries_on_next_block() {
 	});
 }
 
+/// V12 audit #161704+#162455: if the agenda at the alarm's target block is full,
+/// `set_alarm` must slide forward to a later block instead of dropping the alarm, and
+/// `status.alarm` must reflect the block that was actually scheduled.
+///
+/// A referendum submitted at block 1 gets its (no-deposit) timeout alarm at
+/// `1 + UndecidingTimeout (20)` = block 21. With block 21's agenda completely full, the
+/// alarm must land at block 22 and the referendum must time out there, not at 21.
+#[test]
+fn full_alarm_block_agenda_retries_on_next_block() {
+	ExtBuilder::default().build_and_execute(|| {
+		let target = 21u64;
+		let max = <<Test as pallet_scheduler::Config>::MaxScheduledPerBlock as frame_support::traits::Get<
+			u32,
+		>>::get();
+		let filler = RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+		// Priority 100 != LOWEST_PRIORITY (255), so these fillers are not subject to
+		// the reservation cap and can occupy the whole agenda including reserved slots.
+		for _ in 0..max {
+			assert_ok!(Scheduler::schedule(
+				RuntimeOrigin::root(),
+				target,
+				100,
+				Box::new(filler.clone()),
+			));
+		}
+
+		// Submit: the alarm cannot go into the full block 21 and must land at 22.
+		assert_ok!(propose_set_balance(1, 1, 1));
+		let status = Referenda::ensure_ongoing(0).unwrap();
+		assert_eq!(status.alarm.map(|(when, _)| when), Some(22));
+
+		// Not timed out at the (full) block 21, since no alarm fired there ...
+		run_to(21);
+		assert_matches!(ReferendumInfoFor::<Test>::get(0), Some(ReferendumInfo::Ongoing(..)));
+		// ... but the alarm fires at block 22 and the referendum times out there.
+		run_to(22);
+		assert_eq!(timed_out_since(0), 22);
+	});
+}
+
+/// V12 audit #161743: a referendum evicted from a full `TrackQueue` keeps `in_queue =
+/// true` in storage while being absent from the queue (ghost-queued). Servicing it must
+/// clear the flag and mark the status dirty so it can be re-routed through
+/// `ready_for_deciding` or the undeciding timeout instead of stranding it forever.
+///
+/// Track 0 has `max_deciding = 1` and `MaxQueued = 3`. Once the queue is full, ref4 with
+/// more ayes than the queue's tail squeezes in via `force_insert_keep_right`, which evicts
+/// the lowest-ayes entry (ref1). Servicing ref1 must then hit the `NotQueued` arm (its
+/// ayes sort to position 0) and clear `in_queue`.
+#[test]
+fn evicted_from_full_queue_clears_in_queue_on_service() {
+	ExtBuilder::default().build_and_execute(|| {
+		// Block 1: ref0 occupies the single deciding slot of track 0 from block 5 on.
+		assert_ok!(propose_set_balance(1, 0, 0));
+		assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(1), 0));
+		run_to(5);
+		assert_eq!(deciding_and_failing_since(0), 5);
+
+		// Refs 1-4 (accounts 2-5), with ayes pre-set so the queue fills as
+		// [(1, 1), (2, 2), (3, 3)] and ref4 (2 ayes) then evicts ref1.
+		for (who, ayes) in [(2u64, 1u32), (3, 2), (4, 3), (5, 2)] {
+			let index = who as u32 - 1;
+			assert_ok!(propose_set_balance(who, who, 0));
+			assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(who), index));
+			set_tally(index, ayes, 0);
+		}
+		run_to(9);
+		// ref0 is rejected; refs 1, 2, 3 entered the queue and ref4 evicted ref1.
+		assert_eq!(rejected_since(0), 9);
+		assert_eq!(
+			Vec::<_>::from(TrackQueue::<Test>::get(0)),
+			vec![(4u32, 2u32), (2u32, 2u32), (3u32, 3u32)]
+		);
+		// Pre-fix ghost state: ref1 believes it is queued but is absent from `TrackQueue`.
+		assert!(Referenda::ensure_ongoing(1).unwrap().in_queue);
+
+		// Service ref1: it is not found in the queue and its single aye sorts to position
+		// 0, so the `NotQueued` arm must clear the flag and store the referendum.
+		assert_ok!(Referenda::nudge_referendum(RuntimeOrigin::root(), 1));
+		assert!(!Referenda::ensure_ongoing(1).unwrap().in_queue);
+	});
+}
+
 #[test]
 fn insta_confirm_then_kill_works() {
 	ExtBuilder::default().build_and_execute(|| {

--- a/pallets/referenda/src/tests.rs
+++ b/pallets/referenda/src/tests.rs
@@ -225,6 +225,64 @@ fn evicted_from_full_queue_clears_in_queue_on_service() {
 	});
 }
 
+/// V12 audit #162455: releasing a deciding slot must not depend on the deferred
+/// `one_fewer_deciding` alarm being schedulable. When a deciding referendum ends while
+/// the agendas of the alarm's target block and of all 16 retry blocks are full, the
+/// track's deciding slot must still be released inline instead of leaving
+/// `DecidingCount` stuck at capacity forever (with `max_deciding = 1` this would
+/// deadlock the whole governance lane).
+///
+/// The referendum is ended through the rejection path (its own decision-period alarm at
+/// block 9), because that alarm has already been consumed by the scheduler when it
+/// fires and so - unlike `cancel`/`kill`, which free the referendum's alarm slot first -
+/// leaves no hole in any agenda for the `one_fewer_deciding` alarm to slip into.
+#[test]
+fn unschedulable_one_fewer_deciding_releases_deciding_slot_inline() {
+	ExtBuilder::default().build_and_execute(|| {
+		// ref0 occupies track 0's single deciding slot from block 5 on; with a failing
+		// tally its decision period (4 blocks) ends with rejection at block 9.
+		assert_ok!(propose_set_balance(1, 1, 0));
+		assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(1), 0));
+		run_to(5);
+		assert_eq!(deciding_and_failing_since(0), 5);
+		assert_eq!(DecidingCount::<Test>::get(0), 1);
+
+		// Fill the agendas of the deferred `one_fewer_deciding` alarm's target block
+		// (rejection block 9 + 1 = 10) and of all 16 retry blocks after it.
+		let max = <<Test as pallet_scheduler::Config>::MaxScheduledPerBlock as frame_support::traits::Get<
+			u32,
+		>>::get();
+		let filler = RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+		for when in 10..=26 {
+			for _ in 0..max {
+				assert_ok!(Scheduler::schedule(
+					RuntimeOrigin::root(),
+					when,
+					100,
+					Box::new(filler.clone()),
+				));
+			}
+		}
+
+		// The rejection at block 9 cannot schedule `one_fewer_deciding` anywhere, so the
+		// slot must be released inline, immediately. (This also proves the agendas really
+		// were full - had the alarm been scheduled, the count could only drop once it
+		// fired at block 10 or later.)
+		run_to(9);
+		assert_eq!(rejected_since(0), 9);
+		assert_eq!(DecidingCount::<Test>::get(0), 0);
+
+		// The freed slot is genuinely usable: once past the filled agendas, a fresh
+		// referendum begins deciding after its prepare period instead of queueing behind
+		// a phantom occupant.
+		run_to(27);
+		assert_ok!(propose_set_balance(2, 2, 0));
+		assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(2), 1));
+		run_to(31);
+		assert_eq!(deciding_since(1), 31);
+	});
+}
+
 #[test]
 fn insta_confirm_then_kill_works() {
 	ExtBuilder::default().build_and_execute(|| {

--- a/pallets/referenda/src/tests.rs
+++ b/pallets/referenda/src/tests.rs
@@ -200,6 +200,28 @@ fn evicted_from_full_queue_clears_in_queue_on_service() {
 		// 0, so the `NotQueued` arm must clear the flag and store the referendum.
 		assert_ok!(Referenda::nudge_referendum(RuntimeOrigin::root(), 1));
 		assert!(!Referenda::ensure_ongoing(1).unwrap().in_queue);
+
+		// The same service must also restore the undeciding-timeout alarm (submitted at
+		// block 5 + UndecidingTimeout 20 = block 25): `nudge_referendum` is Root-only on
+		// this chain, so without an alarm the referendum would stay stranded until a
+		// second governance intervention.
+		assert_eq!(Referenda::ensure_ongoing(1).unwrap().alarm.map(|(when, _)| when), Some(25));
+
+		// When that alarm fires, the referendum (deposit placed, prepare period elapsed)
+		// re-routes through `ready_for_deciding` or times out. Whatever the exact outcome,
+		// it must no longer sit stranded with no alarm, no queue entry and no deciding
+		// status.
+		run_to(25);
+		let stranded = matches!(
+			ReferendumInfoFor::<Test>::get(1),
+			Some(ReferendumInfo::Ongoing(ReferendumStatus {
+				in_queue: false,
+				deciding: None,
+				alarm: None,
+				..
+			}))
+		);
+		assert!(!stranded, "evicted referendum must make progress after its timeout alarm");
 	});
 }
 

--- a/pallets/referenda/src/weights.rs
+++ b/pallets/referenda/src/weights.rs
@@ -541,6 +541,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(33_048_000, 219984)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
+			// V12 audit #162501: the local fork's `schedule_enactment` retries `schedule_named`
+			// at consecutive blocks up to `MAX_ENACTMENT_SCHEDULE_RETRIES` (16) extra times on a
+			// full agenda. Each failed attempt costs roughly a `Scheduler::Lookup` read, a
+			// `Scheduler::Agenda` read and a `Preimages::drop` (`RequestStatusFor` read + write);
+			// add a conservative 16 x (4 reads, 2 writes) for the retry loop.
+			.saturating_add(T::DbWeight::get().reads_writes(4_u64, 2_u64).saturating_mul(16_u64))
 	}
 	/// Storage: `Referenda::ReferendumInfoFor` (r:1 w:1)
 	/// Proof: `Referenda::ReferendumInfoFor` (`max_values`: None, `max_size`: Some(366), added: 2841, mode: `MaxEncodedLen`)
@@ -1025,6 +1031,12 @@ impl WeightInfo for () {
 		Weight::from_parts(33_048_000, 219984)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			// V12 audit #162501: the local fork's `schedule_enactment` retries `schedule_named`
+			// at consecutive blocks up to `MAX_ENACTMENT_SCHEDULE_RETRIES` (16) extra times on a
+			// full agenda. Each failed attempt costs roughly a `Scheduler::Lookup` read, a
+			// `Scheduler::Agenda` read and a `Preimages::drop` (`RequestStatusFor` read + write);
+			// add a conservative 16 x (4 reads, 2 writes) for the retry loop.
+			.saturating_add(RocksDbWeight::get().reads_writes(4_u64, 2_u64).saturating_mul(16_u64))
 	}
 	/// Storage: `Referenda::ReferendumInfoFor` (r:1 w:1)
 	/// Proof: `Referenda::ReferendumInfoFor` (`max_values`: None, `max_size`: Some(366), added: 2841, mode: `MaxEncodedLen`)

--- a/pallets/scheduler/src/benchmarking.rs
+++ b/pallets/scheduler/src/benchmarking.rs
@@ -174,9 +174,13 @@ benchmarks! {
 	service_task_base {
 		let now = BLOCK_NUMBER.into();
 		let task = make_task::<T>(false, false, None, 0);
-		let mut counter = WeightMeter::with_limit(Weight::zero());
+		// V12 audit #162534: use an uncapped meter (like the other service benchmarks) so the
+		// dispatch actually executes; a zero limit forced every measurement into the
+		// permanently-overweight branch and never measured the success path.
+		let mut counter = WeightMeter::new();
 	}: {
 		let result = Scheduler::<T>::service_task(&mut counter, BlockNumberOrTimestamp::BlockNumber(now), BlockNumberOrTimestamp::BlockNumber(now), 0, true, task);
+		assert!(result.is_ok());
 	} verify {
 	}
 
@@ -187,18 +191,22 @@ benchmarks! {
 		let s in (BoundedInline::bound() as u32) .. (T::Preimages::MAX_LENGTH as u32);
 		let now = BLOCK_NUMBER.into();
 		let task = make_task::<T>(false, false, Some(s), 0);
-		let mut counter = WeightMeter::with_limit(Weight::zero());
+		// V12 audit #162534: see `service_task_base` - the dispatch must actually execute.
+		let mut counter = WeightMeter::new();
 	}: {
 		let result = Scheduler::<T>::service_task(&mut counter, BlockNumberOrTimestamp::BlockNumber(now), BlockNumberOrTimestamp::BlockNumber(now), 0, true, task);
+		assert!(result.is_ok());
 	} verify {
 	}
 
 	service_task_named {
 		let now = BLOCK_NUMBER.into();
 		let task = make_task::<T>(true, false, None, 0);
-		let mut counter = WeightMeter::with_limit(Weight::zero());
+		// V12 audit #162534: see `service_task_base` - the dispatch must actually execute.
+		let mut counter = WeightMeter::new();
 	}: {
 		let result = Scheduler::<T>::service_task(&mut counter, BlockNumberOrTimestamp::BlockNumber(now), BlockNumberOrTimestamp::BlockNumber(now), 0, true, task);
+		assert!(result.is_ok());
 	} verify {
 	}
 

--- a/pallets/scheduler/src/lib.rs
+++ b/pallets/scheduler/src/lib.rs
@@ -78,8 +78,8 @@ use frame_support::{
 	ensure,
 	traits::{
 		schedule::{self, DispatchTime as DispatchBlock},
-		Bounded, CallerTrait, DefensiveOption, EnsureOrigin, Get, IsType, OriginTrait,
-		PrivilegeCmp, QueryPreimage, StorageVersion, StorePreimage, Time,
+		Bounded, BoundedInline, CallerTrait, DefensiveOption, EnsureOrigin, Get, IsType,
+		OriginTrait, PrivilegeCmp, QueryPreimage, StorageVersion, StorePreimage, Time,
 	},
 	weights::{Weight, WeightMeter},
 };
@@ -90,7 +90,7 @@ use frame_system::{
 use qp_scheduler::{BlockNumberOrTimestamp, DispatchTime, ScheduleNamed};
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{BadOrigin, Dispatchable, One, Saturating, Zero},
+	traits::{BadOrigin, Dispatchable, Hash, One, Saturating, Zero},
 	BoundedVec, DispatchError, RuntimeDebug,
 };
 
@@ -425,11 +425,14 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
 			let origin = <T as Config>::RuntimeOrigin::from(origin);
-			Self::do_schedule(
+			// Must be checked before `bound`; see `lookup_already_requested` (V12 audit #162453).
+			let already_requested = Self::lookup_already_requested(&call);
+			Self::do_schedule_inner(
 				DispatchTime::At(when),
 				priority,
 				origin.caller().clone(),
 				T::Preimages::bound(*call)?,
+				already_requested,
 			)?;
 			Ok(())
 		}
@@ -459,12 +462,15 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
 			let origin = <T as Config>::RuntimeOrigin::from(origin);
-			Self::do_schedule_named(
+			// Must be checked before `bound`; see `lookup_already_requested` (V12 audit #162453).
+			let already_requested = Self::lookup_already_requested(&call);
+			Self::do_schedule_named_inner(
 				id,
 				DispatchTime::At(when),
 				priority,
 				origin.caller().clone(),
 				T::Preimages::bound(*call)?,
+				already_requested,
 			)?;
 			Ok(())
 		}
@@ -489,11 +495,14 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
 			let origin = <T as Config>::RuntimeOrigin::from(origin);
-			Self::do_schedule(
+			// Must be checked before `bound`; see `lookup_already_requested` (V12 audit #162453).
+			let already_requested = Self::lookup_already_requested(&call);
+			Self::do_schedule_inner(
 				DispatchTime::After(after),
 				priority,
 				origin.caller().clone(),
 				T::Preimages::bound(*call)?,
+				already_requested,
 			)?;
 			Ok(())
 		}
@@ -509,12 +518,15 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
 			let origin = <T as Config>::RuntimeOrigin::from(origin);
-			Self::do_schedule_named(
+			// Must be checked before `bound`; see `lookup_already_requested` (V12 audit #162453).
+			let already_requested = Self::lookup_already_requested(&call);
+			Self::do_schedule_named_inner(
 				id,
 				DispatchTime::After(after),
 				priority,
 				origin.caller().clone(),
 				T::Preimages::bound(*call)?,
+				already_requested,
 			)?;
 			Ok(())
 		}
@@ -762,11 +774,53 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	/// V12 audit #162523: put `task` back into the agenda at its original `(when, index)` slot
+	/// after a failed reschedule, regrowing the agenda with empty slots if `cleanup_agenda`
+	/// truncated or removed it in between. This restores the exact pre-reschedule agenda state.
+	fn restore_task(when: BlockNumberOrTimestampOf<T>, index: u32, task: ScheduledOf<T>) {
+		Agenda::<T>::mutate(when, |agenda| {
+			while (agenda.len() as u32) <= index {
+				// Cannot fail: the task previously occupied slot `index`, which is therefore
+				// within `MaxScheduledPerBlock`.
+				let _ = agenda.try_push(None);
+			}
+			agenda[index as usize] = Some(task);
+		});
+	}
+
 	fn do_schedule(
 		when: DispatchTime<BlockNumberFor<T>, T::Moment>,
 		priority: schedule::Priority,
 		origin: T::PalletsOrigin,
 		call: BoundedCallOf<T>,
+	) -> Result<TaskAddressOf<T>, DispatchError> {
+		// V12 audit #162453: callers that hand over an already-`Bounded` call (the v3 trait
+		// shims, benchmarks and tests) cannot tell whether they own a preimage request for the
+		// lookup hash, so keep the historical behavior and unconditionally request one. The
+		// `schedule*` dispatchables use `do_schedule_inner` with a precise flag instead.
+		Self::do_schedule_inner(when, priority, origin, call, true)
+	}
+
+	/// V12 audit #162453: returns `true` if `call` is large enough that `StorePreimage::bound`
+	/// will store it as a preimage lookup AND its hash carries a live request already (i.e.
+	/// `bound` will not register a fresh request count for it). Only then must the scheduling
+	/// task add its own request reference; otherwise the note made by `bound` is exactly the
+	/// reference the task owns. Must be called on the raw call, before `bound`.
+	fn lookup_already_requested(call: &<T as Config>::RuntimeCall) -> bool {
+		call.using_encoded(|encoded| {
+			// `StorePreimage::bound` only falls back to a preimage lookup when the encoded call
+			// exceeds the inline bound.
+			encoded.len() > BoundedInline::bound() &&
+				T::Preimages::is_requested(&T::Hashing::hash(encoded))
+		})
+	}
+
+	fn do_schedule_inner(
+		when: DispatchTime<BlockNumberFor<T>, T::Moment>,
+		priority: schedule::Priority,
+		origin: T::PalletsOrigin,
+		call: BoundedCallOf<T>,
+		request_preimage: bool,
 	) -> Result<TaskAddressOf<T>, DispatchError> {
 		// `call` may already carry a preimage noted by `StorePreimage::bound` (called by the
 		// scheduler entrypoints before this). If any later fallible step fails, drop that
@@ -788,7 +842,12 @@ impl<T: Config> Pallet<T> {
 				return Err(e)
 			},
 		};
-		if let Some(hash) = lookup_hash {
+		// V12 audit #162453: only request the preimage if it was already requested before the
+		// caller's `StorePreimage::bound` (in which case `bound` did not bump the request count
+		// and the task needs its own reference). Otherwise `bound` itself noted the hash as
+		// `Requested { count: 1, .. }`, which is exactly the reference this task owns, and
+		// requesting again would orphan the count since every terminal path drops only once.
+		if let Some(hash) = lookup_hash.filter(|_| request_preimage) {
 			T::Preimages::request(&hash);
 		}
 		Ok(res)
@@ -841,7 +900,17 @@ impl<T: Config> Pallet<T> {
 		Self::cleanup_agenda(when);
 		Self::deposit_event(Event::Canceled { when, index });
 
-		let new_address = Self::place_task(new_time, task).map_err(|x| x.0)?;
+		// V12 audit #162523: if the destination agenda is exhausted, restore the task at its
+		// original address instead of dropping it (which would also leak its preimage
+		// reference). `Retries` is only taken on the success path below, so it is left
+		// untouched here.
+		let new_address = match Self::place_task(new_time, task) {
+			Ok(new_address) => new_address,
+			Err((e, task)) => {
+				Self::restore_task(when, index, task);
+				return Err(e);
+			},
+		};
 		// Transfer retry configuration to the new address
 		if let Some(retry_config) = Retries::<T>::take((when, index)) {
 			Retries::<T>::insert(new_address, retry_config);
@@ -855,6 +924,19 @@ impl<T: Config> Pallet<T> {
 		priority: schedule::Priority,
 		origin: T::PalletsOrigin,
 		call: BoundedCallOf<T>,
+	) -> Result<TaskAddressOf<T>, DispatchError> {
+		// See `do_schedule`: keep unconditionally requesting the preimage for callers that hand
+		// over an already-`Bounded` call; the dispatchables use `do_schedule_named_inner`.
+		Self::do_schedule_named_inner(id, when, priority, origin, call, true)
+	}
+
+	fn do_schedule_named_inner(
+		id: TaskName,
+		when: DispatchTime<BlockNumberFor<T>, T::Moment>,
+		priority: schedule::Priority,
+		origin: T::PalletsOrigin,
+		call: BoundedCallOf<T>,
+		request_preimage: bool,
 	) -> Result<TaskAddressOf<T>, DispatchError> {
 		// See `do_schedule`: drop any preimage noted by `StorePreimage::bound` on every fallible
 		// path so a failed schedule cannot leave an unowned, system-requested preimage behind.
@@ -879,7 +961,8 @@ impl<T: Config> Pallet<T> {
 				return Err(e)
 			},
 		};
-		if let Some(hash) = lookup_hash {
+		// See `do_schedule_inner` (V12 audit #162453).
+		if let Some(hash) = lookup_hash.filter(|_| request_preimage) {
 			T::Preimages::request(&hash);
 		}
 		Ok(res)
@@ -940,7 +1023,19 @@ impl<T: Config> Pallet<T> {
 		Self::cleanup_agenda(when);
 		Self::deposit_event(Event::Canceled { when, index });
 
-		let new_address = Self::place_task(new_time, task).map_err(|x| x.0)?;
+		// V12 audit #162523: if the destination agenda is exhausted, restore the task at its
+		// original address instead of dropping it (which would also leak its preimage
+		// reference). `place_task` only writes `Lookup` after a successful placement, so the
+		// name's `Lookup` entry still points at this original address and stays valid once the
+		// task is restored. `Retries` is only taken on the success path below, so it is left
+		// untouched here.
+		let new_address = match Self::place_task(new_time, task) {
+			Ok(new_address) => new_address,
+			Err((e, task)) => {
+				Self::restore_task(when, index, task);
+				return Err(e);
+			},
+		};
 		// Transfer retry configuration to the new address
 		if let Some(retry_config) = Retries::<T>::take((when, index)) {
 			Retries::<T>::insert(new_address, retry_config);
@@ -1230,6 +1325,9 @@ impl<T: Config> Pallet<T> {
 				if let Some(ref id) = task.maybe_id {
 					Lookup::<T>::remove(id);
 				}
+				// V12 audit #162524: also drop the retry configuration, mirroring the
+				// `CallUnavailable` arm above - a permanently removed task must not retain one.
+				Retries::<T>::remove((when, agenda_index));
 				T::Preimages::drop(&task.call);
 				Self::deposit_event(Event::PermanentlyOverweight {
 					task: (when, agenda_index),
@@ -1349,7 +1447,15 @@ impl<T: Config> Pallet<T> {
 			Some(n) => n,
 			None => return false,
 		};
-		match now.saturating_add(&period) {
+		// V12 audit #162526: `service_timestamp_agendas` only ever visits bucket-aligned agenda
+		// keys (multiples of `TimestampBucketSize`), so a timestamp retry whose wake moment is
+		// not bucket-aligned would never be serviced. Round the wake moment up to the next
+		// bucket boundary, using the same `normalize` semantics as `resolve_time`. Block
+		// numbers are returned unchanged by `normalize`.
+		let wake = now
+			.saturating_add(&period)
+			.map(|wake| wake.normalize(T::TimestampBucketSize::get()));
+		match wake {
 			Ok(wake) => match Self::place_task(wake, task.as_retry()) {
 				Ok(address) => {
 					// Retry successfully placed. The retry clone now "owns" the preimage

--- a/pallets/scheduler/src/tests.rs
+++ b/pallets/scheduler/src/tests.rs
@@ -3960,3 +3960,216 @@ fn timestamp_retry_scheduling_and_cancellation() {
 		assert_eq!(Retries::<Test>::iter().count(), 0, "Retry config should be cleaned up");
 	});
 }
+
+/// V12 audit #162526: a timestamp retry whose period is not a multiple of the bucket size must
+/// still be serviced - the wake moment is rounded up to the next bucket boundary.
+#[test]
+fn timestamp_retry_unaligned_period_is_serviced() {
+	new_test_ext().execute_with(|| {
+		// Task fails until block 50 is reached.
+		Threshold::<Test>::put((50, 100)); // Use block threshold as proxy
+
+		MockTimestamp::set_timestamp(10000);
+		run_to_block(1);
+
+		// Schedule a timestamp task; resolves to bucket 30000.
+		assert_ok!(Scheduler::schedule_after(
+			RuntimeOrigin::root(),
+			BlockNumberOrTimestamp::Timestamp(15000),
+			127,
+			Box::new(RuntimeCall::Logger(LoggerCall::timed_log {
+				i: 42,
+				weight: Weight::from_parts(10, 0),
+			})),
+		));
+		let when = BlockNumberOrTimestamp::Timestamp(30000u64);
+		assert!(Agenda::<Test>::get(when)[0].is_some());
+
+		// Retry once, 5000ms later - NOT a multiple of the 10000ms bucket size.
+		assert_ok!(Scheduler::set_retry(
+			root().into(),
+			(when, 0),
+			1,
+			BlockNumberOrTimestamp::Timestamp(5000)
+		));
+
+		// Trigger the task; it fails and the retry must be placed at the bucket-aligned key
+		// 40000 (the unaligned wake moment 35000 rounded up to the next bucket boundary).
+		MockTimestamp::set_timestamp(25000);
+		run_to_block(2);
+		assert!(logger::log().is_empty(), "task should have failed");
+		assert!(Agenda::<Test>::get(when).is_empty(), "original task should be done");
+		let retry_when = BlockNumberOrTimestamp::Timestamp(40000u64);
+		assert_eq!(
+			Agenda::<Test>::get(retry_when).len(),
+			1,
+			"retry should be scheduled at the next bucket boundary"
+		);
+
+		// Advance past the retry bucket: the retry must actually be serviced (it fails again
+		// and, with no retries left, is removed for good).
+		MockTimestamp::set_timestamp(35000);
+		run_to_block(3);
+		assert!(
+			Agenda::<Test>::get(retry_when).is_empty(),
+			"retry task should have been serviced and removed"
+		);
+		assert_eq!(Retries::<Test>::iter().count(), 0, "retry config should be cleaned up");
+	});
+}
+
+/// V12 audit #162523: a reschedule that fails because the destination agenda is full must not
+/// destroy the task.
+#[test]
+fn reschedule_into_full_agenda_preserves_task() {
+	use frame_support::traits::schedule::{v3::Anon, DispatchTime};
+
+	new_test_ext().execute_with(|| {
+		let max: u32 = <Test as Config>::MaxScheduledPerBlock::get();
+		let call =
+			RuntimeCall::Logger(LoggerCall::log { i: 42, weight: Weight::from_parts(10, 0) });
+		let bound = Preimage::bound(call).unwrap();
+
+		// Fill the block 5 agenda to capacity.
+		for _ in 0..max {
+			<Scheduler as Anon<_, _, _>>::schedule(
+				DispatchTime::At(5),
+				None,
+				127,
+				root(),
+				bound.clone(),
+			)
+			.unwrap();
+		}
+
+		// Schedule the task to be rescheduled at block 4 and give it a retry config.
+		let address = <Scheduler as Anon<_, _, _>>::schedule(
+			DispatchTime::At(4),
+			None,
+			127,
+			root(),
+			bound.clone(),
+		)
+		.unwrap();
+		assert_eq!(address, (BlockNumberOrTimestamp::BlockNumber(4), 0));
+		assert_ok!(Scheduler::set_retry(
+			root().into(),
+			address,
+			3,
+			BlockNumberOrTimestamp::BlockNumber(2)
+		));
+
+		// Rescheduling into the full agenda fails ...
+		assert_err!(
+			<Scheduler as Anon<_, _, _>>::reschedule(address, DispatchTime::At(5)),
+			DispatchError::Exhausted
+		);
+
+		// ... and the task remains intact at its original address, along with its retry
+		// configuration and the full destination agenda.
+		let agenda = Agenda::<Test>::get(BlockNumberOrTimestamp::BlockNumber(4));
+		assert_eq!(agenda.len(), 1);
+		assert!(agenda[0].is_some());
+		assert_eq!(
+			Retries::<Test>::get(address),
+			Some(RetryConfig {
+				total_retries: 3,
+				remaining: 3,
+				period: BlockNumberOrTimestamp::BlockNumber(2)
+			}),
+			"retry config should be untouched by the failed reschedule"
+		);
+		assert_eq!(Agenda::<Test>::get(BlockNumberOrTimestamp::BlockNumber(5)).len(), max as usize);
+
+		// The task still executes at its original block.
+		run_to_block(4);
+		assert_eq!(logger::log(), vec![(root(), 42u32)]);
+	});
+}
+
+/// V12 audit #162523: a failed named reschedule must keep the `Lookup` entry pointing at the
+/// original address, so the name stays usable.
+#[test]
+fn reschedule_named_into_full_agenda_preserves_lookup() {
+	use frame_support::traits::schedule::{
+		v3::{Anon, Named},
+		DispatchTime,
+	};
+
+	new_test_ext().execute_with(|| {
+		let max: u32 = <Test as Config>::MaxScheduledPerBlock::get();
+		let id = [1u8; 32];
+		let call =
+			RuntimeCall::Logger(LoggerCall::log { i: 42, weight: Weight::from_parts(10, 0) });
+		let bound = Preimage::bound(call).unwrap();
+
+		// Fill the block 5 agenda to capacity.
+		for _ in 0..max {
+			<Scheduler as Anon<_, _, _>>::schedule(
+				DispatchTime::At(5),
+				None,
+				127,
+				root(),
+				bound.clone(),
+			)
+			.unwrap();
+		}
+
+		// Schedule the named task at block 4 (distinct payload to tell it apart from fillers).
+		let named_call =
+			RuntimeCall::Logger(LoggerCall::log { i: 43, weight: Weight::from_parts(10, 0) });
+		let address = <Scheduler as Named<_, _, _>>::schedule_named(
+			id,
+			DispatchTime::At(4),
+			None,
+			127,
+			root(),
+			Preimage::bound(named_call).unwrap(),
+		)
+		.unwrap();
+		assert_eq!(Lookup::<Test>::get(id), Some(address));
+
+		// Rescheduling into the full agenda fails ...
+		assert_err!(
+			<Scheduler as Named<_, _, _>>::reschedule_named(id, DispatchTime::At(5)),
+			DispatchError::Exhausted
+		);
+
+		// ... and both the task and its name lookup remain intact at the original address.
+		assert_eq!(Lookup::<Test>::get(id), Some(address));
+		let agenda = Agenda::<Test>::get(BlockNumberOrTimestamp::BlockNumber(4));
+		assert_eq!(agenda.len(), 1);
+		assert!(agenda[0].is_some());
+
+		// The name is not bricked: rescheduling into a non-full agenda still works.
+		assert_ok!(<Scheduler as Named<_, _, _>>::reschedule_named(id, DispatchTime::At(6)));
+		assert_eq!(Lookup::<Test>::get(id), Some((BlockNumberOrTimestamp::BlockNumber(6), 0)));
+
+		// The block 5 fillers execute first, then the named task at block 6.
+		run_to_block(6);
+		let mut expected = vec![(root(), 42u32); max as usize];
+		expected.push((root(), 43u32));
+		assert_eq!(logger::log(), expected);
+	});
+}
+
+/// V12 audit #162453: scheduling an oversized call through a dispatchable must not orphan the
+/// preimage request count - `StorePreimage::bound` already noted it as requested, so the
+/// scheduler must not request it again.
+#[test]
+fn schedule_oversized_call_does_not_leak_preimage_request() {
+	new_test_ext().execute_with(|| {
+		let call = RuntimeCall::System(system::Call::remark { remark: vec![0u8; 200] });
+		let hash = <Test as frame_system::Config>::Hashing::hash_of(&call);
+		// The encoded call exceeds the inline bound, so `bound` stores it as a lookup.
+		assert!(call.using_encoded(|c| c.len()) > BoundedInline::bound());
+
+		assert_ok!(Scheduler::schedule(RuntimeOrigin::root(), 4, 127, Box::new(call)));
+		assert!(Preimage::is_requested(&hash));
+
+		run_to_block(4);
+		// The single request reference is dropped on execution, fully cleaning up the preimage.
+		assert!(!Preimage::is_requested(&hash));
+		assert!(Preimage::len(&hash).is_none());
+	});
+}

--- a/pallets/scheduler/src/weights.rs
+++ b/pallets/scheduler/src/weights.rs
@@ -110,12 +110,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: `Scheduler::Retries` (r:1 w:1)
+	/// Proof: `Scheduler::Retries` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
 	fn service_task_base() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_000_000 picoseconds.
 		Weight::from_parts(2_000_000, 0)
+			// V12 audit #162534: `service_task` unconditionally takes the `Retries` entry at the
+			// task address on every successful dispatch (1 read + 1 write); the benchmark used a
+			// zero-limit meter and never measured that path, so charge for it explicitly.
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Preimage::PreimageFor` (r:1 w:1)
 	/// Proof: `Preimage::PreimageFor` (`max_values`: None, `max_size`: Some(4194344), added: 4196819, mode: `Measured`)
@@ -344,12 +351,19 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	/// Storage: `Scheduler::Retries` (r:1 w:1)
+	/// Proof: `Scheduler::Retries` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
 	fn service_task_base() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_000_000 picoseconds.
 		Weight::from_parts(2_000_000, 0)
+			// V12 audit #162534: `service_task` unconditionally takes the `Retries` entry at the
+			// task address on every successful dispatch (1 read + 1 write); the benchmark used a
+			// zero-limit meter and never measured that path, so charge for it explicitly.
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Preimage::PreimageFor` (r:1 w:1)
 	/// Proof: `Preimage::PreimageFor` (`max_values`: None, `max_size`: Some(4194344), added: 4196819, mode: `Measured`)

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -223,8 +223,11 @@ parameter_types! {
 	pub const ReferendumMaxProposals: u32 = 100;
 	// Submission deposit for referenda
 	pub const ReferendumSubmissionDeposit: Balance = 100 * UNIT;
-	// Undeciding timeout (45 days): a submitted referendum that never receives a decision deposit
-	// (or never gets a free deciding slot) is rejected as TimedOut after this long.
+	// Undeciding timeout (45 days): a submitted referendum that is NOT in the track queue —
+	// e.g. one that never received a decision deposit — is rejected as TimedOut after this
+	// long. Referenda that ARE queued for deciding are exempt: the timeout check
+	// (pallets/referenda/src/lib.rs, `service_referendum`) is gated on `!status.in_queue`,
+	// so a queued referendum that simply never gets a free deciding slot is NOT timed out.
 	pub const UndecidingTimeout: BlockNumber = 45 * DAYS;
 	pub const AlarmInterval: BlockNumber = 1;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -76,7 +76,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 139,
+	spec_version: 140,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
# V12 Security Audit — Remediation

Full accounting of **all 246 findings** in `export-findings.json` (auditor: V12): 23 triaged valid, 223 triaged invalid. Every valid finding is either fixed in this PR, fixed via #639 (merged into this branch), or documented not-fix below with reasoning — see the tables at the bottom of this description for the complete per-finding accounting.

**`spec_version` bumped 139 → 140** (runtime WASM changed).

> **Merge note:** `main` (#639) independently fixed three scheduler findings also addressed here. Resolved toward main's implementations: **#162523** (failed reschedule) keeps main's copy-first / no-op-on-failure design — this branch contributes its two extra regression tests; **#162526** (unaligned timestamp retries) is covered by main's fail-fast `InvalidRetryPeriod` validation at `set_retry` time — this branch's normalization approach was dropped; **#162524** landed identically in both (same `Retries::remove` line).

## Fixed in this branch

### pallets/referenda
- **`set_alarm` retry loop** — fixes **#161704** + **#162455** (HIGH). On a full scheduler agenda, alarms slide forward up to 16 blocks (mirroring `schedule_enactment`) instead of being silently dropped. A dropped alarm could permanently stall a referendum — and with `max_deciding = 1` and no sudo backstop, deadlock the entire governance lane, with no runtime-upgrade path out.
- **Ghost-queue fix** — **#161743**: when a referendum was evicted from a full `TrackQueue` by `force_insert_keep_right`, `in_queue` stayed `true` with no alarm, stranding it (timeout check is gated on `!in_queue`). The `NotQueued` service branch now clears the flag and marks the status dirty.
- **`nudge_referendum_approved` weight** — **#162501**: accounts for the locally-added 17-attempt enactment scheduling retry loop (both weight impls).

### pallets/scheduler
- **`service_task_base` weight charges `Retries::take`** (1r/1w, unconditional on every successful dispatch) — **#162534**. Also fixes the service-task benchmarks, which used a zero-limit `WeightMeter` and therefore never measured the success path.
- **Preimage request leak** — **#162453**: `bound` on a fresh oversized call already notes the hash (`Requested { count: 1 }`); the unconditional follow-up `request` bumped the count to 2 while every terminal path drops once, leaking the bytes permanently. The request is now skipped unless the hash was already requested before `bound` (keeps the user-noted `Unrequested` deposit flow balanced, and the multi-task-same-hash case).
- Regression tests for **#162523** (retry-config survival, named task not bricked after failed reschedule — the fix itself is main's, from #639).

### pallets/frame-system
- **`validate_unsigned` honors `check_version`** — **#162411**: pool validation for `apply_authorized_upgrade` hardcoded `false`; now matches the dispatch path (diverges from upstream, which has the same bug).
- **`set_heap_pages` range validation** — **#162546**: rejects values outside `64..=65536` (4 MiB executor-practical minimum … 4 GiB wasm32 linear-memory hard max) with new `Error::InvalidHeapPages`. Root-only, but a bad value bricks execution and this chain has no sudo backstop.

### Docs / comments
- `docs/TECH_REFERENDA_FEATURES.md` claimed `nudge_referendum` is "permissionless" — it is Root-only (`pallets/referenda/src/lib.rs:651`). Corrected; this misstated the exact recovery lever the HIGH findings depend on.
- `runtime/src/configs/mod.rs`: the `UndecidingTimeout` comment claimed queued referenda time out — they don't (upstream-intended). Comment corrected.

## Testing

Regression tests added across all three pallets; all suites green on the merged branch:
- `cargo test -p frame-system` — **76 passed**
- `cargo test -p pallet-referenda` — **42 passed**
- `cargo test -p pallet-scheduler` — **88 passed** (+ `--features runtime-benchmarks`: 105 passed, incl. benchmark tests for the reworked service-task benchmarks)
- `cargo check -p quantus-runtime` — clean (pre-existing warnings only)

## Deployment note

Runtime WASM changed → deploy via governance runtime upgrade per `docs/RUNTIME_UPDATE.md` (spec_version 140).

## Follow-up (out of scope, pre-existing)

Failure paths of `do_schedule_inner`/`do_schedule_named_inner` drop the preimage even when `bound` added no reference (hash already `Requested` by another live task), decrementing someone else's count. Pre-existing behavior, not touched here — worth a separate issue.

---

# Complete findings accounting

### Valid findings — full accounting (23)

| Finding | Severity | Title | Status / reasoning |
|---|---|---|---|
| #161704 | HIGH | Silent alarm-drop on scheduler failure stalls referendum lifecycle | Fixed in this PR — `set_alarm` slides forward up to 16 blocks on full agendas |
| #162455 | HIGH | Scheduler exhaustion can permanently retain a deciding slot | Fixed in this PR — same `set_alarm` retry fix as #161704 (shared root cause) |
| #162469 | HIGH | Queued referenda can bypass the undeciding deadline | Not fixing (code) — verbatim upstream-intended semantics (don't punish depositors for congestion); the misleading `UndecidingTimeout` comment was corrected in this PR |
| #162488 | HIGH | Account reaping resets nonce and enables transaction replay | Not fixing — known upstream design property; defense is mortal txs via `CheckEra` (present). All first-party clients are mortal (cli `.mortal(256)`, SDK `eraPeriod: 64`). Rejecting immortal txs breaks third-party tooling for marginal gain |
| #162534 | HIGH | Task weights omit retry and preimage-cleanup costs | Fixed in this PR — `service_task_base` charges `Retries::take` (1r/1w); benchmarks use real WeightMeter |
| #162540 | HIGH | Storage writes are not weighted by key and value size | Not fixing — `ensure_root` only; sudo removed; only TechCollective governance (members-only, 2h+3d delays) can call. No public spam path |
| #162546 | HIGH | Unvalidated heap-page setting can disable runtime execution | Fixed in this PR — `set_heap_pages` validates range 64..=65536 (`InvalidHeapPages`) |
| #162572 | HIGH | Runtime code installation weight ignores blob length | Not fixing — `set_code` is `ensure_root` only; `apply_authorized_upgrade` is gated to a governance-authorized blob hash. No public path |
| #162411 | MEDIUM | Unsigned validation for apply_authorized_upgrade skips required version check | Fixed in this PR — `validate_unsigned` honors `res.check_version` |
| #162459 | MEDIUM | Non-atomic legacy preimage migration destroys status | Not fixing — moot: chain launched with pallet-preimage 39.0.0 (`STORAGE_VERSION = 1` since 2022); v0 storage can never exist, so the legacy conversion path is unreachable |
| #162461 | MEDIUM | Schedule the preimage v0-to-v1 storage migration | Not fixing — moot for the same reason as #162459: on-chain version was 1 since genesis; nothing to migrate |
| #162541 | MEDIUM | Storage deletion weight omits key length | Not fixing — `kill_storage` is `ensure_root` only, same rationale as #162540 |
| #162542 | MEDIUM | Runtime code installation undercharges variable-length blobs | Not fixing — duplicate of #162572, same rationale |
| #162570 | MEDIUM | Storage-write weight omits key and value sizes | Not fixing — duplicate of #162540 (weight impl detail), same rationale |
| #161743 | LOW | Ghost-queued referenda can be stranded when no longer in the track queue | Fixed in this PR — `NotQueued` branch clears `in_queue` + marks dirty |
| #162232 | LOW | Runtime-benchmarks feature disables runtime-version checks | Not fixing — production artifacts never build with `runtime-benchmarks` (release workflow builds plain `--release`); fork is already stricter than upstream |
| #162453 | LOW | Lookup preimages retain an orphaned request after task cleanup | Fixed in this PR — skip redundant preimage request when `bound` just noted the hash |
| #162501 | LOW | Approved nudge weight omits enactment scheduling retries | Fixed in this PR — `nudge_referendum_approved` weight covers 17-attempt retry loop |
| #162503 | LOW | Make block-number-provider migration one-time and complete | Not fixing — dead code: `MigrateBlockNumberProvider` is not wired into the runtime `Migrations` tuple; upstream-identical; left untouched |
| #162523 | LOW | Failed rescheduling destroys tasks and leaves coupled state stale | Fixed via #639 (merged into this branch) — copy-first reschedule, failure is a complete no-op; this PR adds regression tests |
| #162524 | LOW | Terminally overweight tasks retain retry policies | Fixed via #639 (merged; identical `Retries::remove` in both PRs) |
| #162526 | LOW | Unaligned timestamp retries are never serviced | Fixed via #639 (merged) — fail-fast `InvalidRetryPeriod` rejects non-bucket-aligned periods at `set_retry` |
| #162571 | LOW | Storage deletion weight omits key length | Not fixing — duplicate of #162541 (weight impl detail), same rationale |

The 6 invalid-triaged findings flagged `needs-review` by the tool were manually reviewed as well:

| Finding | Title | Review conclusion |
|---|---|---|
| #162239 | set_storage and kill_storage accept unbounded item counts | Same family as #162540: `set_storage`/`kill_storage` are `ensure_root` only — no public path; governance self-limiting |
| #162472 | Bound multi-block migration steps by the remaining block budget | Not applicable to our config: the runtime `Migrations` tuple uses one-shot `on_runtime_upgrade` migrations, not multi-block stepped migrations |
| #162477 | Raw storage administration can bypass runtime upgrade controls | Same family as #162540: raw storage admin is `ensure_root` only — governance itself is the control |
| #162529 | Worst-case agenda weight gate prematurely defers scheduled tasks | Upstream-intended: the agenda weight gate (`MaximumWeight` = 80% of block) defers tasks to later blocks under load; standard scheduler behavior |
| #162538 | Unbounded event data enables unpriced proof growth and silent event loss | Events are not state and do not affect consensus weight; bounded by block-size limits on the extrinsic side. Accepted upstream property |
| #162545 | Report incomplete bounded prefix deletion | Informational/monitoring request; bounded prefix deletion was already hardened in #616/#617. No correctness issue |

### Invalid findings (223) — triaged invalid by the audit tool, verified in aggregate

| Finding | Severity | Title | Triage category |
|---|---|---|---|
| #161555 | LOW | Timestamp retry scheduling bypasses future-time validation | theoretical-attack-vector |
| #161561 | LOW | Agenda housekeeping weights undercount storage accesses | invalid-finding |
| #161568 | LOW | service_agendas_base undercharges IncompleteBlockSince write | invalid-finding |
| #161569 | LOW | service_timestamp_agendas_base undercounts timestamp housekeeping reads/writes | negligible-economic-impact |
| #161579 | LOW | Nonce consumption on dispatch failure is not documented as an invariant | code-quality-issue |
| #161584 | LOW | Nonce provides/requires tags and stale/future handling match intent | invalid-finding |
| #161585 | LOW | MAX_EXTRINSIC_DEPTH enforced before unchecked-to-checked conversion | invalid-finding |
| #161600 | LOW | Zero-sender rejection behaves as documented | invalid-finding |
| #161603 | LOW | Genesis hash binding enforced in signed implication | invalid-finding |
| #161604 | LOW | Era birth hash binding and AncientBirthBlock match intent | invalid-finding |
| #161607 | LOW | Account provider/sufficient gating of nonce admission matches intent | invalid-finding |
| #161629 | LOW | Order of event reset, upgrade hooks, System::initialize, and Mandatory weight registration is correct | invalid-finding |
| #161630 | LOW | runtime_upgraded() predicate matches documented spec-version/spec-name semantics | invalid-finding |
| #161631 | LOW | Unchecked downgrade/equal-version code install correctly suppresses upgrade hooks as documented | intended-behavior |
| #161641 | LOW | VERSION identity and upgrade ordering verified | invalid-finding |
| #161648 | LOW | CheckWeight extension weight omits storage I/O costs | invalid-finding |
| #161649 | LOW | CheckWeight extension weight omits storage I/O costs | known-issue |
| #161655 | LOW | Block weight and extrinsic index are not reset at finalization | user-operational-error |
| #161657 | LOW | Missing runtime header number re-verification on import | invalid-finding |
| #161665 | LOW | Pallet-level on_idle/on_poll nondeterminism is a latent chain-split risk | theoretical-attack-vector |
| #161666 | LOW | No panic-based Ok-with-mismatch path found in import execution | invalid-finding |
| #161679 | LOW | Signed payload can be decoupled from unsigned call in offchain helper | theoretical-attack-vector |
| #161680 | LOW | ForAll iterates over live keystore without snapshot or deduplication | user-operational-error |
| #161681 | LOW | Offchain submission pipeline returns opaque errors without rollback | code-quality-issue |
| #161693 | LOW | PreimageDeposit allows zero-footprint tickets and lacks stale-ticket guard | invalid-finding |
| #161696 | LOW | Fee policy wiring consistent with documentation | invalid-finding |
| #161697 | LOW | HighSecurityConfig whitelist exact and complete | invalid-finding |
| #161698 | LOW | NonWormholeAccounts exclusions match policy | invalid-finding |
| #161699 | LOW | Scheduler configuration matches documented limits | invalid-finding |
| #161702 | LOW | Executive type alias in docs omits configured migration tuple | code-quality-issue |
| #161706 | LOW | Vote-weight overflow for maximum-rank members in Linear/Geometric | deployment-configuration-error |
| #161707 | LOW | Unchecked vote-sum overflow in Tally::approval | deployment-configuration-error |
| #161708 | LOW | Unconditional status and alarm rewrite on every poll access | theoretical-attack-vector |
| #161709 | LOW | try_state_index panics on broken forward/inverse mapping | code-quality-issue |
| #161710 | LOW | try_state_members has weak per-rank check and overflow-prone accumulator | code-quality-issue |
| #161711 | LOW | remove_from_rank saturates a zero MemberCount instead of flagging corruption | code-quality-issue |
| #161712 | LOW | remove_member doc comment contradicts rank-0 removal | code-quality-issue |
| #161713 | LOW | Misleading comment on Curve::passing threshold comparison | code-quality-issue |
| #161734 | LOW | Approved referendum left permanently unscheduled after 17 consecutive full agendas | theoretical-attack-vector |
| #161740 | LOW | Exported MigrateBlockNumberProvider has an impossible generic bound | code-quality-issue |
| #161747 | LOW | Post-vote alarm calculation uses non-saturating addition | theoretical-attack-vector |
| #161748 | LOW | Manual nudge can leave stale scheduler alarm | theoretical-attack-vector |
| #161750 | LOW | cancel leaves stale metadata and preimage reference behind | false-invariant |
| #161752 | LOW | Technical referendum wiring matches intended authority model | invalid-finding |
| #161753 | LOW | Migration tuple does not include referendum migrations | invalid-finding |
| #161769 | LOW | Try-runtime migration tuple does not short-circuit on failure | informational-monitoring |
| #161773 | LOW | Wormhole v0→v1 migration non-idempotent counter re-seed | theoretical-attack-vector |
| #161780 | LOW | Pallet init/finalize hooks run ungated during MBM | theoretical-attack-vector |
| #161781 | LOW | Pre/post upgrade state bytes lack integrity check | invalid-finding |
| #161782 | LOW | StorageNoopGuard is a post-hoc assertion, not strong isolation | invalid-finding |
| #161783 | LOW | LastRuntimeUpgrade written before try-state checks | invalid-finding |
| #161790 | LOW | No overflow in RemovePallet/RemoveStorage weight arithmetic | invalid-finding |
| #161791 | LOW | Post-upgrade checks correctly tolerate bounded residual keys | intended-behavior |
| #161800 | LOW | Final release branch relies on a debug-only count assertion | theoretical-attack-vector |
| #161801 | LOW | Trait unrequest/unnote methods swallow release errors in release builds | code-quality-issue |
| #161821 | LOW | ensure_updated weight proof mismatches reserve/unreserve path | invalid-finding |
| #161824 | LOW | Preimage migration try-runtime check silently accepts data loss | theoretical-attack-vector |
| #161826 | LOW | Inclusion mode correctly restricts extrinsics during migrations | invalid-finding |
| #161827 | LOW | Inherent handoff and phase transitions are correct | invalid-finding |
| #161828 | LOW | Depth-limited decode is applied before signature check | invalid-finding |
| #161829 | LOW | Weight accounting and extrinsic recording are correct | invalid-finding |
| #161847 | LOW | ZkTreeRoot and ExtrinsicData cleanup rely on implicit cross-block overwriting and accurate counters | invalid-finding |
| #161852 | LOW | Unchecked addition in `inc_sufficients` creation test risks wraparound false creation | theoretical-attack-vector |
| #162112 | LOW | Saturating tally arithmetic masks vote-tally inconsistency | theoretical-attack-vector |
| #162113 | LOW | Fee waiver and replacement-fee logic align with Voting record | invalid-finding |
| #162121 | LOW | Verification: technical submitter must be a current member | invalid-finding |
| #162127 | LOW | Verification: TechReferenda instance and TechCollective::Polls wiring match | invalid-finding |
| #162128 | LOW | cleanup_poll fee waiver excludes successful zero-removal calls | code-quality-issue |
| #162175 | LOW | Stale block length and extrinsic count survive initialization | invalid-finding |
| #162178 | LOW | TxExtension includes three extra extensions beyond the eight-member pipeline | code-quality-issue |
| #162179 | LOW | on_idle gate collapses to ref-time-only when proof_size is u64::MAX | design-decision |
| #162181 | LOW | Proof-size weight dimension is intentionally uncapped by runtime configuration | design-decision |
| #162182 | LOW | RUNTIME_SURFACE.md lists Executive with empty migrations tuple | code-quality-issue |
| #162184 | LOW | final_checks verifies all required header commitments exactly | invalid-finding |
| #162185 | LOW | execute_block and finalize_block share identical hook and weight paths | invalid-finding |
| #162187 | LOW | Core::execute_block discards header; correctness is enforced by internal panics | external-dependency-behavior |
| #162188 | LOW | Core::execute_block discards header; correctness is enforced by internal panics | intended-behavior |
| #162189 | LOW | Malicious blocks can trigger deterministic import panic after full execution | theoretical-attack-vector |
| #162196 | LOW | Production and try-runtime upgrade paths differ in invariant coverage | false-invariant |
| #162197 | LOW | Try-runtime upgrade path skips multi-block migration stepping | theoretical-attack-vector |
| #162198 | LOW | Multi-block migration gate is only enforced in execute_block | invalid-finding |
| #162199 | LOW | Unvalidated prefix strings allow removal of wrong storage | theoretical-attack-vector |
| #162201 | LOW | Try-runtime guard only covers post-migration checks | false-invariant |
| #162203 | LOW | VersionedMigration relies on caller for StorageNoopGuard | invalid-finding |
| #162204 | LOW | Production upgrade path skips pre/post checks | intended-behavior |
| #162208 | LOW | SteppedMigration documentation typo: 'Nonce' instead of 'None' | code-quality-issue |
| #162228 | LOW | Signature-sender binding verified before dispatch | invalid-finding |
| #162239 | LOW | set_storage and kill_storage accept unbounded item counts | needs-review |
| #162240 | LOW | Reauthorization silently overwrites pending upgrade authorization | invalid-finding |
| #162256 | LOW | Root administration calls correctly enforce `ensure_root` | invalid-finding |
| #162259 | LOW | No replay risk after authorization is consumed | invalid-finding |
| #162260 | LOW | Hash computation timing is not a security vulnerability | theoretical-attack-vector |
| #162261 | LOW | Fee waiver does not bypass block weight limit | code-quality-issue |
| #162299 | LOW | Block-weight arithmetic uses non-saturating operations | theoretical-attack-vector |
| #162300 | LOW | check_inherents does not replay the validate_transaction state-write defect | invalid-finding |
| #162304 | LOW | Operational reserved weight uses non-saturating subtraction | invalid-finding |
| #162305 | LOW | Base weight validation uses non-saturating addition | invalid-finding |
| #162312 | LOW | Scheduler call disabling and migration set verified correct | invalid-finding |
| #162313 | LOW | fast-governance feature does not affect system/executive component | invalid-finding |
| #162374 | LOW | Reschedule can transfer mismatched-domain retry config | theoretical-attack-vector |
| #162390 | LOW | try_execute_block digest check truncates on mismatched lengths | theoretical-attack-vector |
| #162391 | LOW | Vote benchmark underestimates weight for vote changes | invalid-finding |
| #162392 | LOW | Benchmarks fall back to error path when no poll classes exist | theoretical-attack-vector |
| #162393 | LOW | cleanup_poll weight extrapolates beyond benchmarked range | theoretical-attack-vector |
| #162403 | LOW | High-security whitelist excludes wrapped and alternate reversible calls | intended-behavior |
| #162410 | LOW | StoredMap::try_mutate_exists can remove account with active consumers | invalid-finding |
| #162414 | LOW | Runtime Version Comment Contradicts Configuration | code-quality-issue |
| #162421 | LOW | Benchmark Origin Fails Membership Check | code-quality-issue |
| #162454 | LOW | Retain only live scheduler weight coverage | code-quality-issue |
| #162456 | LOW | Scheduled dispatches can exceed the reported weight budget | false-invariant |
| #162457 | LOW | Retry placement is charged at maximum agenda occupancy | theoretical-attack-vector |
| #162458 | LOW | V3 scheduler cancellation traits bypass task-origin privilege checks | theoretical-attack-vector |
| #162460 | LOW | Metadata references do not retain their preimages | informational-monitoring |
| #162462 | LOW | Saturating preimage request counter loses reference accounting | theoretical-attack-vector |
| #162463 | LOW | Preimage submission weight omits runtime reserve costs | invalid-finding |
| #162464 | LOW | Preimage weights are benchmarked against the wrong deposit path | known-issue |
| #162465 | LOW | Preimage deposits charge blob count as bytes | negligible-economic-impact |
| #162466 | LOW | Failed ticket updates can release the existing reservation | theoretical-attack-vector |
| #162467 | LOW | Stale public block-hash retention constant conflicts with active config | code-quality-issue |
| #162468 | LOW | System calls use uncalibrated fallback weights | theoretical-attack-vector |
| #162470 | LOW | Runtime upgrade weight is not bounded by the block budget | theoretical-attack-vector |
| #162471 | LOW | Lifecycle hooks can bypass the block-weight limit | false-invariant |
| #162472 | LOW | Bound multi-block migration steps by the remaining block budget | needs-review |
| #162473 | LOW | Reset aggregate extrinsic length before pool validation | invalid-finding |
| #162474 | LOW | Weight schedule undercharges reclamation storage accesses | theoretical-attack-vector |
| #162475 | LOW | Reject extrinsic lengths that exceed `u32` accounting bounds | theoretical-attack-vector |
| #162476 | LOW | Authorized origin drops the original signer identity | intended-behavior |
| #162477 | LOW | Raw storage administration can bypass runtime upgrade controls | needs-review |
| #162478 | LOW | Make inactive migration configuration explicit | code-quality-issue |
| #162479 | LOW | Event counter overflow silently omits later events | theoretical-attack-vector |
| #162480 | LOW | Unbounded event topics can create underpriced proof growth | theoretical-attack-vector |
| #162481 | LOW | Make block-hash pruning boundary explicit and tested | code-quality-issue |
| #162482 | LOW | Public consumer increment bypasses the configured reference limit | false-invariant |
| #162483 | LOW | Omitted transaction extensions for weight reclaim and authorization | invalid-finding |
| #162484 | LOW | Under-declared execution weight escapes block-weight accounting | intended-behavior |
| #162485 | LOW | Configure multi-block migration handlers | code-quality-issue |
| #162486 | LOW | Prevent signing transactions for nonexistent accounts | user-operational-error |
| #162487 | LOW | Authorized dispatch bypasses original-origin restrictions | invalid-finding |
| #162489 | LOW | Pool-valid future nonces can invalidate block import | theoretical-attack-vector |
| #162490 | LOW | Pool validation correctly defers extension state changes | invalid-finding |
| #162491 | LOW | Offchain nonce counter wraps after exhaustion | invalid-finding |
| #162492 | LOW | Authorized transaction helper lacks active authorization pipeline | theoretical-attack-vector |
| #162493 | LOW | Block builder bypasses inherent ordering and inclusion checks | user-operational-error |
| #162494 | LOW | Validation relies on host rollback for block-state writes | user-operational-error |
| #162495 | LOW | Upgrade rehearsal failures panic instead of returning diagnostics | intended-behavior |
| #162496 | LOW | Make migration ordering dependencies explicit and tested | code-quality-issue |
| #162497 | LOW | Failed migrations can repeatedly halt runtime upgrades | invalid-finding |
| #162498 | LOW | Transaction validation accepts an unverified parent hash | external-dependency-behavior |
| #162499 | LOW | Non-None origins bypass the transaction authorization gate | false-invariant |
| #162500 | LOW | Failed alarm replacement can permanently stall referenda | theoretical-attack-vector |
| #162502 | LOW | Live membership changes can bias active referendum support | known-issue |
| #162504 | LOW | Referenda weights are unvalidated for the configured queue bound | invalid-finding |
| #162505 | LOW | Test feature can remove production governance delays | deployment-configuration-error |
| #162506 | LOW | Executive and migration configuration is correct | invalid-finding |
| #162507 | LOW | Runtime upgrade migration order is correctly configured | invalid-finding |
| #162508 | LOW | Transaction signature verification is consistently enforced | invalid-finding |
| #162509 | LOW | Runtime version and migration invariants are correctly implemented | invalid-finding |
| #162510 | LOW | Transaction extension ordering and payload binding are correct | invalid-finding |
| #162511 | LOW | Block resource limits match the documented policy | design-decision |
| #162512 | LOW | Extrinsics-root hashing and import validation are correctly aligned | invalid-finding |
| #162513 | LOW | Shared finalization preserves builder/import lifecycle consistency | invalid-finding |
| #162514 | LOW | Mandatory extrinsics are correctly excluded from pool validation | invalid-finding |
| #162515 | LOW | Expected transaction-extension re-export surface | invalid-finding |
| #162516 | LOW | Governance adapter wiring enforces the intended technical lane | invalid-finding |
| #162517 | LOW | Flat collective rank and membership policy is correctly enforced | invalid-finding |
| #162518 | LOW | Linear vote weighting correctly handles the configured rank | code-quality-issue |
| #162519 | LOW | Technical referendum path enforces Root proposal origins | invalid-finding |
| #162520 | LOW | Caller-supplied parent hash has no scoped validation effect | invalid-finding |
| #162521 | LOW | Block length lacks an aggregate cross-class cap | invalid-finding |
| #162522 | LOW | Nonce and transaction-authentication checks are correctly enforced | invalid-finding |
| #162525 | LOW | Reject zero-count retry configurations | user-operational-error |
| #162527 | LOW | Same-bucket retries are erased by agenda writeback | theoretical-attack-vector |
| #162528 | LOW | Enforce per-task scheduler overhead against the weight meter | invalid-finding |
| #162529 | LOW | Worst-case agenda weight gate prematurely defers scheduled tasks | needs-review |
| #162530 | LOW | Ignored ticket-drop failures can orphan provider deposits | theoretical-attack-vector |
| #162531 | LOW | Provider ticket lifecycle contradicts documented request semantics | code-quality-issue |
| #162532 | LOW | Emit an event when the final preimage request is released | informational-monitoring |
| #162533 | LOW | Do not report a preimage before byte storage succeeds | theoretical-attack-vector |
| #162535 | LOW | Remove stale preimage deposit configuration | code-quality-issue |
| #162536 | LOW | Correct stale multisig weight-limit documentation | code-quality-issue |
| #162537 | LOW | Align multisig inner-call cap with active block-weight policy | invalid-finding |
| #162538 | LOW | Unbounded event data enables unpriced proof growth and silent event loss | needs-review |
| #162539 | LOW | Runtime scheduler, pallet indices, and migrations are correctly configured | invalid-finding |
| #162543 | LOW | Authorization deletion relies on an external rollback boundary | invalid-finding |
| #162544 | LOW | Installer errors do not consume authorized upgrades | invalid-finding |
| #162545 | LOW | Report incomplete bounded prefix deletion | needs-review |
| #162547 | LOW | Unchecked code replacement can bypass upgrade reconciliation | intended-behavior |
| #162548 | LOW | Missing extrinsic entries are silently committed as empty data | theoretical-attack-vector |
| #162549 | LOW | Unchecked weight registration can exceed the block budget | trust-assumption |
| #162550 | LOW | Authorized-origin guard requires explicit use by protected calls | intended-behavior |
| #162551 | LOW | Stale ZK tree root can be committed to subsequent headers | invalid-finding |
| #162552 | LOW | Clear extrinsic data entries outside the finalized range | invalid-finding |
| #162553 | LOW | Provider underflow can trigger a spurious account-death lifecycle | false-invariant |
| #162554 | LOW | Sufficient-reference underflow can trigger invalid account reaping | theoretical-attack-vector |
| #162555 | LOW | Unmatched consumer decrements are only logged | code-quality-issue |
| #162556 | LOW | Sufficient decrement can reap accounts with active consumers | theoretical-attack-vector |
| #162557 | LOW | Rejected checked upgrades consume their authorization | intended-behavior |
| #162558 | LOW | Detect gaps and clear stale extrinsic data | code-quality-issue |
| #162559 | LOW | Nonce replay safeguards are correctly enforced | invalid-finding |
| #162560 | LOW | Inherent ordering and block-boundary checks are enforced | invalid-finding |
| #162561 | LOW | Unchecked hook weight can exceed the block budget | false-invariant |
| #162562 | LOW | Meter post-extrinsic hooks against the block-weight budget | false-invariant |
| #162563 | LOW | Validation admits transactions forbidden during migrations | theoretical-attack-vector |
| #162564 | LOW | Mandatory and ordinary dispatch failures are handled as intended | invalid-finding |
| #162565 | LOW | Validate parent hash before overwriting prior hash state | external-dependency-behavior |
| #162566 | LOW | Block flowchart misorders migration and post-transaction hooks | code-quality-issue |
| #162567 | LOW | Initialize current block state before runtime-upgrade hooks | informational-monitoring |
| #162568 | LOW | Mandatory initialization weight can exceed the block limit | design-decision |
| #162569 | LOW | Single-extrinsic cap omits base execution weight | false-invariant |
| #162573 | LOW | Make base genesis and technical-collective seeding atomic | user-operational-error |
| #162574 | LOW | Reconcile offchain signing nonces with chain inclusion | invalid-finding |
| #162576 | LOW | Signer enumeration permits duplicate keys and unstable indexes | code-quality-issue |
| #162577 | LOW | Report incompatible offchain key types instead of skipping them | invalid-finding |
| #162579 | LOW | Unsynchronized offchain nonce tracking stalls signed dispatches | known-issue |
| #162580 | LOW | Unsigned signed-payload submissions lack enforced replay protection | theoretical-attack-vector |
| #162581 | LOW | Authorization validation trusts an unenforced weight declaration | theoretical-attack-vector |
| #162582 | LOW | Reconcile authorization refunds with declared weight | invalid-finding |
| #162583 | LOW | Runtime surface documentation is stale | code-quality-issue |
| #162584 | LOW | Report the actual amount deducted when slashing deposits | informational-monitoring |
| #162585 | LOW | Zero-limit cleanup discards the continuation cursor | theoretical-attack-vector |
| #162586 | LOW | Prefix-removal migrations undercharge traversal weight | invalid-finding |
| #162587 | LOW | Migration permanently deletes invalid legacy preimages and locks deposits | theoretical-attack-vector |
| #162979 | LOW | Offchain signing helpers lack domain separation, enabling cross-context signature replay | theoretical-attack-vector |
