### PR TITLE
V12-ZK-Tree

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -114,6 +114,28 @@ pub struct FullDeps<C, P> {
 }
 
 /// Instantiate all full RPC extensions.
+///
+/// # RPC admission model
+///
+/// There is deliberately no module-level gate here: like upstream Substrate's
+/// node template, admission control is *per method*, enforced against the
+/// per-connection [`sc_rpc_api::DenyUnsafe`] policy that the substrate RPC
+/// server injects into request extensions (local connections and
+/// `--rpc-methods unsafe` get `No`; external connections under the default
+/// `auto` get `Yes`). Server-level limits (`--rpc-max-connections`,
+/// `--rpc-max-subscriptions-per-connection`, `--rpc-rate-limit`, CORS) apply
+/// on top.
+///
+/// Every method merged below must therefore be explicitly classified:
+///
+/// - **Unsafe** (discloses topology/identity or does privileged work): must
+///   call `sc_rpc_api::check_if_safe(ext)` before doing anything, like
+///   [`Peer::get_network_info`] and upstream `system_dryRun`.
+/// - **Safe** (public chain/mempool data, bounded per-request work): must have
+///   its request-driven resource use bounded, like the `zkTree_getMerkleProof`
+///   proof-window guard and `TxWatch`'s fixed-capacity broadcast fanout.
+///
+/// Do not merge a new module without classifying each of its methods this way.
 pub fn create_full<C, P>(
 	deps: FullDeps<C, P>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -38,12 +38,7 @@ pub struct NetworkInfo {
 /// Peer RPC API
 #[rpc(client, server)]
 pub trait PeerApi {
-	/// Get this node's network identity and topology (peer ID, connected peers,
-	/// external and listen addresses).
-	///
-	/// This is an *unsafe* RPC (like upstream `system_peers`/`system_unstable_networkState`):
-	/// it discloses the node's network topology, so it is only served to local connections
-	/// or when the node runs with `--rpc-methods unsafe`.
+	/// Network identity and topology. Unsafe: gated by `DenyUnsafe`.
 	#[method(name = "peer_getNetworkInfo", with_extensions)]
 	async fn get_network_info(&self) -> RpcResult<NetworkInfo>;
 }
@@ -64,8 +59,6 @@ impl Peer {
 #[async_trait]
 impl PeerApiServer for Peer {
 	async fn get_network_info(&self, ext: &jsonrpsee::Extensions) -> RpcResult<NetworkInfo> {
-		// Peer IDs and external/listen addresses enable network mapping and targeted
-		// eclipse/partition attempts; upstream only exposes them via unsafe-gated RPCs.
 		sc_rpc_api::check_if_safe(ext)?;
 
 		if let Some(network) = &self.network {
@@ -115,27 +108,12 @@ pub struct FullDeps<C, P> {
 
 /// Instantiate all full RPC extensions.
 ///
-/// # RPC admission model
-///
-/// There is deliberately no module-level gate here: like upstream Substrate's
-/// node template, admission control is *per method*, enforced against the
-/// per-connection [`sc_rpc_api::DenyUnsafe`] policy that the substrate RPC
-/// server injects into request extensions (local connections and
-/// `--rpc-methods unsafe` get `No`; external connections under the default
-/// `auto` get `Yes`). Server-level limits (`--rpc-max-connections`,
-/// `--rpc-max-subscriptions-per-connection`, `--rpc-rate-limit`, CORS) apply
-/// on top.
-///
-/// Every method merged below must therefore be explicitly classified:
-///
-/// - **Unsafe** (discloses topology/identity or does privileged work): must call
-///   `sc_rpc_api::check_if_safe(ext)` before doing anything, like [`Peer::get_network_info`] and
-///   upstream `system_dryRun`.
-/// - **Safe** (public chain/mempool data, bounded per-request work): must have its request-driven
-///   resource use bounded, like the `zkTree_getMerkleProof` proof-window guard and `TxWatch`'s
-///   fixed-capacity broadcast fanout.
-///
-/// Do not merge a new module without classifying each of its methods this way.
+/// Admission is per method against the per-connection [`sc_rpc_api::DenyUnsafe`]
+/// policy (not a module-level gate). Classify each merged method as:
+/// - **Unsafe**: call `sc_rpc_api::check_if_safe(ext)` first (e.g. [`Peer::get_network_info`],
+///   `system_dryRun`).
+/// - **Safe**: public data with bounded per-request work (e.g. zkTree proof-window guard, TxWatch's
+///   fixed broadcast capacity).
 pub fn create_full<C, P>(
 	deps: FullDeps<C, P>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
@@ -175,19 +153,12 @@ mod tests {
 	use jsonrpsee::MethodsError;
 	use sc_rpc_api::DenyUnsafe;
 
-	/// Call `peer_getNetworkInfo` on a `Peer` module with the given per-connection safety
-	/// policy, the way the substrate RPC server injects it for real connections.
 	async fn call_get_network_info(deny_unsafe: DenyUnsafe) -> Result<NetworkInfo, MethodsError> {
 		let mut module = Peer::new(None).into_rpc();
 		module.extensions_mut().insert(deny_unsafe);
 		module.call("peer_getNetworkInfo", jsonrpsee::rpc_params![]).await
 	}
 
-	/// `peer_getNetworkInfo` discloses the node's peer ID, connected peer IDs and
-	/// external/listen addresses -- the same network topology upstream Substrate only
-	/// serves through unsafe-gated RPCs (`system_peers`, `system_unstable_networkState`).
-	/// Untrusted callers (external connections under the default `--rpc-methods auto`)
-	/// must be rejected by the safety gate before the handler does anything.
 	#[tokio::test]
 	async fn get_network_info_is_denied_for_untrusted_callers() {
 		let err = call_get_network_info(DenyUnsafe::Yes).await.unwrap_err();
@@ -200,9 +171,6 @@ mod tests {
 		}
 	}
 
-	/// Trusted callers (local connections, or `--rpc-methods unsafe`) pass the gate and
-	/// reach the handler proper: without a network handle it reports that peer sharing
-	/// is disabled (code 5000) rather than an authorization error.
 	#[tokio::test]
 	async fn get_network_info_reaches_the_handler_for_trusted_callers() {
 		let err = call_get_network_info(DenyUnsafe::No).await.unwrap_err();

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -128,12 +128,12 @@ pub struct FullDeps<C, P> {
 ///
 /// Every method merged below must therefore be explicitly classified:
 ///
-/// - **Unsafe** (discloses topology/identity or does privileged work): must
-///   call `sc_rpc_api::check_if_safe(ext)` before doing anything, like
-///   [`Peer::get_network_info`] and upstream `system_dryRun`.
-/// - **Safe** (public chain/mempool data, bounded per-request work): must have
-///   its request-driven resource use bounded, like the `zkTree_getMerkleProof`
-///   proof-window guard and `TxWatch`'s fixed-capacity broadcast fanout.
+/// - **Unsafe** (discloses topology/identity or does privileged work): must call
+///   `sc_rpc_api::check_if_safe(ext)` before doing anything, like [`Peer::get_network_info`] and
+///   upstream `system_dryRun`.
+/// - **Safe** (public chain/mempool data, bounded per-request work): must have its request-driven
+///   resource use bounded, like the `zkTree_getMerkleProof` proof-window guard and `TxWatch`'s
+///   fixed-capacity broadcast fanout.
 ///
 /// Do not merge a new module without classifying each of its methods this way.
 pub fn create_full<C, P>(

--- a/pallets/mining-rewards/src/lib.rs
+++ b/pallets/mining-rewards/src/lib.rs
@@ -35,10 +35,7 @@ pub mod pallet {
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
-	/// Value awaiting distribution by `on_finalize`: transaction fees collected
-	/// during block execution, plus any reward whose mint failed on an earlier
-	/// finalize (see [`Pallet::mint_reward`]) and is being retried through the
-	/// normal fee-distribution path.
+	/// Fees and failed-mint retries awaiting distribution by `on_finalize`.
 	#[pallet::storage]
 	#[pallet::getter(fn collected_fees)]
 	pub(super) type CollectedFees<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
@@ -110,13 +107,7 @@ pub mod pallet {
 			/// The reward amount redirected to treasury
 			reward: BalanceOf<T>,
 		},
-		/// Treasury mint failed - reward was not issued this block.
-		///
-		/// This is a critical operational signal. If this event is observed, it indicates
-		/// either a misconfigured treasury account or a currency invariant violation.
-		/// The amount is rolled back into [`CollectedFees`] and redistributed by a
-		/// subsequent finalize (to that block's miner, or its treasury fallback), so it
-		/// is recovered once either can receive mints again.
+		/// Treasury mint failed; amount retained in [`CollectedFees`] for retry.
 		TreasuryMintFailed {
 			/// The reward amount that failed to mint
 			reward: BalanceOf<T>,
@@ -138,9 +129,6 @@ pub mod pallet {
 		fn on_finalize(_block_number: BlockNumberFor<T>) {
 			// Take collected fees first - needed for accurate supply calculation below.
 			// This also picks up any reward whose mint failed on an earlier finalize:
-			// `mint_reward`'s failure path rolls the amount back into `CollectedFees`,
-			// so it is retried here through the normal fee distribution instead of
-			// being dropped.
 			let tx_fees = <CollectedFees<T>>::take();
 
 			// Calculate dynamic block reward based on remaining supply.
@@ -310,11 +298,7 @@ pub mod pallet {
 			};
 		}
 
-		/// Retain a reward whose mint failed so a later `on_finalize` retries it,
-		/// instead of dropping it: roll it back into [`CollectedFees`], the bucket the
-		/// next finalize takes and redistributes (to that block's miner, falling back
-		/// to the treasury). No separate storage is needed; the amount simply rejoins
-		/// the value awaiting distribution, and consecutive failures accumulate.
+		/// Roll a failed mint back into [`CollectedFees`] for the next finalize.
 		fn retain_unminted(reward: BalanceOf<T>) {
 			<CollectedFees<T>>::mutate(|pending| {
 				*pending = pending.saturating_add(reward);

--- a/pallets/mining-rewards/src/lib.rs
+++ b/pallets/mining-rewards/src/lib.rs
@@ -35,6 +35,10 @@ pub mod pallet {
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
+	/// Value awaiting distribution by `on_finalize`: transaction fees collected
+	/// during block execution, plus any reward whose mint failed on an earlier
+	/// finalize (see [`Pallet::mint_reward`]) and is being retried through the
+	/// normal fee-distribution path.
 	#[pallet::storage]
 	#[pallet::getter(fn collected_fees)]
 	pub(super) type CollectedFees<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
@@ -106,11 +110,13 @@ pub mod pallet {
 			/// The reward amount redirected to treasury
 			reward: BalanceOf<T>,
 		},
-		/// Treasury mint failed - reward was not issued.
+		/// Treasury mint failed - reward was not issued this block.
 		///
 		/// This is a critical operational signal. If this event is observed, it indicates
 		/// either a misconfigured treasury account or a currency invariant violation.
-		/// The reward amount was permanently lost (not minted).
+		/// The amount is rolled back into [`CollectedFees`] and redistributed by a
+		/// subsequent finalize (to that block's miner, or its treasury fallback), so it
+		/// is recovered once either can receive mints again.
 		TreasuryMintFailed {
 			/// The reward amount that failed to mint
 			reward: BalanceOf<T>,
@@ -131,6 +137,10 @@ pub mod pallet {
 
 		fn on_finalize(_block_number: BlockNumberFor<T>) {
 			// Take collected fees first - needed for accurate supply calculation below.
+			// This also picks up any reward whose mint failed on an earlier finalize:
+			// `mint_reward`'s failure path rolls the amount back into `CollectedFees`,
+			// so it is retried here through the normal fee distribution instead of
+			// being dropped.
 			let tx_fees = <CollectedFees<T>>::take();
 
 			// Calculate dynamic block reward based on remaining supply.
@@ -138,6 +148,9 @@ pub mod pallet {
 			// (during transaction execution), so we add them back to get the true
 			// current supply before re-minting them to the miner. This prevents the
 			// block reward calculation from being slightly inflated by the burned fees.
+			// Retried unminted rewards inside `tx_fees` are likewise already-scheduled
+			// supply (they were budgeted from the remaining supply of their own block),
+			// so this line covers them too.
 			let max_supply = T::MaxSupply::get();
 			let current_supply = T::Currency::total_issuance().saturating_add(tx_fees);
 			let emission_divisor = T::EmissionDivisor::get();
@@ -262,9 +275,10 @@ pub mod pallet {
 								Err(e2) => {
 									log::error!(
 										target: "mining-rewards",
-										"Failed to redirect {:?} to treasury: {:?}",
+										"Failed to redirect {:?} to treasury: {:?}, retaining for retry",
 										reward, e2
 									);
+									Self::retain_unminted(reward);
 									Self::deposit_event(Event::TreasuryMintFailed { reward });
 								},
 							}
@@ -285,14 +299,26 @@ pub mod pallet {
 						Err(e) => {
 							log::error!(
 								target: "mining-rewards",
-								"Failed to mint {:?} to treasury: {:?}",
+								"Failed to mint {:?} to treasury: {:?}, retaining for retry",
 								reward, e
 							);
+							Self::retain_unminted(reward);
 							Self::deposit_event(Event::TreasuryMintFailed { reward });
 						},
 					}
 				},
 			};
+		}
+
+		/// Retain a reward whose mint failed so a later `on_finalize` retries it,
+		/// instead of dropping it: roll it back into [`CollectedFees`], the bucket the
+		/// next finalize takes and redistributes (to that block's miner, falling back
+		/// to the treasury). No separate storage is needed; the amount simply rejoins
+		/// the value awaiting distribution, and consecutive failures accumulate.
+		fn retain_unminted(reward: BalanceOf<T>) {
+			<CollectedFees<T>>::mutate(|pending| {
+				*pending = pending.saturating_add(reward);
+			});
 		}
 	}
 

--- a/pallets/mining-rewards/src/mock.rs
+++ b/pallets/mining-rewards/src/mock.rs
@@ -37,7 +37,9 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 189;
 	pub const MaxSupply: u128 = 21_000_000 * UNIT;
 	pub const EmissionDivisor: u128 = 15_163_560;
-	pub const ExistentialDeposit: Balance = 1;
+	/// `static` so individual tests can raise it (e.g. to make a treasury mint
+	/// fail below the ED) via `ExistentialDeposit::set`.
+	pub static ExistentialDeposit: Balance = 1;
 }
 
 impl frame_system::Config for Test {

--- a/pallets/mining-rewards/src/tests.rs
+++ b/pallets/mining-rewards/src/tests.rs
@@ -352,12 +352,7 @@ fn fees_go_to_treasury_when_no_miner() {
 	});
 }
 
-/// A treasury that temporarily cannot receive mints must not permanently lose
-/// that block's rewards. Transaction fees were already burned from fee payers
-/// during execution — on_finalize re-mints them — so a failed treasury mint
-/// that just emits TreasuryMintFailed and drops the amount destroys value that
-/// demonstrably existed. The failed amount must be retained in recoverable
-/// state and minted once the treasury can receive again.
+/// Failed treasury mints are retained in CollectedFees and recovered later.
 #[test]
 fn failed_treasury_mint_is_retained_and_recovered() {
 	new_test_ext().execute_with(|| {
@@ -407,8 +402,6 @@ fn failed_treasury_mint_is_retained_and_recovered() {
 	});
 }
 
-/// While the treasury outage persists, repeated finalizations must keep
-/// accumulating the failed amounts instead of overwriting or dropping them.
 #[test]
 fn unminted_rewards_accumulate_across_consecutive_outage_blocks() {
 	new_test_ext().execute_with(|| {
@@ -439,9 +432,6 @@ fn unminted_rewards_accumulate_across_consecutive_outage_blocks() {
 	});
 }
 
-/// A retried amount follows the normal fee destination: when the next block
-/// has a miner, the previously failed treasury-directed rewards are paid to
-/// that miner as fees rather than lingering or being force-directed anywhere.
 #[test]
 fn retried_rewards_follow_fee_destination_to_next_miner() {
 	new_test_ext().execute_with(|| {

--- a/pallets/mining-rewards/src/tests.rs
+++ b/pallets/mining-rewards/src/tests.rs
@@ -352,6 +352,120 @@ fn fees_go_to_treasury_when_no_miner() {
 	});
 }
 
+/// A treasury that temporarily cannot receive mints must not permanently lose
+/// that block's rewards. Transaction fees were already burned from fee payers
+/// during execution — on_finalize re-mints them — so a failed treasury mint
+/// that just emits TreasuryMintFailed and drops the amount destroys value that
+/// demonstrably existed. The failed amount must be retained in recoverable
+/// state and minted once the treasury can receive again.
+#[test]
+fn failed_treasury_mint_is_retained_and_recovered() {
+	new_test_ext().execute_with(|| {
+		let treasury_account = Treasury::account_id();
+		let balance_before = Balances::free_balance(&treasury_account);
+		let issuance_before = Balances::total_issuance();
+
+		// Fees burned from payers during block 1's execution, awaiting re-mint.
+		let tx_fees: Balance = 1_000 * Unit::get();
+		MiningRewards::collect_transaction_fees(tx_fees);
+
+		// No miner digest: fees, miner portion and treasury portion are all
+		// treasury-directed. Raise the ED so every one of those mints fails.
+		let total_reward_1 =
+			(MaxSupply::get() - (issuance_before + tx_fees)) / EmissionDivisor::get();
+		let lost = tx_fees + total_reward_1;
+		ExistentialDeposit::set(MaxSupply::get());
+		MiningRewards::on_finalize(1);
+
+		// The outage block minted nothing; the full amount was rolled back into
+		// CollectedFees, awaiting redistribution by the next finalize.
+		assert_eq!(Balances::free_balance(&treasury_account), balance_before);
+		assert_eq!(Balances::total_issuance(), issuance_before);
+		System::assert_has_event(Event::TreasuryMintFailed { reward: tx_fees }.into());
+		assert_eq!(
+			MiningRewards::collected_fees(),
+			lost,
+			"every failed mint must be retained for retry"
+		);
+
+		// The treasury becomes receivable again; the next finalize must recover
+		// the retained block-1 amounts (block 2's own emission comes on top).
+		ExistentialDeposit::set(1);
+		MiningRewards::on_finalize(2);
+
+		let gained = Balances::free_balance(&treasury_account) - balance_before;
+		assert!(
+			gained >= lost,
+			"a recoverable treasury outage must not lose that block's rewards: \
+			 gained {gained}, needed at least {lost}"
+		);
+		assert_eq!(
+			MiningRewards::collected_fees(),
+			0,
+			"recovered rewards must leave the retry bucket"
+		);
+	});
+}
+
+/// While the treasury outage persists, repeated finalizations must keep
+/// accumulating the failed amounts instead of overwriting or dropping them.
+#[test]
+fn unminted_rewards_accumulate_across_consecutive_outage_blocks() {
+	new_test_ext().execute_with(|| {
+		let treasury_account = Treasury::account_id();
+		let balance_before = Balances::free_balance(&treasury_account);
+
+		ExistentialDeposit::set(MaxSupply::get());
+
+		MiningRewards::on_finalize(1);
+		let retained_after_1 = MiningRewards::collected_fees();
+		assert!(retained_after_1 > 0, "outage block must retain its rewards");
+
+		MiningRewards::on_finalize(2);
+		let retained_after_2 = MiningRewards::collected_fees();
+		assert!(
+			retained_after_2 > retained_after_1,
+			"a second outage block must add its own rewards to the retained pool"
+		);
+
+		// Once the treasury recovers, the whole accumulated pool is minted.
+		ExistentialDeposit::set(1);
+		MiningRewards::on_finalize(3);
+		assert_eq!(MiningRewards::collected_fees(), 0);
+		assert!(
+			Balances::free_balance(&treasury_account) - balance_before >= retained_after_2,
+			"recovery must mint the entire accumulated pool"
+		);
+	});
+}
+
+/// A retried amount follows the normal fee destination: when the next block
+/// has a miner, the previously failed treasury-directed rewards are paid to
+/// that miner as fees rather than lingering or being force-directed anywhere.
+#[test]
+fn retried_rewards_follow_fee_destination_to_next_miner() {
+	new_test_ext().execute_with(|| {
+		// Block 1: no miner, treasury unreachable — everything is retained.
+		ExistentialDeposit::set(MaxSupply::get());
+		MiningRewards::on_finalize(1);
+		let retained = MiningRewards::collected_fees();
+		assert!(retained > 0);
+
+		// Block 2 has a miner and mints work again: the retained amount is
+		// distributed as that block's fees, i.e. to the miner.
+		ExistentialDeposit::set(1);
+		let miner_before = Balances::free_balance(MINER_1.account_id());
+		set_miner_preimage_digest(MINER_1.preimage());
+		MiningRewards::on_finalize(2);
+
+		assert_eq!(MiningRewards::collected_fees(), 0);
+		assert!(
+			Balances::free_balance(MINER_1.account_id()) >= miner_before + retained,
+			"retried rewards must reach the next block's miner via the fee path"
+		);
+	});
+}
+
 // =========================================================================
 // EQ-QNT-WORMHOLE-F-03: Tests for extract_author_from_digest edge cases
 // =========================================================================

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -62,60 +62,29 @@ pub trait WeightInfo {
 /// worst case.
 const MAX_LEAF_INSERTS: u64 = 3;
 
-/// Non-Zk-tree storage for the worst-case finalize path, split out from the
-/// leaf-insert cost so the latter can be priced at `MAX_TREE_DEPTH`.
+/// Non-tree storage for the worst-case finalize path.
 ///
-/// Once per finalize: `MiningRewards::CollectedFees` (r1 w1),
-/// `TreasuryPallet::TreasuryPortion` (r1), `TreasuryPallet::TreasuryAccount` (r1).
+/// Once per finalize: `CollectedFees` (r1 w1), `TreasuryPortion` (r1),
+/// `TreasuryAccount` (r1).
 ///
-/// Per reward transfer × [`MAX_LEAF_INSERTS`], priced independently with no
-/// cross-transfer storage dedup (same stance as the leaf inserts), at the
-/// worst-case redirect path — a failed miner mint (`System::Account` r1)
-/// falling back to a successful treasury mint (`System::Account` r1 w1),
-/// `Wormhole::TransferCount` (r1 w1), and the conditional
-/// `Wormhole::PotentialWormholeBalance` deposit add when the recipient is
-/// ambiguous (r1 w1): 4 reads, 3 writes. The all-mints-fail path (rolling the
-/// amount back into `CollectedFees` instead) costs strictly less and stays
-/// within this envelope. The shallow benchmark only observed two unique
-/// Account/TransferCount keys and predated both the potential-balance write
-/// and the failed-mint retention, so its measured base is not a complete
-/// bound.
+/// Per reward transfer × [`MAX_LEAF_INSERTS`], priced independently: failed miner
+/// mint (Account r1) → successful treasury mint (Account r1 w1) + `TransferCount`
+/// (r1 w1) + conditional `PotentialWormholeBalance` (r1 w1) = 4 reads, 3 writes.
 const BASE_READS: u64 = 15;
 const BASE_WRITES: u64 = 10;
 
-/// Conservative PoV bound per ZK-tree storage key touched during a leaf insert's
-/// path walk (same figure and justification as `pallet-wormhole`'s `TREE_KEY_POV`:
-/// tree entries are 32-byte hashes with small keys, and the comparable benchmarked
-/// `UsedNullifiers` map with 49-byte entries has an `added` figure of 2524 per key).
+/// PoV per ZK-tree path key (matches `pallet-wormhole`'s `TREE_KEY_POV`).
 const TREE_KEY_POV: u64 = 2600;
 
-/// Conservative PoV bound per non-tree key in the fixed base. The largest key in
-/// the base is `System::Account`, whose benchmarked `added` figure is 2603;
-/// rounded up to cover the smaller `TransferCount` / `CollectedFees` /
-/// `PotentialWormholeBalance` / treasury keys uniformly.
+/// PoV per fixed-base key (rounded up from `System::Account` MaxEncodedLen).
 const BASE_KEY_POV: u64 = 2700;
 
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	/// `on_finalize` mints up to three rewards, each recording a wormhole transfer
-	/// proof whose ZK-tree leaf insert walks the tree leaf-to-root, so its cost
-	/// grows with the tree depth *at finalize*. This weight is reserved in
-	/// `on_initialize`, before any extrinsics run, and the tree can grow by several
-	/// depths in between (a single public-batch exit bundle inserts hundreds of
-	/// leaves), so the start-of-block depth — even plus one — is not a bound on the
-	/// depth the hook will walk. Mandatory finalization cannot correct its consumed
-	/// weight afterwards, so the leaf inserts are priced at `MAX_TREE_DEPTH`, the
-	/// only provable upper bound.
-	///
-	/// Depth-sensitive costs are the tree reads/writes, the compute, AND the proof
-	/// size: `update_path` performs one Poseidon hash per tree level (so each
-	/// insert's `ref_time` grows with depth), and every sibling/path key it reads
-	/// must appear in the state proof (so PoV grows with depth too). The benchmark
-	/// ran against a fresh tree and cannot bound either, so the per-level hash cost
-	/// and a per-key PoV bound are charged on top, all at `MAX_TREE_DEPTH`. The
-	/// base PoV likewise prices every fixed-base key (`BASE_READS ×
-	/// BASE_KEY_POV`) rather than the shallow benchmark's two-transfer snapshot.
+	/// Reserved in `on_initialize` before extrinsics can grow the tree, so leaf
+	/// inserts are priced at `MAX_TREE_DEPTH`: DB ops, Poseidon hashing, and PoV
+	/// all scale with depth (`update_path` hashes and reads siblings per level).
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 161_000_000 picoseconds.
 		let (tree_reads, tree_writes) =
@@ -164,12 +133,7 @@ impl WeightInfo for () {
 mod tests {
 	use super::*;
 
-	/// The finalize cost the hook actually incurs when the tree sits at `depth`
-	/// while it runs: the benchmarked base plus three leaf inserts at that depth —
-	/// their database operations, their per-level Poseidon hashing (`update_path`
-	/// hashes once per tree level), AND their proof size: every key the path walk
-	/// reads must appear in the state proof, so PoV grows with depth exactly like
-	/// the read count does.
+	/// Finalize cost at a given tree depth (DB ops + hashing + PoV).
 	fn finalize_cost_at_depth(depth: u8) -> Weight {
 		let (tree_reads, tree_writes) = pallet_zk_tree::insert_leaf_db_ops_at_depth(depth);
 		let hash_time = MAX_LEAF_INSERTS
@@ -186,17 +150,9 @@ mod tests {
 			))
 	}
 
-	/// Regression test for the stale-depth hole: the weight is reserved in
-	/// `on_initialize` (shallow tree), but intervening extrinsics can grow the tree
-	/// by any number of depths before `on_finalize` walks it — a single public-batch
-	/// exit bundle alone inserts hundreds of leaves. The reserved weight must
-	/// therefore cover the finalize cost at *every* depth the tree can reach by
-	/// end of block, up to the hard `MAX_TREE_DEPTH` cap, not just the
-	/// start-of-block depth plus one.
+	/// Reserved weight must cover finalize at every reachable end-of-block depth.
 	#[test]
 	fn reserved_weight_covers_any_end_of_block_depth() {
-		// The reservation is depth-independent (it never reads the live tree), so
-		// what it returns at the shallow start-of-block state is what the block got.
 		let reserved = <() as WeightInfo>::on_finalize_rewarded_miner();
 
 		for end_depth in 0..=pallet_zk_tree::MAX_TREE_DEPTH {
@@ -208,30 +164,13 @@ mod tests {
 		}
 	}
 
-	/// The weight must price its leaf inserts at `MAX_TREE_DEPTH`: it is the only
-	/// upper bound on the tree depth at finalize that holds regardless of what runs
-	/// earlier in the block. (`SubstrateWeight` is the identical formula with the
-	/// runtime's configured `DbWeight`; the mock's zero `DbWeight` makes asserting
-	/// on it vacuous, so only the RocksDb fallback is pinned here.)
 	#[test]
 	fn weight_is_priced_at_max_tree_depth() {
 		let expected = finalize_cost_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		assert_eq!(<() as WeightInfo>::on_finalize_rewarded_miner(), expected);
 	}
 
-	/// Regression for the incomplete fixed base: `on_finalize` can successfully
-	/// `mint_into` + `record_transfer_proof` three times (fees, miner reward,
-	/// treasury), and each native `record_transfer` may also mutate
-	/// `PotentialWormholeBalance` for an ambiguous recipient. The reserved base
-	/// must price those non-tree ops independently for all three transfers — the
-	/// same no-dedup stance as `MAX_LEAF_INSERTS` — not the two-account snapshot
-	/// the shallow benchmark happened to observe.
-	/// Regression for the stale PoV bound: reads and compute were repriced at
-	/// `MAX_TREE_DEPTH`, but the proof-size component stayed at the shallow
-	/// benchmark's constant. Every sibling/path key the three inserts read at
-	/// depth must appear in the state proof, and the expanded fixed base (third
-	/// account/transfer pair, `PotentialWormholeBalance`) needs proof bytes too —
-	/// so the declared PoV must scale with tree reads and cover every base key.
+	/// PoV must grow with tree depth and cover every base + path key at max depth.
 	#[test]
 	fn proof_size_scales_with_depth_and_covers_base_keys() {
 		let shallow = finalize_cost_at_depth(1);

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -73,9 +73,6 @@ const MAX_LEAF_INSERTS: u64 = 3;
 const BASE_READS: u64 = 15;
 const BASE_WRITES: u64 = 10;
 
-/// PoV per ZK-tree path key (matches `pallet-wormhole`'s `TREE_KEY_POV`).
-const TREE_KEY_POV: u64 = 2600;
-
 /// PoV per fixed-base key (rounded up from `System::Account` MaxEncodedLen).
 const BASE_KEY_POV: u64 = 2700;
 
@@ -93,7 +90,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
 		);
 		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
-			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+			MAX_LEAF_INSERTS
+				.saturating_mul(tree_reads)
+				.saturating_mul(pallet_zk_tree::TREE_KEY_POV),
 		);
 		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(T::DbWeight::get().reads(
@@ -117,7 +116,9 @@ impl WeightInfo for () {
 			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
 		);
 		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
-			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+			MAX_LEAF_INSERTS
+				.saturating_mul(tree_reads)
+				.saturating_mul(pallet_zk_tree::TREE_KEY_POV),
 		);
 		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(RocksDbWeight::get().reads(
@@ -139,7 +140,9 @@ mod tests {
 		let hash_time = MAX_LEAF_INSERTS
 			.saturating_mul(pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(depth));
 		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
-			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+			MAX_LEAF_INSERTS
+				.saturating_mul(tree_reads)
+				.saturating_mul(pallet_zk_tree::TREE_KEY_POV),
 		);
 		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(RocksDbWeight::get().reads(
@@ -186,7 +189,7 @@ mod tests {
 		assert!(
 			reserved.proof_size() >=
 				BASE_READS * BASE_KEY_POV +
-					MAX_LEAF_INSERTS * tree_reads * TREE_KEY_POV,
+					MAX_LEAF_INSERTS * tree_reads * pallet_zk_tree::TREE_KEY_POV,
 			"reserved PoV must cover every base key plus all tree path keys at MAX_TREE_DEPTH"
 		);
 	}

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -83,6 +83,18 @@ const MAX_LEAF_INSERTS: u64 = 3;
 const BASE_READS: u64 = 15;
 const BASE_WRITES: u64 = 10;
 
+/// Conservative PoV bound per ZK-tree storage key touched during a leaf insert's
+/// path walk (same figure and justification as `pallet-wormhole`'s `TREE_KEY_POV`:
+/// tree entries are 32-byte hashes with small keys, and the comparable benchmarked
+/// `UsedNullifiers` map with 49-byte entries has an `added` figure of 2524 per key).
+const TREE_KEY_POV: u64 = 2600;
+
+/// Conservative PoV bound per non-tree key in the fixed base. The largest key in
+/// the base is `System::Account`, whose benchmarked `added` figure is 2603;
+/// rounded up to cover the smaller `TransferCount` / `CollectedFees` /
+/// `PotentialWormholeBalance` / treasury keys uniformly.
+const BASE_KEY_POV: u64 = 2700;
+
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
@@ -96,12 +108,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// weight afterwards, so the leaf inserts are priced at `MAX_TREE_DEPTH`, the
 	/// only provable upper bound.
 	///
-	/// Depth-sensitive costs are BOTH the tree reads/writes and the compute:
-	/// `update_path` performs one Poseidon hash per tree level, so each insert's
-	/// `ref_time` grows with depth too. The benchmark ran against a fresh tree and
-	/// its measured base cannot bound deep-tree hashing, so the per-level hash
-	/// cost is added on top, also at `MAX_TREE_DEPTH`. The proof size stays at the
-	/// benchmarked value.
+	/// Depth-sensitive costs are the tree reads/writes, the compute, AND the proof
+	/// size: `update_path` performs one Poseidon hash per tree level (so each
+	/// insert's `ref_time` grows with depth), and every sibling/path key it reads
+	/// must appear in the state proof (so PoV grows with depth too). The benchmark
+	/// ran against a fresh tree and cannot bound either, so the per-level hash cost
+	/// and a per-key PoV bound are charged on top, all at `MAX_TREE_DEPTH`. The
+	/// base PoV likewise prices every fixed-base key (`BASE_READS ×
+	/// BASE_KEY_POV`) rather than the shallow benchmark's two-transfer snapshot.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 161_000_000 picoseconds.
 		let (tree_reads, tree_writes) =
@@ -109,7 +123,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		let hash_time = MAX_LEAF_INSERTS.saturating_mul(
 			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
 		);
-		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
+		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
+			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+		);
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(T::DbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
@@ -130,7 +147,10 @@ impl WeightInfo for () {
 		let hash_time = MAX_LEAF_INSERTS.saturating_mul(
 			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
 		);
-		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
+		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
+			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+		);
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(RocksDbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
@@ -146,14 +166,18 @@ mod tests {
 
 	/// The finalize cost the hook actually incurs when the tree sits at `depth`
 	/// while it runs: the benchmarked base plus three leaf inserts at that depth —
-	/// both their database operations AND their per-level Poseidon hashing, which
-	/// `update_path` performs once per tree level and therefore also grows with
-	/// depth.
+	/// their database operations, their per-level Poseidon hashing (`update_path`
+	/// hashes once per tree level), AND their proof size: every key the path walk
+	/// reads must appear in the state proof, so PoV grows with depth exactly like
+	/// the read count does.
 	fn finalize_cost_at_depth(depth: u8) -> Weight {
 		let (tree_reads, tree_writes) = pallet_zk_tree::insert_leaf_db_ops_at_depth(depth);
 		let hash_time = MAX_LEAF_INSERTS
 			.saturating_mul(pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(depth));
-		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
+		let proof_size = BASE_READS.saturating_mul(BASE_KEY_POV).saturating_add(
+			MAX_LEAF_INSERTS.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV),
+		);
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), proof_size)
 			.saturating_add(RocksDbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
@@ -202,6 +226,32 @@ mod tests {
 	/// must price those non-tree ops independently for all three transfers — the
 	/// same no-dedup stance as `MAX_LEAF_INSERTS` — not the two-account snapshot
 	/// the shallow benchmark happened to observe.
+	/// Regression for the stale PoV bound: reads and compute were repriced at
+	/// `MAX_TREE_DEPTH`, but the proof-size component stayed at the shallow
+	/// benchmark's constant. Every sibling/path key the three inserts read at
+	/// depth must appear in the state proof, and the expanded fixed base (third
+	/// account/transfer pair, `PotentialWormholeBalance`) needs proof bytes too —
+	/// so the declared PoV must scale with tree reads and cover every base key.
+	#[test]
+	fn proof_size_scales_with_depth_and_covers_base_keys() {
+		let shallow = finalize_cost_at_depth(1);
+		let deep = finalize_cost_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		assert!(
+			deep.proof_size() > shallow.proof_size(),
+			"finalize PoV must grow with tree depth"
+		);
+
+		let reserved = <() as WeightInfo>::on_finalize_rewarded_miner();
+		let (tree_reads, _) =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+		assert!(
+			reserved.proof_size() >=
+				BASE_READS * BASE_KEY_POV +
+					MAX_LEAF_INSERTS * tree_reads * TREE_KEY_POV,
+			"reserved PoV must cover every base key plus all tree path keys at MAX_TREE_DEPTH"
+		);
+	}
+
 	#[test]
 	fn base_covers_three_reward_transfers_including_potential_balance() {
 		// Once per finalize (outside the per-transfer mint/record path).

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -68,14 +68,19 @@ const MAX_LEAF_INSERTS: u64 = 3;
 /// Once per finalize: `MiningRewards::CollectedFees` (r1 w1),
 /// `TreasuryPallet::TreasuryPortion` (r1), `TreasuryPallet::TreasuryAccount` (r1).
 ///
-/// Per successful reward transfer × [`MAX_LEAF_INSERTS`], priced independently
-/// with no cross-transfer storage dedup (same stance as the leaf inserts):
-/// `System::Account` mint (r1 w1), `Wormhole::TransferCount` (r1 w1), and the
-/// conditional `Wormhole::PotentialWormholeBalance` deposit add when the
-/// recipient is ambiguous (r1 w1). The shallow benchmark only observed two
-/// unique Account/TransferCount keys and predated the potential-balance write,
-/// so its measured base is not a complete bound.
-const BASE_READS: u64 = 12;
+/// Per reward transfer × [`MAX_LEAF_INSERTS`], priced independently with no
+/// cross-transfer storage dedup (same stance as the leaf inserts), at the
+/// worst-case redirect path — a failed miner mint (`System::Account` r1)
+/// falling back to a successful treasury mint (`System::Account` r1 w1),
+/// `Wormhole::TransferCount` (r1 w1), and the conditional
+/// `Wormhole::PotentialWormholeBalance` deposit add when the recipient is
+/// ambiguous (r1 w1): 4 reads, 3 writes. The all-mints-fail path (rolling the
+/// amount back into `CollectedFees` instead) costs strictly less and stays
+/// within this envelope. The shallow benchmark only observed two unique
+/// Account/TransferCount keys and predated both the potential-balance write
+/// and the failed-mint retention, so its measured base is not a complete
+/// bound.
+const BASE_READS: u64 = 15;
 const BASE_WRITES: u64 = 10;
 
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
@@ -200,13 +205,15 @@ mod tests {
 	#[test]
 	fn base_covers_three_reward_transfers_including_potential_balance() {
 		// Once per finalize (outside the per-transfer mint/record path).
-		const FIXED_READS: u64 = 3; // CollectedFees + TreasuryPortion + TreasuryAccount
-		const FIXED_WRITES: u64 = 1; // CollectedFees
+		// CollectedFees (r1 w1) + TreasuryPortion (r1) + TreasuryAccount (r1).
+		const FIXED_READS: u64 = 3;
+		const FIXED_WRITES: u64 = 1;
 
-		// Per successful reward transfer, priced independently:
-		// System::Account mint (r1 w1) + TransferCount (r1 w1) +
-		// conditional PotentialWormholeBalance deposit add (r1 w1).
-		const PER_TRANSFER_READS: u64 = 3;
+		// Per reward transfer, priced independently at the worst-case redirect
+		// path: failed miner Account mint (r1) + successful treasury Account
+		// mint (r1 w1) + TransferCount (r1 w1) + conditional
+		// PotentialWormholeBalance deposit add (r1 w1).
+		const PER_TRANSFER_READS: u64 = 4;
 		const PER_TRANSFER_WRITES: u64 = 3;
 
 		let expected_reads =

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -62,13 +62,21 @@ pub trait WeightInfo {
 /// worst case.
 const MAX_LEAF_INSERTS: u64 = 3;
 
-/// Non-Zk-tree storage measured by the benchmark, split out from the leaf-insert
-/// cost so the latter can be priced at the live tree depth. Covers
-/// `MiningRewards::CollectedFees` (r1 w1), `TreasuryPallet::TreasuryPortion`
-/// (r1), `TreasuryPallet::TreasuryAccount` (r1), `System::Account` (r2 w2) and
-/// `Wormhole::TransferCount` (r2 w2).
-const BASE_READS: u64 = 7;
-const BASE_WRITES: u64 = 5;
+/// Non-Zk-tree storage for the worst-case finalize path, split out from the
+/// leaf-insert cost so the latter can be priced at `MAX_TREE_DEPTH`.
+///
+/// Once per finalize: `MiningRewards::CollectedFees` (r1 w1),
+/// `TreasuryPallet::TreasuryPortion` (r1), `TreasuryPallet::TreasuryAccount` (r1).
+///
+/// Per successful reward transfer × [`MAX_LEAF_INSERTS`], priced independently
+/// with no cross-transfer storage dedup (same stance as the leaf inserts):
+/// `System::Account` mint (r1 w1), `Wormhole::TransferCount` (r1 w1), and the
+/// conditional `Wormhole::PotentialWormholeBalance` deposit add when the
+/// recipient is ambiguous (r1 w1). The shallow benchmark only observed two
+/// unique Account/TransferCount keys and predated the potential-balance write,
+/// so its measured base is not a complete bound.
+const BASE_READS: u64 = 12;
+const BASE_WRITES: u64 = 10;
 
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
@@ -163,5 +171,39 @@ mod tests {
 	fn weight_is_priced_at_max_tree_depth() {
 		let expected = finalize_cost_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		assert_eq!(<() as WeightInfo>::on_finalize_rewarded_miner(), expected);
+	}
+
+	/// Regression for the incomplete fixed base: `on_finalize` can successfully
+	/// `mint_into` + `record_transfer_proof` three times (fees, miner reward,
+	/// treasury), and each native `record_transfer` may also mutate
+	/// `PotentialWormholeBalance` for an ambiguous recipient. The reserved base
+	/// must price those non-tree ops independently for all three transfers — the
+	/// same no-dedup stance as `MAX_LEAF_INSERTS` — not the two-account snapshot
+	/// the shallow benchmark happened to observe.
+	#[test]
+	fn base_covers_three_reward_transfers_including_potential_balance() {
+		// Once per finalize (outside the per-transfer mint/record path).
+		const FIXED_READS: u64 = 3; // CollectedFees + TreasuryPortion + TreasuryAccount
+		const FIXED_WRITES: u64 = 1; // CollectedFees
+
+		// Per successful reward transfer, priced independently:
+		// System::Account mint (r1 w1) + TransferCount (r1 w1) +
+		// conditional PotentialWormholeBalance deposit add (r1 w1).
+		const PER_TRANSFER_READS: u64 = 3;
+		const PER_TRANSFER_WRITES: u64 = 3;
+
+		let expected_reads =
+			FIXED_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(PER_TRANSFER_READS));
+		let expected_writes =
+			FIXED_WRITES.saturating_add(MAX_LEAF_INSERTS.saturating_mul(PER_TRANSFER_WRITES));
+
+		assert_eq!(
+			BASE_READS, expected_reads,
+			"BASE_READS must cover fixed overhead plus three mint/TransferCount/PotentialWormholeBalance reads"
+		);
+		assert_eq!(
+			BASE_WRITES, expected_writes,
+			"BASE_WRITES must cover fixed overhead plus three mint/TransferCount/PotentialWormholeBalance writes"
+		);
 	}
 }

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -89,13 +89,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// leaves), so the start-of-block depth — even plus one — is not a bound on the
 	/// depth the hook will walk. Mandatory finalization cannot correct its consumed
 	/// weight afterwards, so the leaf inserts are priced at `MAX_TREE_DEPTH`, the
-	/// only provable upper bound. The compute time and proof size stay at the
-	/// benchmarked values; the depth-sensitive cost is the tree reads/writes.
+	/// only provable upper bound.
+	///
+	/// Depth-sensitive costs are BOTH the tree reads/writes and the compute:
+	/// `update_path` performs one Poseidon hash per tree level, so each insert's
+	/// `ref_time` grows with depth too. The benchmark ran against a fresh tree and
+	/// its measured base cannot bound deep-tree hashing, so the per-level hash
+	/// cost is added on top, also at `MAX_TREE_DEPTH`. The proof size stays at the
+	/// benchmarked value.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 161_000_000 picoseconds.
 		let (tree_reads, tree_writes) =
 			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
-		Weight::from_parts(163_000_000, 8619)
+		let hash_time = MAX_LEAF_INSERTS.saturating_mul(
+			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
+		);
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
 			.saturating_add(T::DbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
@@ -113,7 +122,10 @@ impl WeightInfo for () {
 		// Minimum execution time: 161_000_000 picoseconds.
 		let (tree_reads, tree_writes) =
 			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
-		Weight::from_parts(163_000_000, 8619)
+		let hash_time = MAX_LEAF_INSERTS.saturating_mul(
+			pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(pallet_zk_tree::MAX_TREE_DEPTH),
+		);
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
 			.saturating_add(RocksDbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))
@@ -128,10 +140,15 @@ mod tests {
 	use super::*;
 
 	/// The finalize cost the hook actually incurs when the tree sits at `depth`
-	/// while it runs: the benchmarked base plus three leaf inserts at that depth.
+	/// while it runs: the benchmarked base plus three leaf inserts at that depth —
+	/// both their database operations AND their per-level Poseidon hashing, which
+	/// `update_path` performs once per tree level and therefore also grows with
+	/// depth.
 	fn finalize_cost_at_depth(depth: u8) -> Weight {
 		let (tree_reads, tree_writes) = pallet_zk_tree::insert_leaf_db_ops_at_depth(depth);
-		Weight::from_parts(163_000_000, 8619)
+		let hash_time = MAX_LEAF_INSERTS
+			.saturating_mul(pallet_zk_tree::insert_leaf_hash_ref_time_at_depth(depth));
+		Weight::from_parts(163_000_000_u64.saturating_add(hash_time), 8619)
 			.saturating_add(RocksDbWeight::get().reads(
 				BASE_READS.saturating_add(MAX_LEAF_INSERTS.saturating_mul(tree_reads)),
 			))

--- a/pallets/reversible-transfers/src/weights.rs
+++ b/pallets/reversible-transfers/src/weights.rs
@@ -63,23 +63,17 @@ pub trait WeightInfo {
 const EXECUTE_TRANSFER_BASE_READS: u64 = 5;
 const EXECUTE_TRANSFER_BASE_WRITES: u64 = 5;
 
-/// Conservative PoV bound per ZK-tree storage key touched during a path update.
-/// Same figure as `pallet-wormhole`'s weights: tree entries are 32-byte hashes with
-/// small keys, comparable to the benchmarked `ZkTree::Leaves` `added` figure of 2543.
-const TREE_KEY_POV: u64 = 2600;
-
 /// `execute_transfer`'s weight: the benchmarked base (compute + non-tree storage)
 /// plus the depth-dependent ZK-tree leaf insert performed by the wormhole proof
-/// recorder. `insert_leaf` walks the tree leaf-to-root (`pallet_zk_tree::update_path`
-/// reads 3 sibling `Nodes` per level and writes one internal node per level), so the
-/// DB ops and PoV must scale with `tree_ops` rather than stay flat — otherwise
-/// deep-tree executions do far more storage I/O than the block weight model charges.
-/// The shallow tree component embedded in the benchmarked base is deliberately not
-/// deducted (over-charging is the safe direction).
+/// recorder. `insert_leaf` walks the tree leaf-to-root, so DB ops and PoV scale
+/// with `tree_ops` via [`pallet_zk_tree::TREE_KEY_POV`].
 fn execute_transfer_weight(db: RuntimeDbWeight, (tree_reads, tree_writes): (u64, u64)) -> Weight {
 	// Minimum execution time: 105_000_000 picoseconds.
 	Weight::from_parts(110_000_000, 8619)
-		.saturating_add(Weight::from_parts(0, tree_reads.saturating_mul(TREE_KEY_POV)))
+		.saturating_add(Weight::from_parts(
+			0,
+			tree_reads.saturating_mul(pallet_zk_tree::TREE_KEY_POV),
+		))
 		.saturating_add(db.reads(EXECUTE_TRANSFER_BASE_READS.saturating_add(tree_reads)))
 		.saturating_add(db.writes(EXECUTE_TRANSFER_BASE_WRITES.saturating_add(tree_writes)))
 }

--- a/pallets/wormhole/src/bench_fixtures.rs
+++ b/pallets/wormhole/src/bench_fixtures.rs
@@ -1,0 +1,52 @@
+//! Shared pre-validation fixtures for benchmarks and the timing harness.
+//!
+//! Kept in one place so the runtime-benchmarks path and the ignored calibration
+//! test cannot drift to different worst-case inputs.
+
+use crate::{circuit_config, Config, ExitBundle, ExitSegment, UsedNullifiers};
+use frame_support::traits::Get;
+use qp_wormhole_verifier::{BlockData, BytesDigest, PublicInputsByAccount};
+
+/// Populate `UsedNullifiers` with decoys; fixture nullifiers stay absent so every
+/// segment remains valid and the full scan/dedup/claimed-set path runs.
+pub fn insert_decoy_nullifiers<T: Config>(count: u32) {
+	for i in 0..count {
+		let mut nullifier = [0xFFu8; 32];
+		nullifier[0..4].copy_from_slice(&i.to_le_bytes());
+		UsedNullifiers::<T>::insert(nullifier, true);
+	}
+}
+
+/// All-valid exit bundle: every segment non-inert with distinct unused
+/// nullifiers (disjoint from decoy keys). Needed because proof fixtures use
+/// dummy padding that `segment_validity` skips as inert.
+pub fn worst_case_bundle<T: Config>(block_data: BlockData, num_segments: usize) -> ExitBundle {
+	let slots_per_segment = circuit_config::NUM_LEAF_PROOFS * 2;
+	let mut counter: u32 = 0;
+	let segments = (0..num_segments)
+		.map(|_| {
+			let nullifiers = (0..circuit_config::NUM_LEAF_PROOFS)
+				.map(|_| {
+					counter += 1;
+					let mut bytes = [0xABu8; 32];
+					bytes[0..4].copy_from_slice(&counter.to_le_bytes());
+					BytesDigest::new_unchecked(bytes)
+				})
+				.collect();
+			let account_data = (0..slots_per_segment)
+				.map(|_| PublicInputsByAccount {
+					summed_output_amount: 1,
+					exit_account: BytesDigest::new_unchecked([0xCDu8; 32]),
+				})
+				.collect();
+			ExitSegment { account_data, nullifiers }
+		})
+		.collect();
+	ExitBundle {
+		asset_id: 0,
+		volume_fee_bps: T::VolumeFeeRateBps::get(),
+		block_data,
+		aggregator_address: None,
+		segments,
+	}
+}

--- a/pallets/wormhole/src/benchmarking.rs
+++ b/pallets/wormhole/src/benchmarking.rs
@@ -31,63 +31,73 @@ const D: usize = 2;
 #[benchmarks]
 mod benchmarks {
 	use super::*;
+	use frame_system::pallet_prelude::BlockNumberFor;
+	use qp_wormhole_verifier::{
+		parse_private_batch_public_inputs, parse_public_batch_public_inputs,
+	};
 
-	/// Benchmark for the pre-validation phase of verify_private_batch.
-	///
-	/// This measures the actual cost of:
-	/// - Proof deserialization (using a real private-batch proof)
-	/// - Public inputs parsing
-	/// - Block hash lookup (1 read)
-	/// - Nullifier existence checks (up to MAX_NULLIFIERS reads)
-	#[benchmark]
-	fn pre_validate_proof() {
-		// Decode the hex proof to bytes
-		let proof_bytes: Vec<u8> =
-			hex::decode(PRIVATE_BATCH_PROOF_HEX.trim()).expect("Invalid hex in test proof");
+	/// Insert `block_data`'s referenced block hash into `frame_system::BlockHash` so
+	/// the production pre-validation's block check passes for the fixture proof.
+	fn insert_fixture_block_hash<T: Config>(block_data: &qp_wormhole_verifier::BlockData) {
+		let mut hash = <T as frame_system::Config>::Hash::default();
+		hash.as_mut().copy_from_slice(block_data.block_hash.as_ref());
+		frame_system::BlockHash::<T>::insert(
+			BlockNumberFor::<T>::from(block_data.block_number),
+			hash,
+		);
+	}
 
-		// Get verifier for deserialization
-		let verifier =
-			crate::get_private_batch_verifier().expect("Private-batch verifier not available");
-
-		// Setup: Create nullifiers in storage to simulate worst-case reads
-		let nullifiers: Vec<[u8; 32]> = (0..MAX_NULLIFIERS)
-			.map(|i| {
-				let mut nullifier = [0u8; 32];
-				nullifier[0..4].copy_from_slice(&i.to_le_bytes());
-				nullifier
-			})
-			.collect();
-
-		// Insert nullifiers into storage (these are "other" nullifiers, not the ones we're
-		// checking) This populates the storage map to make reads realistic
-		for nullifier in &nullifiers {
+	/// Populate `UsedNullifiers` with decoy entries so the production nullifier scan
+	/// reads a realistically populated map. The fixture's own nullifiers stay absent:
+	/// that is the worst case (every segment stays valid, so the scan, the
+	/// intra-segment dedup and the cross-segment claimed-set all run to completion).
+	fn insert_decoy_nullifiers<T: Config>(count: u32) {
+		for i in 0..count {
+			let mut nullifier = [0xFFu8; 32];
+			nullifier[0..4].copy_from_slice(&i.to_le_bytes());
 			pallet::UsedNullifiers::<T>::insert(nullifier, true);
-		}
-
-		// Setup a block hash so the lookup succeeds
-		let block_number = frame_system::Pallet::<T>::block_number();
-
-		#[block]
-		{
-			// 1. Deserialize proof (the expensive part)
-			let _proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
-				proof_bytes.clone(),
-				&verifier.circuit_data.common,
-			)
-			.expect("Failed to deserialize proof");
-
-			// 2. Block hash lookup
-			let _block_hash = frame_system::Pallet::<T>::block_hash(block_number);
-
-			// 3. Nullifier existence checks (worst case: all checks performed)
-			for nullifier in &nullifiers {
-				let _exists = pallet::UsedNullifiers::<T>::contains_key(nullifier);
-			}
 		}
 	}
 
-	/// Pre-validation for the public-batch path: deserialize + scan every nullifier
-	/// slot across all inner private-batch segments.
+	/// Benchmark for the pre-validation phase of verify_private_batch.
+	///
+	/// Executes the *production* `pre_validate_private_batch_proof` path end to end:
+	/// proof deserialization, public-input parsing, `ExitBundle` construction, and
+	/// `validate_exit_bundle_common` (block-hash check, per-segment nullifier
+	/// normalization + intra-segment dedup + cross-segment collision checks +
+	/// used-nullifier reads, and `ensure_any_segment_valid`). Measuring anything
+	/// less understates the CPU cost this weight is charged for — twice — on the
+	/// inclusion path.
+	#[benchmark]
+	fn pre_validate_proof() {
+		let proof_bytes: Vec<u8> =
+			hex::decode(PRIVATE_BATCH_PROOF_HEX.trim()).expect("Invalid hex in test proof");
+
+		// Parse the fixture (setup only) to learn which block hash it commits to.
+		let verifier =
+			crate::get_private_batch_verifier().expect("Private-batch verifier not available");
+		let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
+			proof_bytes.clone(),
+			&verifier.circuit_data.common,
+		)
+		.expect("Failed to deserialize proof");
+		let inputs = parse_private_batch_public_inputs(&proof).expect("Failed to parse inputs");
+
+		insert_fixture_block_hash::<T>(&inputs.block_data);
+		insert_decoy_nullifiers::<T>(MAX_NULLIFIERS);
+
+		#[block]
+		{
+			let result = Pallet::<T>::pre_validate_private_batch_proof(&proof_bytes);
+			assert!(result.is_ok(), "production pre-validation must succeed");
+		}
+	}
+
+	/// Pre-validation for the public-batch path. Executes the *production*
+	/// `pre_validate_public_batch_proof` end to end: deserialization, public-input
+	/// parsing, `ExitBundle::from_public_batch` segment construction across all
+	/// `NUM_PRIVATE_BATCH_PROOFS` inner segments, and `validate_exit_bundle_common`
+	/// with the full nullifier scan / dedup / collision checks.
 	#[benchmark]
 	fn pre_validate_public_batch_proof() {
 		let proof_bytes: Vec<u8> =
@@ -95,34 +105,25 @@ mod benchmarks {
 
 		let verifier =
 			crate::get_public_batch_verifier().expect("Public-batch verifier not available");
+		let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
+			proof_bytes.clone(),
+			&verifier.circuit_data.common,
+		)
+		.expect("Failed to deserialize public-batch proof");
+		let inputs = parse_public_batch_public_inputs(
+			&proof,
+			crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS,
+			crate::circuit_config::NUM_LEAF_PROOFS,
+		)
+		.expect("Failed to parse public-batch inputs");
 
-		let nullifiers: Vec<[u8; 32]> = (0..MAX_PUBLIC_NULLIFIERS)
-			.map(|i| {
-				let mut nullifier = [0u8; 32];
-				nullifier[0..4].copy_from_slice(&i.to_le_bytes());
-				nullifier
-			})
-			.collect();
-
-		for nullifier in &nullifiers {
-			pallet::UsedNullifiers::<T>::insert(nullifier, true);
-		}
-
-		let block_number = frame_system::Pallet::<T>::block_number();
+		insert_fixture_block_hash::<T>(&inputs.block_data);
+		insert_decoy_nullifiers::<T>(MAX_PUBLIC_NULLIFIERS);
 
 		#[block]
 		{
-			let _proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
-				proof_bytes.clone(),
-				&verifier.circuit_data.common,
-			)
-			.expect("Failed to deserialize public-batch proof");
-
-			let _block_hash = frame_system::Pallet::<T>::block_hash(block_number);
-
-			for nullifier in &nullifiers {
-				let _exists = pallet::UsedNullifiers::<T>::contains_key(nullifier);
-			}
+			let result = Pallet::<T>::pre_validate_public_batch_proof(&proof_bytes);
+			assert!(result.is_ok(), "production pre-validation must succeed");
 		}
 	}
 

--- a/pallets/wormhole/src/benchmarking.rs
+++ b/pallets/wormhole/src/benchmarking.rs
@@ -37,8 +37,7 @@ mod benchmarks {
 		parse_private_batch_public_inputs, parse_public_batch_public_inputs,
 	};
 
-	/// Insert `block_data`'s referenced block hash into `frame_system::BlockHash` so
-	/// the production pre-validation's block check passes for the fixture proof.
+	/// Insert the fixture's committed block hash so pre-validation's block check passes.
 	fn insert_fixture_block_hash<T: Config>(block_data: &qp_wormhole_verifier::BlockData) {
 		let mut hash = <T as frame_system::Config>::Hash::default();
 		hash.as_mut().copy_from_slice(block_data.block_hash.as_ref());
@@ -48,10 +47,8 @@ mod benchmarks {
 		);
 	}
 
-	/// Populate `UsedNullifiers` with decoy entries so the production nullifier scan
-	/// reads a realistically populated map. The fixture's own nullifiers stay absent:
-	/// that is the worst case (every segment stays valid, so the scan, the
-	/// intra-segment dedup and the cross-segment claimed-set all run to completion).
+	/// Populate `UsedNullifiers` with decoys; fixture nullifiers stay absent so every
+	/// segment remains valid and the full scan/dedup/claimed-set path runs.
 	fn insert_decoy_nullifiers<T: Config>(count: u32) {
 		for i in 0..count {
 			let mut nullifier = [0xFFu8; 32];
@@ -60,20 +57,9 @@ mod benchmarks {
 		}
 	}
 
-	/// Build a worst-case exit bundle for segment validation: every segment is
-	/// non-inert with `NUM_LEAF_PROOFS` distinct, unused nullifiers.
-	///
-	/// The embedded proof fixtures carry dummy padding (the public fixture has one
-	/// real inner segment out of `NUM_PRIVATE_BATCH_PROOFS`; the private fixture
-	/// has one real nullifier out of `NUM_LEAF_PROOFS`), and `segment_validity`
-	/// skips inert segments entirely — so validating the fixture alone would miss
-	/// almost all of the per-segment normalization, intra-segment dedup,
-	/// cross-segment claimed-set checks, and `UsedNullifiers` reads. This bundle
-	/// makes every one of those branches execute in full.
-	///
-	/// Nullifier patterns (`0xAB…` + counter) are disjoint from the decoy keys
-	/// (`0xFF…` + counter), so every scan is an absent-key read against a
-	/// populated map and all segments stay valid — the maximal path.
+	/// All-valid exit bundle: every segment non-inert with distinct unused
+	/// nullifiers (disjoint from decoy keys). Needed because proof fixtures use
+	/// dummy padding that `segment_validity` skips as inert.
 	fn worst_case_bundle<T: Config>(
 		block_data: qp_wormhole_verifier::BlockData,
 		num_segments: usize,
@@ -110,26 +96,12 @@ mod benchmarks {
 		}
 	}
 
-	/// Benchmark for the pre-validation phase of verify_private_batch.
-	///
-	/// Executes the *production* `pre_validate_private_batch_proof` path end to end:
-	/// proof deserialization, public-input parsing, `ExitBundle` construction, and
-	/// `validate_exit_bundle_common` (block-hash check, per-segment nullifier
-	/// normalization + intra-segment dedup + cross-segment collision checks +
-	/// used-nullifier reads, and `ensure_any_segment_valid`). Measuring anything
-	/// less understates the CPU cost this weight is charged for — twice — on the
-	/// inclusion path.
-	///
-	/// The fixture proof carries dummy nullifier padding that `segment_validity`
-	/// skips, so a worst-case all-real segment validation is measured on top (see
-	/// [`worst_case_bundle`]); the fixture's own (cheaper) validation stays in the
-	/// block, slightly over-charging — the safe direction.
+	/// Production private-batch pre-validation plus worst-case segment validation.
 	#[benchmark]
 	fn pre_validate_proof() {
 		let proof_bytes: Vec<u8> =
 			hex::decode(PRIVATE_BATCH_PROOF_HEX.trim()).expect("Invalid hex in test proof");
 
-		// Parse the fixture (setup only) to learn which block hash it commits to.
 		let verifier =
 			crate::get_private_batch_verifier().expect("Private-batch verifier not available");
 		let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
@@ -152,19 +124,7 @@ mod benchmarks {
 		}
 	}
 
-	/// Pre-validation for the public-batch path. Executes the *production*
-	/// `pre_validate_public_batch_proof` end to end: deserialization, public-input
-	/// parsing, `ExitBundle::from_public_batch` segment construction across all
-	/// `NUM_PRIVATE_BATCH_PROOFS` inner segments, and `validate_exit_bundle_common`.
-	///
-	/// The fixture aggregates one real private batch plus dummy padding, and
-	/// `segment_validity` skips the padded (inert) segments — so the fixture alone
-	/// cannot exercise the all-valid worst case. A synthetic bundle with every
-	/// segment non-inert (see [`worst_case_bundle`]) is validated in the same
-	/// block, making all `NUM_PRIVATE_BATCH_PROOFS × NUM_LEAF_PROOFS` nullifier
-	/// normalizations, dedup/claimed-set operations and `UsedNullifiers` reads
-	/// execute. The fixture's own (cheaper) validation stays in the block,
-	/// slightly over-charging — the safe direction.
+	/// Production public-batch pre-validation plus all-segment worst-case validation.
 	#[benchmark]
 	fn pre_validate_public_batch_proof() {
 		let proof_bytes: Vec<u8> =

--- a/pallets/wormhole/src/benchmarking.rs
+++ b/pallets/wormhole/src/benchmarking.rs
@@ -3,9 +3,9 @@
 extern crate alloc;
 
 use super::*;
+use crate::bench_fixtures::{insert_decoy_nullifiers, worst_case_bundle};
 use alloc::vec::Vec;
 use frame_benchmarking::v2::*;
-use frame_support::traits::Get;
 use qp_wormhole_verifier::{ProofWithPublicInputs, C, F};
 
 /// Real private-batch proof for benchmarking (hex-encoded).
@@ -45,55 +45,6 @@ mod benchmarks {
 			BlockNumberFor::<T>::from(block_data.block_number),
 			hash,
 		);
-	}
-
-	/// Populate `UsedNullifiers` with decoys; fixture nullifiers stay absent so every
-	/// segment remains valid and the full scan/dedup/claimed-set path runs.
-	fn insert_decoy_nullifiers<T: Config>(count: u32) {
-		for i in 0..count {
-			let mut nullifier = [0xFFu8; 32];
-			nullifier[0..4].copy_from_slice(&i.to_le_bytes());
-			pallet::UsedNullifiers::<T>::insert(nullifier, true);
-		}
-	}
-
-	/// All-valid exit bundle: every segment non-inert with distinct unused
-	/// nullifiers (disjoint from decoy keys). Needed because proof fixtures use
-	/// dummy padding that `segment_validity` skips as inert.
-	fn worst_case_bundle<T: Config>(
-		block_data: qp_wormhole_verifier::BlockData,
-		num_segments: usize,
-	) -> ExitBundle {
-		let slots_per_segment = crate::circuit_config::NUM_LEAF_PROOFS * 2;
-		let mut counter: u32 = 0;
-		let segments = (0..num_segments)
-			.map(|_| {
-				let nullifiers = (0..crate::circuit_config::NUM_LEAF_PROOFS)
-					.map(|_| {
-						counter += 1;
-						let mut bytes = [0xABu8; 32];
-						bytes[0..4].copy_from_slice(&counter.to_le_bytes());
-						qp_wormhole_verifier::BytesDigest::new_unchecked(bytes)
-					})
-					.collect();
-				let account_data = (0..slots_per_segment)
-					.map(|_| qp_wormhole_verifier::PublicInputsByAccount {
-						summed_output_amount: 1,
-						exit_account: qp_wormhole_verifier::BytesDigest::new_unchecked(
-							[0xCDu8; 32],
-						),
-					})
-					.collect();
-				ExitSegment { account_data, nullifiers }
-			})
-			.collect();
-		ExitBundle {
-			asset_id: 0,
-			volume_fee_bps: T::VolumeFeeRateBps::get(),
-			block_data,
-			aggregator_address: None,
-			segments,
-		}
 	}
 
 	/// Production private-batch pre-validation plus worst-case segment validation.

--- a/pallets/wormhole/src/benchmarking.rs
+++ b/pallets/wormhole/src/benchmarking.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use super::*;
 use alloc::vec::Vec;
 use frame_benchmarking::v2::*;
+use frame_support::traits::Get;
 use qp_wormhole_verifier::{ProofWithPublicInputs, C, F};
 
 /// Real private-batch proof for benchmarking (hex-encoded).
@@ -59,6 +60,56 @@ mod benchmarks {
 		}
 	}
 
+	/// Build a worst-case exit bundle for segment validation: every segment is
+	/// non-inert with `NUM_LEAF_PROOFS` distinct, unused nullifiers.
+	///
+	/// The embedded proof fixtures carry dummy padding (the public fixture has one
+	/// real inner segment out of `NUM_PRIVATE_BATCH_PROOFS`; the private fixture
+	/// has one real nullifier out of `NUM_LEAF_PROOFS`), and `segment_validity`
+	/// skips inert segments entirely — so validating the fixture alone would miss
+	/// almost all of the per-segment normalization, intra-segment dedup,
+	/// cross-segment claimed-set checks, and `UsedNullifiers` reads. This bundle
+	/// makes every one of those branches execute in full.
+	///
+	/// Nullifier patterns (`0xAB…` + counter) are disjoint from the decoy keys
+	/// (`0xFF…` + counter), so every scan is an absent-key read against a
+	/// populated map and all segments stay valid — the maximal path.
+	fn worst_case_bundle<T: Config>(
+		block_data: qp_wormhole_verifier::BlockData,
+		num_segments: usize,
+	) -> ExitBundle {
+		let slots_per_segment = crate::circuit_config::NUM_LEAF_PROOFS * 2;
+		let mut counter: u32 = 0;
+		let segments = (0..num_segments)
+			.map(|_| {
+				let nullifiers = (0..crate::circuit_config::NUM_LEAF_PROOFS)
+					.map(|_| {
+						counter += 1;
+						let mut bytes = [0xABu8; 32];
+						bytes[0..4].copy_from_slice(&counter.to_le_bytes());
+						qp_wormhole_verifier::BytesDigest::new_unchecked(bytes)
+					})
+					.collect();
+				let account_data = (0..slots_per_segment)
+					.map(|_| qp_wormhole_verifier::PublicInputsByAccount {
+						summed_output_amount: 1,
+						exit_account: qp_wormhole_verifier::BytesDigest::new_unchecked(
+							[0xCDu8; 32],
+						),
+					})
+					.collect();
+				ExitSegment { account_data, nullifiers }
+			})
+			.collect();
+		ExitBundle {
+			asset_id: 0,
+			volume_fee_bps: T::VolumeFeeRateBps::get(),
+			block_data,
+			aggregator_address: None,
+			segments,
+		}
+	}
+
 	/// Benchmark for the pre-validation phase of verify_private_batch.
 	///
 	/// Executes the *production* `pre_validate_private_batch_proof` path end to end:
@@ -68,6 +119,11 @@ mod benchmarks {
 	/// used-nullifier reads, and `ensure_any_segment_valid`). Measuring anything
 	/// less understates the CPU cost this weight is charged for — twice — on the
 	/// inclusion path.
+	///
+	/// The fixture proof carries dummy nullifier padding that `segment_validity`
+	/// skips, so a worst-case all-real segment validation is measured on top (see
+	/// [`worst_case_bundle`]); the fixture's own (cheaper) validation stays in the
+	/// block, slightly over-charging — the safe direction.
 	#[benchmark]
 	fn pre_validate_proof() {
 		let proof_bytes: Vec<u8> =
@@ -85,19 +141,30 @@ mod benchmarks {
 
 		insert_fixture_block_hash::<T>(&inputs.block_data);
 		insert_decoy_nullifiers::<T>(MAX_NULLIFIERS);
+		let worst_bundle = worst_case_bundle::<T>(inputs.block_data.clone(), 1);
 
 		#[block]
 		{
 			let result = Pallet::<T>::pre_validate_private_batch_proof(&proof_bytes);
 			assert!(result.is_ok(), "production pre-validation must succeed");
+			let validity = Pallet::<T>::validate_exit_bundle_common(&worst_bundle);
+			assert!(validity.is_ok(), "worst-case segment validation must succeed");
 		}
 	}
 
 	/// Pre-validation for the public-batch path. Executes the *production*
 	/// `pre_validate_public_batch_proof` end to end: deserialization, public-input
 	/// parsing, `ExitBundle::from_public_batch` segment construction across all
-	/// `NUM_PRIVATE_BATCH_PROOFS` inner segments, and `validate_exit_bundle_common`
-	/// with the full nullifier scan / dedup / collision checks.
+	/// `NUM_PRIVATE_BATCH_PROOFS` inner segments, and `validate_exit_bundle_common`.
+	///
+	/// The fixture aggregates one real private batch plus dummy padding, and
+	/// `segment_validity` skips the padded (inert) segments — so the fixture alone
+	/// cannot exercise the all-valid worst case. A synthetic bundle with every
+	/// segment non-inert (see [`worst_case_bundle`]) is validated in the same
+	/// block, making all `NUM_PRIVATE_BATCH_PROOFS × NUM_LEAF_PROOFS` nullifier
+	/// normalizations, dedup/claimed-set operations and `UsedNullifiers` reads
+	/// execute. The fixture's own (cheaper) validation stays in the block,
+	/// slightly over-charging — the safe direction.
 	#[benchmark]
 	fn pre_validate_public_batch_proof() {
 		let proof_bytes: Vec<u8> =
@@ -119,11 +186,17 @@ mod benchmarks {
 
 		insert_fixture_block_hash::<T>(&inputs.block_data);
 		insert_decoy_nullifiers::<T>(MAX_PUBLIC_NULLIFIERS);
+		let worst_bundle = worst_case_bundle::<T>(
+			inputs.block_data.clone(),
+			crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS,
+		);
 
 		#[block]
 		{
 			let result = Pallet::<T>::pre_validate_public_batch_proof(&proof_bytes);
 			assert!(result.is_ok(), "production pre-validation must succeed");
+			let validity = Pallet::<T>::validate_exit_bundle_common(&worst_bundle);
+			assert!(validity.is_ok(), "worst-case segment validation must succeed");
 		}
 	}
 

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -883,18 +883,71 @@ pub mod pallet {
 				Self::deposit_event(Event::SegmentsDenied { indices: denied_segments });
 			}
 
-			// Emit event for each exit account
+			// Mint the exits BEFORE settling fees or emitting ProofVerified: a slot
+			// whose credit fails is skipped (see the loop comment below), so its value
+			// is never minted and never committed. Settling a fee share or reporting an
+			// exit amount for that slot would burn / pay out value for an exit that
+			// never happened, and hand event consumers an exit_amount larger than what
+			// TotalWormholeExits records. Everything downstream is therefore derived
+			// from `minted_exit_amount` — the finalized total of successful credits.
+			let mut minted_exit_amount: BalanceOf<T> = Zero::zero();
+			for (exit_account, exit_balance) in &processed_accounts {
+				// Native token transfer - mint tokens to the exit account.
+				//
+				// A single exit that can't be minted (e.g. a below-existential-deposit
+				// credit to a fresh account) must not revert the whole bundle and deny
+				// every co-bundled user's exit — that is the per-segment isolation
+				// documented on `ExitSegment`. Skip just this slot; its nullifier is
+				// already marked so the deposit cannot be re-exited, and the skipped
+				// value is left out of the fee settlement, the ProofVerified event and
+				// the committed exit total below.
+				match <T::Currency as Unbalanced<_>>::increase_balance(
+					exit_account,
+					*exit_balance,
+					frame_support::traits::tokens::Precision::Exact,
+				) {
+					Ok(_) => {},
+					Err(e) => {
+						log::warn!(
+							"Exit mint of {:?} to {:?} failed ({:?}); skipping this exit",
+							*exit_balance,
+							exit_account,
+							e
+						);
+						Self::deposit_event(Event::ExitMintFailed {
+							account: exit_account.clone(),
+							amount: *exit_balance,
+						});
+						continue;
+					},
+				}
+
+				minted_exit_amount = minted_exit_amount.saturating_add(*exit_balance);
+
+				// Record transfer proof for the minted tokens
+				let from_account: <T as Config>::WormholeAccountId = mint_account.clone().into();
+				let to_account: <T as Config>::WormholeAccountId = exit_account.clone().into();
+				Self::record_transfer(
+					T::AssetId::default(),
+					&from_account,
+					&to_account,
+					*exit_balance,
+				);
+			}
+
+			// Emit the finalized exit amount — what actually minted, and what is
+			// committed to TotalWormholeExits below — not the attempted total.
 			Self::deposit_event(Event::ProofVerified {
-				exit_amount: total_exit_amount,
+				exit_amount: minted_exit_amount,
 				nullifiers: nullifier_list,
 			});
 
-			// Compute the total fee from the input amounts
-			// fee = total_output_amount * volume_fee_bps / (10000 - volume_fee_bps)
+			// Compute the total fee from the minted outputs
+			// fee = minted_output_amount * volume_fee_bps / (10000 - volume_fee_bps)
 			// This is the fee that was deducted from input to get output.
 			let fee_bps = T::VolumeFeeRateBps::get() as u128;
-			let total_exit_u128: u128 = total_exit_amount.try_into().map_err(|_| {
-				log::error!("Failed to convert total_exit_amount to u128");
+			let total_exit_u128: u128 = minted_exit_amount.try_into().map_err(|_| {
+				log::error!("Failed to convert minted_exit_amount to u128");
 				Error::<T>::InvalidProofPublicInputs
 			})?;
 			let total_fee_u128 = total_exit_u128
@@ -1022,51 +1075,6 @@ pub mod pallet {
 				let current = <T::Currency as FungibleInspect<_>>::total_issuance();
 				<T::Currency as Unbalanced<_>>::set_total_issuance(
 					current.saturating_sub(burn_amount),
-				);
-			}
-
-			// Process transfers and record proofs
-			let mut minted_exit_amount: BalanceOf<T> = Zero::zero();
-			for (exit_account, exit_balance) in &processed_accounts {
-				// Native token transfer - mint tokens to the exit account.
-				//
-				// A single exit that can't be minted (e.g. a below-existential-deposit
-				// credit to a fresh account) must not revert the whole bundle and deny
-				// every co-bundled user's exit — that is the per-segment isolation
-				// documented on `ExitSegment`. Skip just this slot; its nullifier is
-				// already marked so the deposit cannot be re-exited, and the skipped
-				// value is left out of the committed exit total below.
-				match <T::Currency as Unbalanced<_>>::increase_balance(
-					exit_account,
-					*exit_balance,
-					frame_support::traits::tokens::Precision::Exact,
-				) {
-					Ok(_) => {},
-					Err(e) => {
-						log::warn!(
-							"Exit mint of {:?} to {:?} failed ({:?}); skipping this exit",
-							*exit_balance,
-							exit_account,
-							e
-						);
-						Self::deposit_event(Event::ExitMintFailed {
-							account: exit_account.clone(),
-							amount: *exit_balance,
-						});
-						continue;
-					},
-				}
-
-				minted_exit_amount = minted_exit_amount.saturating_add(*exit_balance);
-
-				// Record transfer proof for the minted tokens
-				let from_account: <T as Config>::WormholeAccountId = mint_account.clone().into();
-				let to_account: <T as Config>::WormholeAccountId = exit_account.clone().into();
-				Self::record_transfer(
-					T::AssetId::default(),
-					&from_account,
-					&to_account,
-					*exit_balance,
 				);
 			}
 

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -883,24 +883,11 @@ pub mod pallet {
 				Self::deposit_event(Event::SegmentsDenied { indices: denied_segments });
 			}
 
-			// Mint the exits BEFORE settling fees or emitting ProofVerified: a slot
-			// whose credit fails is skipped (see the loop comment below), so its value
-			// is never minted and never committed. Settling a fee share or reporting an
-			// exit amount for that slot would burn / pay out value for an exit that
-			// never happened, and hand event consumers an exit_amount larger than what
-			// TotalWormholeExits records. Everything downstream is therefore derived
-			// from `minted_exit_amount` — the finalized total of successful credits.
+			// Mint exits first; fees and ProofVerified use only successfully minted amounts.
 			let mut minted_exit_amount: BalanceOf<T> = Zero::zero();
 			for (exit_account, exit_balance) in &processed_accounts {
-				// Native token transfer - mint tokens to the exit account.
-				//
-				// A single exit that can't be minted (e.g. a below-existential-deposit
-				// credit to a fresh account) must not revert the whole bundle and deny
-				// every co-bundled user's exit — that is the per-segment isolation
-				// documented on `ExitSegment`. Skip just this slot; its nullifier is
-				// already marked so the deposit cannot be re-exited, and the skipped
-				// value is left out of the fee settlement, the ProofVerified event and
-				// the committed exit total below.
+				// Skip failed credits (e.g. below ED); nullifier already marked, value
+				// excluded from fee settlement / event / TotalWormholeExits.
 				match <T::Currency as Unbalanced<_>>::increase_balance(
 					exit_account,
 					*exit_balance,
@@ -935,16 +922,12 @@ pub mod pallet {
 				);
 			}
 
-			// Emit the finalized exit amount — what actually minted, and what is
-			// committed to TotalWormholeExits below — not the attempted total.
 			Self::deposit_event(Event::ProofVerified {
 				exit_amount: minted_exit_amount,
 				nullifiers: nullifier_list,
 			});
 
-			// Compute the total fee from the minted outputs
-			// fee = minted_output_amount * volume_fee_bps / (10000 - volume_fee_bps)
-			// This is the fee that was deducted from input to get output.
+			// fee = minted_output * volume_fee_bps / (10000 - volume_fee_bps)
 			let fee_bps = T::VolumeFeeRateBps::get() as u128;
 			let total_exit_u128: u128 = minted_exit_amount.try_into().map_err(|_| {
 				log::error!("Failed to convert minted_exit_amount to u128");

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -1157,7 +1157,9 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		/// Shared cheap checks for any exit bundle (asset, fee, block, segment validity).
-		fn validate_exit_bundle_common(bundle: &ExitBundle) -> Result<Vec<bool>, Error<T>> {
+		pub(crate) fn validate_exit_bundle_common(
+			bundle: &ExitBundle,
+		) -> Result<Vec<bool>, Error<T>> {
 			ensure!(bundle.asset_id == 0, Error::<T>::NonNativeAssetNotSupported);
 			ensure!(
 				bundle.volume_fee_bps == T::VolumeFeeRateBps::get(),

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -138,6 +138,8 @@ fn load_batch_verifier_from_bytes(
 	Some(WormholeVerifier { circuit_data: VerifierCircuitData { verifier_only, common } })
 }
 
+#[cfg(any(test, feature = "runtime-benchmarks"))]
+mod bench_fixtures;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 pub mod migrations;

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -1185,7 +1185,7 @@ pub mod pallet {
 		/// (`validate_unsigned`), where running the full ZK verify would let unsigned,
 		/// fee-free traffic force unbounded verification work per gossiped proof. The
 		/// full verification is deferred to the block-inclusion gate (`pre_dispatch`).
-		fn pre_validate_private_batch_proof(
+		pub(crate) fn pre_validate_private_batch_proof(
 			proof_bytes: &[u8],
 		) -> Result<
 			(
@@ -1229,7 +1229,7 @@ pub mod pallet {
 
 		/// Cheap pre-validation of a public-batch proof (no ZK verify). See
 		/// [`Self::pre_validate_private_batch_proof`].
-		fn pre_validate_public_batch_proof(
+		pub(crate) fn pre_validate_public_batch_proof(
 			proof_bytes: &[u8],
 		) -> Result<
 			(

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -2121,7 +2121,10 @@ mod public_batch_proof_tests {
 /// `cargo test -p pallet-wormhole --release measure_pre_validation_time -- --ignored --nocapture`
 #[cfg(test)]
 mod pre_validation_timing {
-	use crate::mock::*;
+	use crate::{
+		bench_fixtures::{insert_decoy_nullifiers, worst_case_bundle},
+		mock::*,
+	};
 	use qp_wormhole_verifier::{parse_private_batch_public_inputs, ProofWithPublicInputs, C, D, F};
 	use sp_core::H256;
 	use std::time::Instant;
@@ -2132,50 +2135,6 @@ mod pre_validation_timing {
 	fn insert_block_hash(block_number: u32, block_hash: &[u8]) {
 		let bytes: [u8; 32] = block_hash.try_into().unwrap();
 		frame_system::BlockHash::<Test>::insert(block_number as u64, H256::from(bytes));
-	}
-
-	fn insert_decoy_nullifiers(count: u32) {
-		for i in 0..count {
-			let mut nullifier = [0xFFu8; 32];
-			nullifier[0..4].copy_from_slice(&i.to_le_bytes());
-			crate::UsedNullifiers::<Test>::insert(nullifier, true);
-		}
-	}
-
-	fn worst_case_bundle(
-		block_data: qp_wormhole_verifier::BlockData,
-		num_segments: usize,
-	) -> crate::ExitBundle {
-		let slots_per_segment = crate::circuit_config::NUM_LEAF_PROOFS * 2;
-		let mut counter: u32 = 0;
-		let segments = (0..num_segments)
-			.map(|_| {
-				let nullifiers = (0..crate::circuit_config::NUM_LEAF_PROOFS)
-					.map(|_| {
-						counter += 1;
-						let mut bytes = [0xABu8; 32];
-						bytes[0..4].copy_from_slice(&counter.to_le_bytes());
-						qp_wormhole_verifier::BytesDigest::new_unchecked(bytes)
-					})
-					.collect();
-				let account_data = (0..slots_per_segment)
-					.map(|_| qp_wormhole_verifier::PublicInputsByAccount {
-						summed_output_amount: 1,
-						exit_account: qp_wormhole_verifier::BytesDigest::new_unchecked(
-							[0xCDu8; 32],
-						),
-					})
-					.collect();
-				crate::ExitSegment { account_data, nullifiers }
-			})
-			.collect();
-		crate::ExitBundle {
-			asset_id: 0,
-			volume_fee_bps: <Test as crate::Config>::VolumeFeeRateBps::get(),
-			block_data,
-			aggregator_address: None,
-			segments,
-		}
 	}
 
 	#[test]
@@ -2198,7 +2157,7 @@ mod pre_validation_timing {
 				inputs.block_data.block_number,
 				inputs.block_data.block_hash.as_ref(),
 			);
-			insert_decoy_nullifiers(crate::circuit_config::NUM_LEAF_PROOFS as u32);
+			insert_decoy_nullifiers::<Test>(crate::circuit_config::NUM_LEAF_PROOFS as u32);
 
 			let t = Instant::now();
 			for _ in 0..iters {
@@ -2216,7 +2175,7 @@ mod pre_validation_timing {
 			}
 			println!("private full pre-validate: {:?}/iter", t.elapsed() / iters);
 
-			let worst = worst_case_bundle(inputs.block_data.clone(), 1);
+			let worst = worst_case_bundle::<Test>(inputs.block_data.clone(), 1);
 			let t = Instant::now();
 			for _ in 0..iters {
 				assert!(Wormhole::pre_validate_private_batch_proof(&proof_bytes).is_ok());
@@ -2243,7 +2202,7 @@ mod pre_validation_timing {
 				inputs.block_data.block_number,
 				inputs.block_data.block_hash.as_ref(),
 			);
-			insert_decoy_nullifiers(
+			insert_decoy_nullifiers::<Test>(
 				(crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS *
 					crate::circuit_config::NUM_LEAF_PROOFS) as u32,
 			);
@@ -2264,7 +2223,7 @@ mod pre_validation_timing {
 			}
 			println!("public full pre-validate: {:?}/iter", t.elapsed() / iters);
 
-			let worst = worst_case_bundle(
+			let worst = worst_case_bundle::<Test>(
 				inputs.block_data.clone(),
 				crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS,
 			);

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -1761,6 +1761,57 @@ mod exit_bundle_tests {
 	}
 
 	#[test]
+	fn process_exit_bundle_settles_fee_and_event_from_minted_exits_only() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			PotentialWormholeBalance::<Test>::put(1_000_000 * UNIT);
+
+			// Seed issuance so the burn is observable.
+			assert_ok!(Balances::mint_into(&account_id(999), 1_000 * UNIT));
+			let issuance_before = <Balances as Inspect<AccountId>>::total_issuance();
+
+			// Raise the ED so the AMOUNT_A exit to a fresh account fails and is
+			// skipped, while the AMOUNT_B exit clears it (same setup as the
+			// skip-below-ED test).
+			ExistentialDeposit::set(scaled(2500));
+
+			let b = bundle(
+				vec![segment(&[1], &[(10, AMOUNT_A)]), segment(&[2], &[(11, AMOUNT_B)])],
+				None,
+			);
+			assert_ok!(Wormhole::process_exit_bundle(b));
+
+			// The skipped exit's value was never minted and never committed, so no
+			// fee attributable to it may be settled: the fee (fully burned here — no
+			// aggregator, no block author in tests) must be computed from the minted
+			// total only, not the attempted total.
+			let fee_bps = VolumeFeeRateBps::get() as u128;
+			let fee_minted = scaled(AMOUNT_B) * fee_bps / (10_000 - fee_bps);
+			let fee_attempted =
+				(scaled(AMOUNT_A) + scaled(AMOUNT_B)) * fee_bps / (10_000 - fee_bps);
+			assert_ne!(fee_minted, fee_attempted, "test must distinguish the two totals");
+
+			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
+			assert_eq!(
+				issuance_before - issuance_after,
+				fee_minted,
+				"fee settlement must be based on successfully minted exits only"
+			);
+
+			// ProofVerified must report the finalized (minted) exit amount, matching
+			// what was committed to TotalWormholeExits — not the attempted total.
+			assert_eq!(TotalWormholeExits::<Test>::get(), scaled(AMOUNT_B));
+			System::assert_has_event(
+				crate::Event::<Test>::ProofVerified {
+					exit_amount: scaled(AMOUNT_B),
+					nullifiers: vec![nullifier_bytes(1), nullifier_bytes(2)],
+				}
+				.into(),
+			);
+		});
+	}
+
+	#[test]
 	fn process_exit_bundle_burns_rebate_when_aggregator_mint_fails() {
 		new_test_ext().execute_with(|| {
 			System::set_block_number(1);

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -1781,25 +1781,14 @@ mod exit_bundle_tests {
 			);
 			assert_ok!(Wormhole::process_exit_bundle(b));
 
-			// The skipped exit's value was never minted and never committed, so no
-			// fee attributable to it may be settled: the fee (fully burned here — no
-			// aggregator, no block author in tests) must be computed from the minted
-			// total only, not the attempted total.
 			let fee_bps = VolumeFeeRateBps::get() as u128;
 			let fee_minted = scaled(AMOUNT_B) * fee_bps / (10_000 - fee_bps);
 			let fee_attempted =
 				(scaled(AMOUNT_A) + scaled(AMOUNT_B)) * fee_bps / (10_000 - fee_bps);
-			assert_ne!(fee_minted, fee_attempted, "test must distinguish the two totals");
+			assert_ne!(fee_minted, fee_attempted);
 
 			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
-			assert_eq!(
-				issuance_before - issuance_after,
-				fee_minted,
-				"fee settlement must be based on successfully minted exits only"
-			);
-
-			// ProofVerified must report the finalized (minted) exit amount, matching
-			// what was committed to TotalWormholeExits — not the attempted total.
+			assert_eq!(issuance_before - issuance_after, fee_minted);
 			assert_eq!(TotalWormholeExits::<Test>::get(), scaled(AMOUNT_B));
 			System::assert_has_event(
 				crate::Event::<Test>::ProofVerified {
@@ -2128,8 +2117,7 @@ mod public_batch_proof_tests {
 	}
 }
 
-/// Manual timing harness used to calibrate the hand-maintained pre-validation
-/// compute constants in `weights.rs`. Run with:
+/// Timing harness for `weights.rs` pre-validation constants.
 /// `cargo test -p pallet-wormhole --release measure_pre_validation_time -- --ignored --nocapture`
 #[cfg(test)]
 mod pre_validation_timing {
@@ -2154,8 +2142,6 @@ mod pre_validation_timing {
 		}
 	}
 
-	/// All-real, all-valid bundle: every segment non-inert with distinct unused
-	/// nullifiers (mirrors `benchmarking::worst_case_bundle`).
 	fn worst_case_bundle(
 		block_data: qp_wormhole_verifier::BlockData,
 		num_segments: usize,

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -2134,9 +2134,7 @@ mod public_batch_proof_tests {
 #[cfg(test)]
 mod pre_validation_timing {
 	use crate::mock::*;
-	use qp_wormhole_verifier::{
-		parse_private_batch_public_inputs, ProofWithPublicInputs, C, D, F,
-	};
+	use qp_wormhole_verifier::{parse_private_batch_public_inputs, ProofWithPublicInputs, C, D, F};
 	use sp_core::H256;
 	use std::time::Instant;
 
@@ -2156,6 +2154,44 @@ mod pre_validation_timing {
 		}
 	}
 
+	/// All-real, all-valid bundle: every segment non-inert with distinct unused
+	/// nullifiers (mirrors `benchmarking::worst_case_bundle`).
+	fn worst_case_bundle(
+		block_data: qp_wormhole_verifier::BlockData,
+		num_segments: usize,
+	) -> crate::ExitBundle {
+		let slots_per_segment = crate::circuit_config::NUM_LEAF_PROOFS * 2;
+		let mut counter: u32 = 0;
+		let segments = (0..num_segments)
+			.map(|_| {
+				let nullifiers = (0..crate::circuit_config::NUM_LEAF_PROOFS)
+					.map(|_| {
+						counter += 1;
+						let mut bytes = [0xABu8; 32];
+						bytes[0..4].copy_from_slice(&counter.to_le_bytes());
+						qp_wormhole_verifier::BytesDigest::new_unchecked(bytes)
+					})
+					.collect();
+				let account_data = (0..slots_per_segment)
+					.map(|_| qp_wormhole_verifier::PublicInputsByAccount {
+						summed_output_amount: 1,
+						exit_account: qp_wormhole_verifier::BytesDigest::new_unchecked(
+							[0xCDu8; 32],
+						),
+					})
+					.collect();
+				crate::ExitSegment { account_data, nullifiers }
+			})
+			.collect();
+		crate::ExitBundle {
+			asset_id: 0,
+			volume_fee_bps: <Test as crate::Config>::VolumeFeeRateBps::get(),
+			block_data,
+			aggregator_address: None,
+			segments,
+		}
+	}
+
 	#[test]
 	#[ignore] // manual calibration harness, not a correctness test
 	fn measure_pre_validation_time() {
@@ -2172,7 +2208,10 @@ mod pre_validation_timing {
 			)
 			.unwrap();
 			let inputs = parse_private_batch_public_inputs(&proof).unwrap();
-			insert_block_hash(inputs.block_data.block_number, inputs.block_data.block_hash.as_ref());
+			insert_block_hash(
+				inputs.block_data.block_number,
+				inputs.block_data.block_hash.as_ref(),
+			);
 			insert_decoy_nullifiers(crate::circuit_config::NUM_LEAF_PROOFS as u32);
 
 			let t = Instant::now();
@@ -2191,6 +2230,14 @@ mod pre_validation_timing {
 			}
 			println!("private full pre-validate: {:?}/iter", t.elapsed() / iters);
 
+			let worst = worst_case_bundle(inputs.block_data.clone(), 1);
+			let t = Instant::now();
+			for _ in 0..iters {
+				assert!(Wormhole::pre_validate_private_batch_proof(&proof_bytes).is_ok());
+				assert!(Wormhole::validate_exit_bundle_common(&worst).is_ok());
+			}
+			println!("private pre-validate + worst-case segments: {:?}/iter", t.elapsed() / iters);
+
 			// --- Public batch ---
 			let proof_bytes =
 				hex::decode(PUBLIC_BATCH_PROOF_HEX.trim()).expect("Invalid public hex");
@@ -2206,7 +2253,10 @@ mod pre_validation_timing {
 				crate::circuit_config::NUM_LEAF_PROOFS,
 			)
 			.unwrap();
-			insert_block_hash(inputs.block_data.block_number, inputs.block_data.block_hash.as_ref());
+			insert_block_hash(
+				inputs.block_data.block_number,
+				inputs.block_data.block_hash.as_ref(),
+			);
 			insert_decoy_nullifiers(
 				(crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS *
 					crate::circuit_config::NUM_LEAF_PROOFS) as u32,
@@ -2227,6 +2277,17 @@ mod pre_validation_timing {
 				assert!(Wormhole::pre_validate_public_batch_proof(&proof_bytes).is_ok());
 			}
 			println!("public full pre-validate: {:?}/iter", t.elapsed() / iters);
+
+			let worst = worst_case_bundle(
+				inputs.block_data.clone(),
+				crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS,
+			);
+			let t = Instant::now();
+			for _ in 0..iters {
+				assert!(Wormhole::pre_validate_public_batch_proof(&proof_bytes).is_ok());
+				assert!(Wormhole::validate_exit_bundle_common(&worst).is_ok());
+			}
+			println!("public pre-validate + worst-case segments: {:?}/iter", t.elapsed() / iters);
 		});
 	}
 }

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -2127,3 +2127,106 @@ mod public_batch_proof_tests {
 		let _ = std::fs::remove_dir_all(&tmp_dir);
 	}
 }
+
+/// Manual timing harness used to calibrate the hand-maintained pre-validation
+/// compute constants in `weights.rs`. Run with:
+/// `cargo test -p pallet-wormhole --release measure_pre_validation_time -- --ignored --nocapture`
+#[cfg(test)]
+mod pre_validation_timing {
+	use crate::mock::*;
+	use qp_wormhole_verifier::{
+		parse_private_batch_public_inputs, ProofWithPublicInputs, C, D, F,
+	};
+	use sp_core::H256;
+	use std::time::Instant;
+
+	const PRIVATE_BATCH_PROOF_HEX: &str = include_str!("../test-data/private_batch.hex");
+	const PUBLIC_BATCH_PROOF_HEX: &str = include_str!("../test-data/public_batch.hex");
+
+	fn insert_block_hash(block_number: u32, block_hash: &[u8]) {
+		let bytes: [u8; 32] = block_hash.try_into().unwrap();
+		frame_system::BlockHash::<Test>::insert(block_number as u64, H256::from(bytes));
+	}
+
+	fn insert_decoy_nullifiers(count: u32) {
+		for i in 0..count {
+			let mut nullifier = [0xFFu8; 32];
+			nullifier[0..4].copy_from_slice(&i.to_le_bytes());
+			crate::UsedNullifiers::<Test>::insert(nullifier, true);
+		}
+	}
+
+	#[test]
+	#[ignore] // manual calibration harness, not a correctness test
+	fn measure_pre_validation_time() {
+		new_test_ext().execute_with(|| {
+			let iters: u32 = 50;
+
+			// --- Private batch ---
+			let proof_bytes =
+				hex::decode(PRIVATE_BATCH_PROOF_HEX.trim()).expect("Invalid private hex");
+			let verifier = crate::get_private_batch_verifier().unwrap();
+			let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
+				proof_bytes.clone(),
+				&verifier.circuit_data.common,
+			)
+			.unwrap();
+			let inputs = parse_private_batch_public_inputs(&proof).unwrap();
+			insert_block_hash(inputs.block_data.block_number, inputs.block_data.block_hash.as_ref());
+			insert_decoy_nullifiers(crate::circuit_config::NUM_LEAF_PROOFS as u32);
+
+			let t = Instant::now();
+			for _ in 0..iters {
+				let _ = ProofWithPublicInputs::<F, C, D>::from_bytes(
+					proof_bytes.clone(),
+					&verifier.circuit_data.common,
+				)
+				.unwrap();
+			}
+			println!("private deserialize-only: {:?}/iter", t.elapsed() / iters);
+
+			let t = Instant::now();
+			for _ in 0..iters {
+				assert!(Wormhole::pre_validate_private_batch_proof(&proof_bytes).is_ok());
+			}
+			println!("private full pre-validate: {:?}/iter", t.elapsed() / iters);
+
+			// --- Public batch ---
+			let proof_bytes =
+				hex::decode(PUBLIC_BATCH_PROOF_HEX.trim()).expect("Invalid public hex");
+			let verifier = crate::get_public_batch_verifier().unwrap();
+			let proof = ProofWithPublicInputs::<F, C, D>::from_bytes(
+				proof_bytes.clone(),
+				&verifier.circuit_data.common,
+			)
+			.unwrap();
+			let inputs = qp_wormhole_verifier::parse_public_batch_public_inputs(
+				&proof,
+				crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS,
+				crate::circuit_config::NUM_LEAF_PROOFS,
+			)
+			.unwrap();
+			insert_block_hash(inputs.block_data.block_number, inputs.block_data.block_hash.as_ref());
+			insert_decoy_nullifiers(
+				(crate::circuit_config::NUM_PRIVATE_BATCH_PROOFS *
+					crate::circuit_config::NUM_LEAF_PROOFS) as u32,
+			);
+
+			let t = Instant::now();
+			for _ in 0..iters {
+				let _ = ProofWithPublicInputs::<F, C, D>::from_bytes(
+					proof_bytes.clone(),
+					&verifier.circuit_data.common,
+				)
+				.unwrap();
+			}
+			println!("public deserialize-only: {:?}/iter", t.elapsed() / iters);
+
+			let t = Instant::now();
+			for _ in 0..iters {
+				assert!(Wormhole::pre_validate_public_batch_proof(&proof_bytes).is_ok());
+			}
+			println!("public full pre-validate: {:?}/iter", t.elapsed() / iters);
+		});
+	}
+}

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -62,12 +62,12 @@ pub trait WeightInfo {
 }
 
 /// Compute for production private-batch pre-validation at the all-valid worst
-/// case (see `benchmarking::worst_case_bundle`). Re-run `pre_validate_proof` to
+/// case (see `bench_fixtures::worst_case_bundle`). Re-run `pre_validate_proof` to
 /// regenerate.
 const PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 700_000_000;
 
 /// Compute for production public-batch pre-validation at the all-valid worst
-/// case (every segment non-inert; see `benchmarking::worst_case_bundle`).
+/// case (every segment non-inert; see `bench_fixtures::worst_case_bundle`).
 /// Re-run `pre_validate_public_batch_proof` to regenerate.
 const PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 4_500_000_000;
 
@@ -97,11 +97,6 @@ fn public_batch_max_exits() -> u64 {
 		.saturating_mul(circuit_config::NUM_PRIVATE_BATCH_PROOFS as u64)
 }
 
-/// Conservative PoV bound per ZK-tree storage key touched during a path update.
-/// Tree entries are 32-byte hashes with small keys; the comparable benchmarked
-/// `UsedNullifiers` map (49-byte entries) has an `added` figure of 2524 per key.
-const TREE_KEY_POV: u64 = 2600;
-
 /// Scale the storage tail to `exits` mints, plus depth-dependent ZK-tree ops per
 /// exit. When `include_aggregator` is set, adds one account r/w for the rebate.
 fn storage_tail(
@@ -124,7 +119,11 @@ fn storage_tail(
 		.saturating_mul(exits)
 		.saturating_div(STORAGE_CALIBRATION_EXITS)
 		.max(1)
-		.saturating_add(exits.saturating_mul(tree_reads).saturating_mul(TREE_KEY_POV));
+		.saturating_add(
+			exits
+				.saturating_mul(tree_reads)
+				.saturating_mul(pallet_zk_tree::TREE_KEY_POV),
+		);
 	if include_aggregator {
 		(reads.saturating_add(1), writes.saturating_add(1), proof_size)
 	} else {

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -63,24 +63,33 @@ pub trait WeightInfo {
 
 /// Measured compute base for the production `pre_validate_private_batch_proof`
 /// path (proof deserialization + public-input parsing + `ExitBundle` construction +
-/// `validate_exit_bundle_common` segment validation).
+/// `validate_exit_bundle_common` segment validation), priced at the all-valid
+/// worst case (all `NUM_LEAF_PROOFS` nullifier slots real and unused — the
+/// fixture's dummy padding is compensated with a synthetic worst-case bundle,
+/// see `benchmarking::worst_case_bundle`).
 ///
-/// Calibration 2026-08-06: the full production path measured 176 µs native-release
-/// against 163 µs for deserialization alone; scaled by this path's observed
-/// wasm-compiled factor (550 µs / 163 µs ≈ 3.4× from the 2026-07-30 benchmark run)
-/// that is ~597 µs, padded to 700 µs. Re-run the `pre_validate_proof` benchmark
-/// (which now executes the production path) to regenerate.
+/// Calibration 2026-08-06: worst-case path measured 181 µs native-release against
+/// 167 µs for deserialization alone; scaled by this path's observed wasm-compiled
+/// factor (550 µs / 167 µs ≈ 3.3× from the 2026-07-30 benchmark run) that is
+/// ~600 µs, padded to 700 µs. Re-run the `pre_validate_proof` benchmark to
+/// regenerate.
 const PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 700_000_000;
 
 /// Measured compute base for the production `pre_validate_public_batch_proof` path
 /// (deserialization + parsing + `ExitBundle::from_public_batch` across all
-/// `NUM_PRIVATE_BATCH_PROOFS` segments + full segment validation).
+/// `NUM_PRIVATE_BATCH_PROOFS` segments + full segment validation), priced at the
+/// all-valid worst case: every segment non-inert, so all
+/// `NUM_PRIVATE_BATCH_PROOFS × NUM_LEAF_PROOFS` nullifier normalizations,
+/// dedup/claimed-set operations and `UsedNullifiers` reads execute (the fixture's
+/// 52 dummy segments are skipped as inert by `segment_validity`, so a synthetic
+/// worst-case bundle is measured on top — see `benchmarking::worst_case_bundle`).
 ///
-/// Calibration 2026-08-06 at NUM_PRIVATE_BATCH_PROOFS=53: full production path
-/// 237 µs native-release vs 223 µs deserialize-only; scaled by this path's
-/// wasm-compiled factor (1578 µs / 223 µs ≈ 7.1×) that is ~1.68 ms, padded to
-/// 1.9 ms. Re-run the `pre_validate_public_batch_proof` benchmark to regenerate.
-const PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 1_900_000_000;
+/// Calibration 2026-08-06 at NUM_PRIVATE_BATCH_PROOFS=53: worst-case path 597 µs
+/// native-release (vs 257 µs with the fixture's padding skips and 240 µs
+/// deserialize-only); scaled by this path's wasm-compiled factor
+/// (1578 µs / 240 µs ≈ 6.6–7.1×) that is ~4.2 ms, padded to 4.5 ms. Re-run the
+/// `pre_validate_public_batch_proof` benchmark to regenerate.
+const PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 4_500_000_000;
 
 /// Measured ZK verification time for a private-batch proof (2026-07-30).
 const PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS: u64 = 14_965_000_000;
@@ -426,11 +435,13 @@ mod tests {
 		);
 	}
 
-	/// The pre-validation compute base must price the *production* path, which does
-	/// strictly more work than the deserialize-only micro-benchmark it replaced
-	/// (public-input parsing, bundle construction, segment validation). Guard the
-	/// calibrated floor so a regenerated weights file can't silently regress to the
-	/// old deserialize-only figures (550 µs private / 1578 µs public, 2026-07-30).
+	/// The pre-validation compute base must price the *production* path at the
+	/// all-valid worst case, which does strictly more work than the two
+	/// calibrations it replaced: the deserialize-only micro-benchmark (550 µs
+	/// private / 1578 µs public, 2026-07-30) and the fixture-only production run
+	/// whose dummy-padded segments were skipped as inert by `segment_validity`
+	/// (~1.9 ms public, 2026-08-06). Guard both floors so a regenerated weights
+	/// file can't silently regress to either under-measurement.
 	#[test]
 	fn pre_validation_compute_covers_production_path() {
 		assert!(
@@ -438,8 +449,8 @@ mod tests {
 			"private pre-validate compute must exceed the deserialize-only measurement"
 		);
 		assert!(
-			PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS > 1_578_000_000,
-			"public pre-validate compute must exceed the deserialize-only measurement"
+			PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS > 1_900_000_000,
+			"public pre-validate compute must exceed the inert-skip fixture measurement"
 		);
 	}
 }

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -61,45 +61,23 @@ pub trait WeightInfo {
 	fn verify_public_batch() -> Weight;
 }
 
-/// Measured compute base for the production `pre_validate_private_batch_proof`
-/// path (proof deserialization + public-input parsing + `ExitBundle` construction +
-/// `validate_exit_bundle_common` segment validation), priced at the all-valid
-/// worst case (all `NUM_LEAF_PROOFS` nullifier slots real and unused — the
-/// fixture's dummy padding is compensated with a synthetic worst-case bundle,
-/// see `benchmarking::worst_case_bundle`).
-///
-/// Calibration 2026-08-06: worst-case path measured 181 µs native-release against
-/// 167 µs for deserialization alone; scaled by this path's observed wasm-compiled
-/// factor (550 µs / 167 µs ≈ 3.3× from the 2026-07-30 benchmark run) that is
-/// ~600 µs, padded to 700 µs. Re-run the `pre_validate_proof` benchmark to
+/// Compute for production private-batch pre-validation at the all-valid worst
+/// case (see `benchmarking::worst_case_bundle`). Re-run `pre_validate_proof` to
 /// regenerate.
 const PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 700_000_000;
 
-/// Measured compute base for the production `pre_validate_public_batch_proof` path
-/// (deserialization + parsing + `ExitBundle::from_public_batch` across all
-/// `NUM_PRIVATE_BATCH_PROOFS` segments + full segment validation), priced at the
-/// all-valid worst case: every segment non-inert, so all
-/// `NUM_PRIVATE_BATCH_PROOFS × NUM_LEAF_PROOFS` nullifier normalizations,
-/// dedup/claimed-set operations and `UsedNullifiers` reads execute (the fixture's
-/// 52 dummy segments are skipped as inert by `segment_validity`, so a synthetic
-/// worst-case bundle is measured on top — see `benchmarking::worst_case_bundle`).
-///
-/// Calibration 2026-08-06 at NUM_PRIVATE_BATCH_PROOFS=53: worst-case path 597 µs
-/// native-release (vs 257 µs with the fixture's padding skips and 240 µs
-/// deserialize-only); scaled by this path's wasm-compiled factor
-/// (1578 µs / 240 µs ≈ 6.6–7.1×) that is ~4.2 ms, padded to 4.5 ms. Re-run the
-/// `pre_validate_public_batch_proof` benchmark to regenerate.
+/// Compute for production public-batch pre-validation at the all-valid worst
+/// case (every segment non-inert; see `benchmarking::worst_case_bundle`).
+/// Re-run `pre_validate_public_batch_proof` to regenerate.
 const PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 4_500_000_000;
 
-/// Measured ZK verification time for a private-batch proof (2026-07-30).
+/// ZK verification time for a private-batch proof.
 const PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS: u64 = 14_965_000_000;
 
-/// Measured ZK verification time for a public-batch proof (2026-07-30,
-/// NUM_PRIVATE_BATCH_PROOFS=53).
+/// ZK verification time for a public-batch proof.
 const PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS: u64 = 20_686_000_000;
 
-/// Historical hand-augmentation calibrated for a private-batch of 16 leaves
-/// (2 exit slots/leaf → 32 exit mints). See `verify_private_batch` docs.
+/// Storage-tail calibration basis: 32 exit mints (16 leaves × 2 slots).
 const STORAGE_CALIBRATION_EXITS: u64 = 32;
 const STORAGE_CALIBRATION_READS: u64 = 200;
 const STORAGE_CALIBRATION_WRITES: u64 = 170;
@@ -124,18 +102,8 @@ fn public_batch_max_exits() -> u64 {
 /// `UsedNullifiers` map (49-byte entries) has an `added` figure of 2524 per key.
 const TREE_KEY_POV: u64 = 2600;
 
-/// Scale the calibrated storage tail to `exits` exit mints, adding the
-/// depth-dependent ZK-tree update cost per exit.
-///
-/// `process_exit_bundle` calls `record_transfer` once per exit mint, and each call
-/// walks the ZK tree leaf-to-root (`tree_ops_per_exit` reads/writes, growing with
-/// tree depth). The historical calibration was measured against a near-empty tree,
-/// so the depth-dependent walk is charged explicitly on top; the small tree
-/// component already embedded in the calibration is deliberately not deducted
-/// (over-charging is the safe direction).
-///
-/// Adds one extra account read/write for the public-batch aggregator rebate when
-/// `include_aggregator` is set.
+/// Scale the storage tail to `exits` mints, plus depth-dependent ZK-tree ops per
+/// exit. When `include_aggregator` is set, adds one account r/w for the rebate.
 fn storage_tail(
 	exits: u64,
 	include_aggregator: bool,
@@ -176,13 +144,8 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 	/// Storage: `Wormhole::UsedNullifiers` (r:NUM_LEAF_PROOFS w:0)
 	/// Proof: `Wormhole::UsedNullifiers` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
 	///
-	/// The nullifier existence scan reads one `UsedNullifiers` key per leaf proof, so
-	/// reads and PoV are derived from `circuit_config::NUM_LEAF_PROOFS` (a build-time
-	/// knob) rather than baked in from the benchmark's aggregation size.
-	///
-	/// The compute base prices the *full* production pre-validation (deserialize,
-	/// parse public inputs, build the `ExitBundle`, run segment validation) — the
-	/// same path the `pre_validate_proof` benchmark now executes.
+	/// One `UsedNullifiers` read per leaf proof; compute covers full production
+	/// pre-validation (deserialize, parse, bundle build, segment validation).
 	fn pre_validate_proof() -> Weight {
 		let nullifier_reads = circuit_config::NUM_LEAF_PROOFS as u64;
 		// PoV: 2519 per benchmarked `BlockHash` key + 2524 per `UsedNullifiers` key.
@@ -190,10 +153,8 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 		Weight::from_parts(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// Public-batch pre-validation (`System::BlockHash` r:1 + `UsedNullifiers` r:
-	/// NUM_PRIVATE_BATCH_PROOFS * NUM_LEAF_PROOFS). The compute base prices the full
-	/// production path: deserialize, parse, `ExitBundle::from_public_batch` across
-	/// all inner segments, and segment validation.
+	/// Public-batch pre-validation: `BlockHash` + all inner-segment nullifier reads,
+	/// with full production-path compute.
 	fn pre_validate_public_batch_proof() -> Weight {
 		let nullifier_reads = (circuit_config::NUM_PRIVATE_BATCH_PROOFS *
 			circuit_config::NUM_LEAF_PROOFS) as u64;
@@ -202,15 +163,8 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 		Weight::from_parts(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// Full private-batch proof verification on the inclusion path:
-	/// - `pre_dispatch`: cheap prevalidation + ZK verify
-	/// - dispatch body: cheap prevalidation again (to recover the bundle) + state updates
-	///
-	/// Base = measured ZK verify. Both prevalidations perform the block-hash read and
-	/// the per-leaf `UsedNullifiers` scan, so [`Self::pre_validate_proof`] is charged
-	/// twice *in full* (compute + DB reads + PoV each). Storage is scaled from a
-	/// calibration of 32 exit mints to `2 · NUM_LEAF_PROOFS`. Keep this augmentation
-	/// when regenerating.
+	/// Inclusion path: ZK verify + pre-validation twice (`pre_dispatch` and dispatch
+	/// body), each charged in full (compute + DB + PoV), plus exit-processing storage.
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) =
@@ -221,13 +175,8 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 			.saturating_add(Self::pre_validate_proof())
 			.saturating_add(Self::pre_validate_proof())
 	}
-	/// Public-batch inclusion path: same double-prevalidation shape as
-	/// [`Self::verify_private_batch`], with heavier ZK time and storage scaled across
-	/// all inner segments plus the aggregator rebate.
-	/// [`Self::pre_validate_public_batch_proof`] is charged twice in full: once for
-	/// `pre_dispatch` and once for the dispatch-body re-scan.
-	///
-	/// Re-measure the ZK / pre-validate bases whenever `NUM_PRIVATE_BATCH_PROOFS` changes.
+	/// Same double-prevalidation shape as [`Self::verify_private_batch`], scaled
+	/// across all inner segments plus the aggregator rebate.
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
@@ -304,9 +253,6 @@ mod tests {
 		}
 	}
 
-	/// The exit-verification storage tail must grow with ZK-tree depth: every
-	/// processed exit walks the tree leaf-to-root, so a deeper tree means more real
-	/// database work per exit and the declared weight has to track it.
 	#[test]
 	fn exit_storage_tail_scales_with_tree_depth() {
 		let exits = private_batch_max_exits();
@@ -318,10 +264,7 @@ mod tests {
 		assert!(deep.2 > shallow.2, "proof size must grow with tree depth");
 	}
 
-	/// `SubstrateWeight` must price the tree component from the *live* depth, and the
-	/// depth-blind `()` impl (which prices at `MAX_TREE_DEPTH`) must never charge less
-	/// than `SubstrateWeight` at any live depth. The mock's `DbWeight` is zero, so the
-	/// depth sensitivity is observed through the PoV component.
+	/// Live-depth pricing in `SubstrateWeight`; `()` impl is a worst-case floor.
 	#[test]
 	fn substrate_weight_reads_live_depth_and_unit_impl_is_worst_case() {
 		crate::mock::new_test_ext().execute_with(|| {
@@ -341,12 +284,7 @@ mod tests {
 		});
 	}
 
-	/// Inclusion runs cheap prevalidation twice: once in `pre_dispatch` (via the full
-	/// validate, together with the ZK verify) and once in the dispatch body to recover
-	/// the bundle. Both executions perform the block-hash read and the per-leaf
-	/// `UsedNullifiers` scan, so the declared verify weight must cover TWO complete
-	/// pre-validations — compute, database reads, and proof size — on top of the
-	/// ZK-verify + exit-processing storage tail.
+	/// Verify weights must cover both pre-validations (compute + PoV).
 	#[test]
 	fn verify_weights_cover_both_prevalidations() {
 		crate::mock::new_test_ext().execute_with(|| {
@@ -355,8 +293,6 @@ mod tests {
 			let tree_ops =
 				pallet_zk_tree::Pallet::<crate::mock::Test>::insert_leaf_db_ops();
 
-			// The mock's DbWeight is zero, so ref_time only observes compute here;
-			// the DB-read component is asserted through the `()` impl below.
 			let pre_private = W::pre_validate_proof();
 			let verify_private = W::verify_private_batch();
 			let (_, _, private_tail_pov) =
@@ -388,9 +324,7 @@ mod tests {
 		});
 	}
 
-	/// Same double-prevalidation bound for the `()` impl, where `RocksDbWeight` is
-	/// nonzero: the ref_time assertion here catches a missing pre-dispatch DB-read
-	/// charge that the zero-DbWeight mock cannot observe.
+	/// Same bound on the `()` impl (nonzero `RocksDbWeight` catches missing DB reads).
 	#[test]
 	fn unit_impl_verify_weights_cover_both_prevalidations() {
 		let tree_ops =
@@ -435,22 +369,10 @@ mod tests {
 		);
 	}
 
-	/// The pre-validation compute base must price the *production* path at the
-	/// all-valid worst case, which does strictly more work than the two
-	/// calibrations it replaced: the deserialize-only micro-benchmark (550 µs
-	/// private / 1578 µs public, 2026-07-30) and the fixture-only production run
-	/// whose dummy-padded segments were skipped as inert by `segment_validity`
-	/// (~1.9 ms public, 2026-08-06). Guard both floors so a regenerated weights
-	/// file can't silently regress to either under-measurement.
+	/// Floor so regenerated weights can't under-price the all-valid worst case.
 	#[test]
 	fn pre_validation_compute_covers_production_path() {
-		assert!(
-			PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS > 550_000_000,
-			"private pre-validate compute must exceed the deserialize-only measurement"
-		);
-		assert!(
-			PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS > 1_900_000_000,
-			"public pre-validate compute must exceed the inert-skip fixture measurement"
-		);
+		assert!(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS > 550_000_000);
+		assert!(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS > 1_900_000_000);
 	}
 }

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -197,35 +197,35 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 	/// - `pre_dispatch`: cheap prevalidation + ZK verify
 	/// - dispatch body: cheap prevalidation again (to recover the bundle) + state updates
 	///
-	/// Base = measured ZK verify + one [`Self::pre_validate_proof`] compute (pre_dispatch
-	/// deserialize). Storage is scaled from a calibration of 32 exit mints to
-	/// `2 · NUM_LEAF_PROOFS`, plus a second [`Self::pre_validate_proof`] for the dispatch
-	/// body's re-deserialize / nullifier scan. Keep this augmentation when regenerating.
+	/// Base = measured ZK verify. Both prevalidations perform the block-hash read and
+	/// the per-leaf `UsedNullifiers` scan, so [`Self::pre_validate_proof`] is charged
+	/// twice *in full* (compute + DB reads + PoV each). Storage is scaled from a
+	/// calibration of 32 exit mints to `2 · NUM_LEAF_PROOFS`. Keep this augmentation
+	/// when regenerating.
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
-		let base_ref_time = PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS
-			.saturating_add(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS);
-		Weight::from_parts(base_ref_time, proof_size)
+		Weight::from_parts(PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_proof())
 			.saturating_add(Self::pre_validate_proof())
 	}
 	/// Public-batch inclusion path: same double-prevalidation shape as
 	/// [`Self::verify_private_batch`], with heavier ZK time and storage scaled across
-	/// all inner segments plus the aggregator rebate. The second
-	/// [`Self::pre_validate_public_batch_proof`] covers the dispatch-body re-scan.
+	/// all inner segments plus the aggregator rebate.
+	/// [`Self::pre_validate_public_batch_proof`] is charged twice in full: once for
+	/// `pre_dispatch` and once for the dispatch-body re-scan.
 	///
 	/// Re-measure the ZK / pre-validate bases whenever `NUM_PRIVATE_BATCH_PROOFS` changes.
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
-		let base_ref_time = PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS
-			.saturating_add(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS);
-		Weight::from_parts(base_ref_time, proof_size)
+		Weight::from_parts(PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_public_batch_proof())
 			.saturating_add(Self::pre_validate_public_batch_proof())
 	}
 }
@@ -253,22 +253,20 @@ impl WeightInfo for () {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
-		let base_ref_time = PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS
-			.saturating_add(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS);
-		Weight::from_parts(base_ref_time, proof_size)
+		Weight::from_parts(PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_proof())
 			.saturating_add(Self::pre_validate_proof())
 	}
 	/// See `SubstrateWeight::verify_public_batch`.
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
-		let base_ref_time = PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS
-			.saturating_add(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS);
-		Weight::from_parts(base_ref_time, proof_size)
+		Weight::from_parts(PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
+			.saturating_add(Self::pre_validate_public_batch_proof())
 			.saturating_add(Self::pre_validate_public_batch_proof())
 	}
 }
@@ -334,43 +332,98 @@ mod tests {
 		});
 	}
 
-	/// Inclusion runs cheap prevalidation twice (`pre_dispatch` via full validate, then
-	/// again in the dispatch body to recover the bundle). The declared verify weight must
-	/// cover that second prevalidation on top of the ZK+storage base.
+	/// Inclusion runs cheap prevalidation twice: once in `pre_dispatch` (via the full
+	/// validate, together with the ZK verify) and once in the dispatch body to recover
+	/// the bundle. Both executions perform the block-hash read and the per-leaf
+	/// `UsedNullifiers` scan, so the declared verify weight must cover TWO complete
+	/// pre-validations — compute, database reads, and proof size — on top of the
+	/// ZK-verify + exit-processing storage tail.
 	#[test]
-	fn verify_weights_cover_second_prevalidation() {
+	fn verify_weights_cover_both_prevalidations() {
 		crate::mock::new_test_ext().execute_with(|| {
 			type W = SubstrateWeight<crate::mock::Test>;
 			pallet_zk_tree::Depth::<crate::mock::Test>::put(1);
+			let tree_ops =
+				pallet_zk_tree::Pallet::<crate::mock::Test>::insert_leaf_db_ops();
 
+			// The mock's DbWeight is zero, so ref_time only observes compute here;
+			// the DB-read component is asserted through the `()` impl below.
 			let pre_private = W::pre_validate_proof();
 			let verify_private = W::verify_private_batch();
+			let (_, _, private_tail_pov) =
+				storage_tail(private_batch_max_exits(), false, tree_ops);
 			assert!(
 				verify_private.ref_time() >=
-					PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS +
-						PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS +
-						pre_private.ref_time(),
-				"private verify must include a second pre_validate_proof compute cost"
+					PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS + 2 * pre_private.ref_time(),
+				"private verify must include both pre-validation compute costs"
 			);
 			assert!(
-				verify_private.proof_size() >= pre_private.proof_size(),
-				"private verify must include pre_validate PoV"
+				verify_private.proof_size() >=
+					private_tail_pov + 2 * pre_private.proof_size(),
+				"private verify must include both pre-validations' PoV on top of the storage tail"
 			);
 
 			let pre_public = W::pre_validate_public_batch_proof();
 			let verify_public = W::verify_public_batch();
+			let (_, _, public_tail_pov) =
+				storage_tail(public_batch_max_exits(), true, tree_ops);
 			assert!(
 				verify_public.ref_time() >=
-					PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS +
-						PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS +
-						pre_public.ref_time(),
-				"public verify must include a second pre_validate_public_batch_proof compute cost"
+					PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS + 2 * pre_public.ref_time(),
+				"public verify must include both pre-validation compute costs"
 			);
 			assert!(
-				verify_public.proof_size() >= pre_public.proof_size(),
-				"public verify must include public pre_validate PoV"
+				verify_public.proof_size() >= public_tail_pov + 2 * pre_public.proof_size(),
+				"public verify must include both pre-validations' PoV on top of the storage tail"
 			);
 		});
+	}
+
+	/// Same double-prevalidation bound for the `()` impl, where `RocksDbWeight` is
+	/// nonzero: the ref_time assertion here catches a missing pre-dispatch DB-read
+	/// charge that the zero-DbWeight mock cannot observe.
+	#[test]
+	fn unit_impl_verify_weights_cover_both_prevalidations() {
+		let tree_ops =
+			pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
+
+		let pre_private = <() as WeightInfo>::pre_validate_proof();
+		let verify_private = <() as WeightInfo>::verify_private_batch();
+		let (reads, writes, private_tail_pov) =
+			storage_tail(private_batch_max_exits(), false, tree_ops);
+		let private_tail_time = RocksDbWeight::get()
+			.reads(reads)
+			.saturating_add(RocksDbWeight::get().writes(writes))
+			.ref_time();
+		assert!(
+			verify_private.ref_time() >=
+				PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS +
+					private_tail_time + 2 * pre_private.ref_time(),
+			"private verify must charge both pre-validations' DB reads"
+		);
+		assert!(
+			verify_private.proof_size() >= private_tail_pov + 2 * pre_private.proof_size(),
+			"private verify must charge both pre-validations' PoV"
+		);
+
+		let pre_public = <() as WeightInfo>::pre_validate_public_batch_proof();
+		let verify_public = <() as WeightInfo>::verify_public_batch();
+		let (reads, writes, public_tail_pov) =
+			storage_tail(public_batch_max_exits(), true, tree_ops);
+		let public_tail_time = RocksDbWeight::get()
+			.reads(reads)
+			.saturating_add(RocksDbWeight::get().writes(writes))
+			.ref_time();
+		assert!(
+			verify_public.ref_time() >=
+				PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS +
+					public_tail_time + 2 * pre_public.ref_time(),
+			"public verify must charge both pre-validations' DB reads"
+		);
+		assert!(
+			verify_public.proof_size() >= public_tail_pov + 2 * pre_public.proof_size(),
+			"public verify must charge both pre-validations' PoV"
+		);
 	}
 
 	/// The pre-validation compute base must price the *production* path, which does

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -61,6 +61,34 @@ pub trait WeightInfo {
 	fn verify_public_batch() -> Weight;
 }
 
+/// Measured compute base for the production `pre_validate_private_batch_proof`
+/// path (proof deserialization + public-input parsing + `ExitBundle` construction +
+/// `validate_exit_bundle_common` segment validation).
+///
+/// Calibration 2026-08-06: the full production path measured 176 µs native-release
+/// against 163 µs for deserialization alone; scaled by this path's observed
+/// wasm-compiled factor (550 µs / 163 µs ≈ 3.4× from the 2026-07-30 benchmark run)
+/// that is ~597 µs, padded to 700 µs. Re-run the `pre_validate_proof` benchmark
+/// (which now executes the production path) to regenerate.
+const PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 700_000_000;
+
+/// Measured compute base for the production `pre_validate_public_batch_proof` path
+/// (deserialization + parsing + `ExitBundle::from_public_batch` across all
+/// `NUM_PRIVATE_BATCH_PROOFS` segments + full segment validation).
+///
+/// Calibration 2026-08-06 at NUM_PRIVATE_BATCH_PROOFS=53: full production path
+/// 237 µs native-release vs 223 µs deserialize-only; scaled by this path's
+/// wasm-compiled factor (1578 µs / 223 µs ≈ 7.1×) that is ~1.68 ms, padded to
+/// 1.9 ms. Re-run the `pre_validate_public_batch_proof` benchmark to regenerate.
+const PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS: u64 = 1_900_000_000;
+
+/// Measured ZK verification time for a private-batch proof (2026-07-30).
+const PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS: u64 = 14_965_000_000;
+
+/// Measured ZK verification time for a public-batch proof (2026-07-30,
+/// NUM_PRIVATE_BATCH_PROOFS=53).
+const PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS: u64 = 20_686_000_000;
+
 /// Historical hand-augmentation calibrated for a private-batch of 16 leaves
 /// (2 exit slots/leaf → 32 exit mints). See `verify_private_batch` docs.
 const STORAGE_CALIBRATION_EXITS: u64 = 32;
@@ -142,25 +170,27 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 	/// The nullifier existence scan reads one `UsedNullifiers` key per leaf proof, so
 	/// reads and PoV are derived from `circuit_config::NUM_LEAF_PROOFS` (a build-time
 	/// knob) rather than baked in from the benchmark's aggregation size.
+	///
+	/// The compute base prices the *full* production pre-validation (deserialize,
+	/// parse public inputs, build the `ExitBundle`, run segment validation) — the
+	/// same path the `pre_validate_proof` benchmark now executes.
 	fn pre_validate_proof() -> Weight {
 		let nullifier_reads = circuit_config::NUM_LEAF_PROOFS as u64;
 		// PoV: 2519 per benchmarked `BlockHash` key + 2524 per `UsedNullifiers` key.
 		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
-		// Measured 2026-07-30: 550_000_000 picoseconds (7 nullifier reads).
-		Weight::from_parts(550_000_000, proof_size)
+		Weight::from_parts(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// Public-batch pre-validation: deserialize + nullifier scan across all inner
-	/// segments (`System::BlockHash` r:1 + `UsedNullifiers` r:
-	/// NUM_PRIVATE_BATCH_PROOFS * NUM_LEAF_PROOFS).
+	/// Public-batch pre-validation (`System::BlockHash` r:1 + `UsedNullifiers` r:
+	/// NUM_PRIVATE_BATCH_PROOFS * NUM_LEAF_PROOFS). The compute base prices the full
+	/// production path: deserialize, parse, `ExitBundle::from_public_batch` across
+	/// all inner segments, and segment validation.
 	fn pre_validate_public_batch_proof() -> Weight {
 		let nullifier_reads = (circuit_config::NUM_PRIVATE_BATCH_PROOFS *
 			circuit_config::NUM_LEAF_PROOFS) as u64;
 		// PoV: 2519 per benchmarked `BlockHash` key + 2524 per `UsedNullifiers` key.
 		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
-		// Measured 2026-07-30 at NUM_PRIVATE_BATCH_PROOFS=53 (371 nullifier reads):
-		// 1_578_000_000 picoseconds.
-		Weight::from_parts(1_578_000_000, proof_size)
+		Weight::from_parts(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(T::DbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
 	/// Full private-batch proof verification on the inclusion path:
@@ -175,8 +205,9 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
-		// Measured 2026-07-30: ZK verify 14_965_000_000 + pre_validate 550_000_000.
-		Weight::from_parts(15_515_000_000, proof_size)
+		let base_ref_time = PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS
+			.saturating_add(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS);
+		Weight::from_parts(base_ref_time, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
 			.saturating_add(Self::pre_validate_proof())
@@ -190,9 +221,9 @@ impl<T: frame_system::Config + pallet_zk_tree::Config> WeightInfo for SubstrateW
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::Pallet::<T>::insert_leaf_db_ops();
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
-		// Measured 2026-07-30 at NUM_PRIVATE_BATCH_PROOFS=53:
-		// ZK verify 20_686_000_000 + pre_validate_public 1_578_000_000.
-		Weight::from_parts(22_264_000_000, proof_size)
+		let base_ref_time = PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS
+			.saturating_add(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS);
+		Weight::from_parts(base_ref_time, proof_size)
 			.saturating_add(T::DbWeight::get().reads(reads))
 			.saturating_add(T::DbWeight::get().writes(writes))
 			.saturating_add(Self::pre_validate_public_batch_proof())
@@ -205,7 +236,7 @@ impl WeightInfo for () {
 	fn pre_validate_proof() -> Weight {
 		let nullifier_reads = circuit_config::NUM_LEAF_PROOFS as u64;
 		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
-		Weight::from_parts(550_000_000, proof_size)
+		Weight::from_parts(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
 	/// See `SubstrateWeight::pre_validate_public_batch_proof`.
@@ -213,7 +244,7 @@ impl WeightInfo for () {
 		let nullifier_reads = (circuit_config::NUM_PRIVATE_BATCH_PROOFS *
 			circuit_config::NUM_LEAF_PROOFS) as u64;
 		let proof_size = 2519_u64.saturating_add(nullifier_reads.saturating_mul(2524));
-		Weight::from_parts(1_578_000_000, proof_size)
+		Weight::from_parts(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
 	/// See `SubstrateWeight::verify_private_batch`. Tree component priced at
@@ -222,7 +253,9 @@ impl WeightInfo for () {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) =
 			storage_tail(private_batch_max_exits(), false, tree_ops);
-		Weight::from_parts(15_515_000_000, proof_size)
+		let base_ref_time = PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS
+			.saturating_add(PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS);
+		Weight::from_parts(base_ref_time, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
 			.saturating_add(Self::pre_validate_proof())
@@ -231,7 +264,9 @@ impl WeightInfo for () {
 	fn verify_public_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::insert_leaf_db_ops_at_depth(pallet_zk_tree::MAX_TREE_DEPTH);
 		let (reads, writes, proof_size) = storage_tail(public_batch_max_exits(), true, tree_ops);
-		Weight::from_parts(22_264_000_000, proof_size)
+		let base_ref_time = PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS
+			.saturating_add(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS);
+		Weight::from_parts(base_ref_time, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(reads))
 			.saturating_add(RocksDbWeight::get().writes(writes))
 			.saturating_add(Self::pre_validate_public_batch_proof())
@@ -311,7 +346,10 @@ mod tests {
 			let pre_private = W::pre_validate_proof();
 			let verify_private = W::verify_private_batch();
 			assert!(
-				verify_private.ref_time() >= 15_515_000_000 + pre_private.ref_time(),
+				verify_private.ref_time() >=
+					PRIVATE_BATCH_ZK_VERIFY_REF_TIME_PS +
+						PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS +
+						pre_private.ref_time(),
 				"private verify must include a second pre_validate_proof compute cost"
 			);
 			assert!(
@@ -322,7 +360,10 @@ mod tests {
 			let pre_public = W::pre_validate_public_batch_proof();
 			let verify_public = W::verify_public_batch();
 			assert!(
-				verify_public.ref_time() >= 22_264_000_000 + pre_public.ref_time(),
+				verify_public.ref_time() >=
+					PUBLIC_BATCH_ZK_VERIFY_REF_TIME_PS +
+						PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS +
+						pre_public.ref_time(),
 				"public verify must include a second pre_validate_public_batch_proof compute cost"
 			);
 			assert!(
@@ -330,5 +371,22 @@ mod tests {
 				"public verify must include public pre_validate PoV"
 			);
 		});
+	}
+
+	/// The pre-validation compute base must price the *production* path, which does
+	/// strictly more work than the deserialize-only micro-benchmark it replaced
+	/// (public-input parsing, bundle construction, segment validation). Guard the
+	/// calibrated floor so a regenerated weights file can't silently regress to the
+	/// old deserialize-only figures (550 µs private / 1578 µs public, 2026-07-30).
+	#[test]
+	fn pre_validation_compute_covers_production_path() {
+		assert!(
+			PRIVATE_BATCH_PRE_VALIDATE_REF_TIME_PS > 550_000_000,
+			"private pre-validate compute must exceed the deserialize-only measurement"
+		);
+		assert!(
+			PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS > 1_578_000_000,
+			"public pre-validate compute must exceed the deserialize-only measurement"
+		);
 	}
 }

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -60,35 +60,20 @@ pub fn insert_leaf_db_ops_at_depth(depth: u8) -> (u64, u64) {
 	(3 * d + 4, d + 5)
 }
 
-/// Conservative worst-case execution time (`ref_time`, picoseconds) of one Poseidon
-/// evaluation as performed by [`tree::hash_node`] / [`tree::hash_leaf`].
-///
-/// Measured at ~3.3µs per `hash_node` call in a native release build (see the
-/// `measure_hash_node_time` ignored test in `tree.rs`); padded ~15x for wasm
-/// execution overhead and slower reference hardware. Over-charging is the safe
-/// direction for a mandatory hook's reserved weight.
+/// Worst-case `ref_time` (picoseconds) of one Poseidon evaluation
+/// ([`tree::hash_node`] / [`tree::hash_leaf`]). Padded for wasm / slower hardware.
 pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 50_000_000;
 
-/// Number of Poseidon evaluations one [`Pallet::insert_leaf`] performs when the tree
-/// is currently at `depth`.
-///
-/// Like [`insert_leaf_db_ops_at_depth`], costing is done at `depth + 1` (capped at
-/// [`MAX_TREE_DEPTH`]) so an insert that triggers tree growth is covered. At
-/// effective depth `d`: `hash_leaf` (1) + `update_path`'s per-level `hash_node` (d)
-/// + `grow_tree`'s `hash_node` (1).
+/// Poseidon evaluations for one [`Pallet::insert_leaf`] at `depth`
+/// (`hash_leaf` + per-level `hash_node` + grow). Costed at `depth + 1` like
+/// [`insert_leaf_db_ops_at_depth`].
 pub fn insert_leaf_poseidon_evals_at_depth(depth: u8) -> u64 {
 	let d = depth.saturating_add(1).min(MAX_TREE_DEPTH) as u64;
 	d + 2
 }
 
-/// Depth-dependent compute cost (`ref_time`, picoseconds) of one
-/// [`Pallet::insert_leaf`] at the given current `depth`.
-///
-/// `update_path` walks the tree leaf-to-root invoking a Poseidon hash at every
-/// level, so the insert's CPU work — not just its database work — grows with tree
-/// depth. Weight metering that scales [`insert_leaf_db_ops_at_depth`] with depth
-/// must scale this compute component the same way, otherwise the declared
-/// `ref_time` silently falls behind the real hashing work as the tree deepens.
+/// Depth-dependent insert compute (`ref_time`); scales with tree depth the same
+/// way as [`insert_leaf_db_ops_at_depth`].
 pub fn insert_leaf_hash_ref_time_at_depth(depth: u8) -> u64 {
 	insert_leaf_poseidon_evals_at_depth(depth).saturating_mul(POSEIDON_EVAL_REF_TIME_PS)
 }

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -78,6 +78,13 @@ pub fn insert_leaf_hash_ref_time_at_depth(depth: u8) -> u64 {
 	insert_leaf_poseidon_evals_at_depth(depth).saturating_mul(POSEIDON_EVAL_REF_TIME_PS)
 }
 
+/// Conservative PoV bound (bytes) per ZK-tree storage key touched during a path
+/// update. Tree entries are 32-byte hashes with small keys; comparable to the
+/// benchmarked `ZkTree::Leaves` / `UsedNullifiers` `added` figures (~2524–2543).
+/// Callers that scale insert weight with [`insert_leaf_db_ops_at_depth`] should
+/// use this for the proof-size term so all pallets share one assumption.
+pub const TREE_KEY_POV: u64 = 2600;
+
 /// Branching factor of the tree.
 pub const ARITY: usize = 4;
 

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -60,6 +60,39 @@ pub fn insert_leaf_db_ops_at_depth(depth: u8) -> (u64, u64) {
 	(3 * d + 4, d + 5)
 }
 
+/// Conservative worst-case execution time (`ref_time`, picoseconds) of one Poseidon
+/// evaluation as performed by [`tree::hash_node`] / [`tree::hash_leaf`].
+///
+/// Measured at ~3.3µs per `hash_node` call in a native release build (see the
+/// `measure_hash_node_time` ignored test in `tree.rs`); padded ~15x for wasm
+/// execution overhead and slower reference hardware. Over-charging is the safe
+/// direction for a mandatory hook's reserved weight.
+pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 50_000_000;
+
+/// Number of Poseidon evaluations one [`Pallet::insert_leaf`] performs when the tree
+/// is currently at `depth`.
+///
+/// Like [`insert_leaf_db_ops_at_depth`], costing is done at `depth + 1` (capped at
+/// [`MAX_TREE_DEPTH`]) so an insert that triggers tree growth is covered. At
+/// effective depth `d`: `hash_leaf` (1) + `update_path`'s per-level `hash_node` (d)
+/// + `grow_tree`'s `hash_node` (1).
+pub fn insert_leaf_poseidon_evals_at_depth(depth: u8) -> u64 {
+	let d = depth.saturating_add(1).min(MAX_TREE_DEPTH) as u64;
+	d + 2
+}
+
+/// Depth-dependent compute cost (`ref_time`, picoseconds) of one
+/// [`Pallet::insert_leaf`] at the given current `depth`.
+///
+/// `update_path` walks the tree leaf-to-root invoking a Poseidon hash at every
+/// level, so the insert's CPU work — not just its database work — grows with tree
+/// depth. Weight metering that scales [`insert_leaf_db_ops_at_depth`] with depth
+/// must scale this compute component the same way, otherwise the declared
+/// `ref_time` silently falls behind the real hashing work as the tree deepens.
+pub fn insert_leaf_hash_ref_time_at_depth(depth: u8) -> u64 {
+	insert_leaf_poseidon_evals_at_depth(depth).saturating_mul(POSEIDON_EVAL_REF_TIME_PS)
+}
+
 /// Branching factor of the tree.
 pub const ARITY: usize = 4;
 

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -525,6 +525,36 @@ fn integration_root_changes_only_on_insert() {
 }
 
 #[test]
+fn insert_leaf_hash_compute_scales_with_depth_and_is_capped() {
+	// `update_path` performs one Poseidon hash per tree level (plus `hash_leaf`
+	// and `grow_tree`'s extra `hash_node`), so the compute cost of an insert must
+	// grow with depth exactly like its db ops — weight metering that scales only
+	// the reads/writes silently under-reserves CPU as the tree deepens.
+	//
+	// Priced at `depth + 1` (growth-covering), capped at MAX_TREE_DEPTH, with
+	// `hash_leaf` + `grow_tree` on top: effective_d + 2 evaluations.
+	assert_eq!(insert_leaf_poseidon_evals_at_depth(0), 3);
+	assert_eq!(insert_leaf_poseidon_evals_at_depth(1), 4);
+	assert_eq!(
+		insert_leaf_poseidon_evals_at_depth(MAX_TREE_DEPTH),
+		MAX_TREE_DEPTH as u64 + 2,
+		"cost at MAX_TREE_DEPTH must stay capped at the max effective depth"
+	);
+
+	for depth in 0..MAX_TREE_DEPTH {
+		assert!(
+			insert_leaf_hash_ref_time_at_depth(depth + 1) >=
+				insert_leaf_hash_ref_time_at_depth(depth),
+			"hash compute must be monotone in depth"
+		);
+	}
+	assert_eq!(
+		insert_leaf_hash_ref_time_at_depth(5),
+		insert_leaf_poseidon_evals_at_depth(5) * POSEIDON_EVAL_REF_TIME_PS
+	);
+}
+
+#[test]
 fn integration_proof_siblings_at_correct_depth() {
 	new_test_ext().execute_with(|| {
 		// Insert 5 leaves to force depth 2

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -382,6 +382,24 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore]
+	fn measure_hash_node_time() {
+		let mut acc = [7u8; 32];
+		let siblings = [[1u8; 32], [2u8; 32], [3u8; 32]];
+		// Warm up
+		for _ in 0..1000 {
+			acc = hash_node(&[acc, siblings[0], siblings[1], siblings[2]]);
+		}
+		let n = 100_000u32;
+		let start = std::time::Instant::now();
+		for _ in 0..n {
+			acc = hash_node(&[acc, siblings[0], siblings[1], siblings[2]]);
+		}
+		let elapsed = start.elapsed();
+		println!("hash_node: {} ns/call over {} calls (sink {:?})", elapsed.as_nanos() / n as u128, n, acc[0]);
+	}
+
+	#[test]
 	fn canonicalize_is_identity_on_canonical_accounts() {
 		// All limbs < p (largest canonical limb is p - 1).
 		let mut bytes = [0x11u8; 32];

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -396,7 +396,12 @@ mod tests {
 			acc = hash_node(&[acc, siblings[0], siblings[1], siblings[2]]);
 		}
 		let elapsed = start.elapsed();
-		println!("hash_node: {} ns/call over {} calls (sink {:?})", elapsed.as_nanos() / n as u128, n, acc[0]);
+		println!(
+			"hash_node: {} ns/call over {} calls (sink {:?})",
+			elapsed.as_nanos() / n as u128,
+			n,
+			acc[0]
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
# Security review remediations: weight accounting, wormhole exit settlement, reward retention, RPC admission

This PR addresses seven security-review findings across `pallet-mining-rewards`, `pallet-wormhole`, `pallet-zk-tree`, and the node RPC layer. Each finding was independently verified, covered by a failing (red) test where applicable, fixed, and re-verified green.

## Findings and fixes

### 1. Mining-rewards finalize weight: incomplete fixed base (`64a840e0`)

`on_finalize_rewarded_miner` priced only two of the three reachable mint/transfer-record pairs and omitted the conditional `PotentialWormholeBalance` mutation for ambiguous recipients. `BASE_READS`/`BASE_WRITES` now cover all three reward transfers (miner, treasury, fee destination) including the ambiguous-recipient update, with a test asserting the complete worst-case bound.

### 2. Exit-bundle fees settled from unminted value (`9702c822`)

`process_exit_bundle` emitted `ProofVerified` and settled the volume fee (burn / miner / aggregator) from the *attempted* `total_exit_amount` before any recipient credit ran, so a failed exit mint still had fee-derived value burned or paid out, and the event over-reported the minted amount. Exit minting now runs first, and the event and all fee math use `minted_exit_amount` — only value that was actually credited. Skipped slots keep their nullifiers marked (no re-exit) and stay out of `TotalWormholeExits`.

### 3. Finalize weight blind to tree-depth compute (`4b78638d`)

The finalize weight scaled DB operations with ZK-tree depth but reserved a flat compute base, even though `update_path` performs one Poseidon hash per tree level per inserted leaf. Added `POSEIDON_EVAL_REF_TIME_PS` (50 µs, calibrated from a native measurement of ~3.3 µs/hash with WASM margin) and depth-scaled helpers in `pallet-zk-tree`; the mining-rewards finalize weight now prices per-level hashing at `MAX_TREE_DEPTH` for all three inserts.

### 4. Failed treasury mints permanently dropped rewards (`5173f3c9`)

If minting the treasury's reward share failed (e.g. treasury account reaped and the amount below the existential deposit), the amount was silently lost, breaking supply-schedule accounting. Failed mint amounts are now rolled back into the existing `CollectedFees` storage — no new state — where the normal `on_finalize` flow retries them next block toward the miner or treasury fallback. Tests cover recovery, accumulation across consecutive outage blocks, and destination-following on retry.

### 5. Pre-validation benchmarks measured a stripped-down path (`4b88a1d8`)

The `pre_validate_proof` / `pre_validate_public_batch_proof` benchmarks measured only proof deserialization plus a raw nullifier scan, omitting public-input parsing, `ExitBundle` construction, and `validate_exit_bundle_common` segment validation. Both benchmarks now execute the production `pre_validate_*_batch_proof` functions end to end against worst-case state (fixture block hash present, decoy-populated `UsedNullifiers`, all segments valid). The compute bases were recalibrated (700 µs private / 1.9 ms public, native measurement scaled by each path's observed WASM factor) and restructured into named constants shared by the verify weights, with a floor test preventing regression to the deserialize-only figures.

### 6. RPC module assembly admission model (`eda2e97f` — docs only, assessed as by-design)

The report flagged `create_full` for merging all RPC modules without a top-level gate. Verified this matches upstream Substrate's intended design: admission is per method against the per-connection `DenyUnsafe` policy injected by the standard RPC server, and every merged method is correctly classified (`system_dryRun` and `peer_getNetworkInfo` unsafe-gated; nonce/fee/zkTree/txWatch methods safe with bounded per-request work). Added an "RPC admission model" doc contract on `create_full` requiring explicit classification for any future module.

### 7. Verify weights charged pre-dispatch reads/PoV only once (`a5b629ee`)

The inclusion path runs pre-validation twice — in `pre_dispatch` (with ZK verify) and again in the dispatch body — but `verify_*_batch` charged the first run's compute only, dropping its DB reads and proof size (372 reads / ~939 KB PoV per public-batch extrinsic). The verify weights now add the full `pre_validate_*()` weight twice on top of the ZK-verify base, with coverage tests on both weight impls asserting the double charge across compute, DB time, and PoV.

## Testing

- Red tests written first for every code-change item, confirmed failing against the pre-fix behavior, green after.
- Full test suites pass: `pallet-mining-rewards`, `pallet-wormhole` (65 tests), `pallet-zk-tree`.
- Benchmark test suite passes under `--features runtime-benchmarks` (the new benchmarks fail loudly if the production path errors).
- Runtime compiles with and without `runtime-benchmarks`.
- Ignored calibration harnesses (`measure_hash_node_time`, `measure_pre_validation_time`) are checked in for reproducing the weight measurements.