### PR TITLE
Fork off

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8823,6 +8823,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.18",
 ]

--- a/MINING.md
+++ b/MINING.md
@@ -352,8 +352,9 @@ service and must never be reachable from the open internet.
 | `--prometheus-port` | Metrics endpoint port | `9616` |
 | `--name` | Node display name | Auto-generated |
 | `--base-path` | Data directory | `~/.local/share/quantus-node` |
+| `--disallowed-runtimes-file` | JSON list of runtime wasm hashes this node will refuse to import | `{base-path}/chains/<chain>/disallowed-runtimes.json` (created empty on first start) |
 
-
+To opt out of a contested runtime upgrade on this node only, add the Blake2-256 `0x…` hash of the proposed wasm to that file before the upgrade enacts. See [docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md](docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md).
 
 ## Monitoring Your Node
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,26 @@ ls ./my-chain-state
 ls ./my-chain-state/chains/
 # dev
 ls ./my-chain-state/chains/dev
-# db keystore network
+# db keystore network disallowed-runtimes.json
 ```
+
+#### Refusing a runtime upgrade
+
+Nodes accept forkless runtime upgrades by default. To refuse a specific upgrade on **this** node, add its Blake2-256 wasm hash to the disallow-list (created empty on first start):
+
+```text
+{base-path}/chains/<chain>/disallowed-runtimes.json
+```
+
+```json
+{
+  "disallowed_code_hashes": [
+    "0x…"
+  ]
+}
+```
+
+The file is re-read on every `:code` change (no restart required). Override the path with `--disallowed-runtimes-file`. See [docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md](docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md).
 
 ### Multi-Node Local Testnet
 

--- a/client/consensus/qpow/Cargo.toml
+++ b/client/consensus/qpow/Cargo.toml
@@ -26,6 +26,7 @@ sp-consensus-qpow = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = true }
 sp-inherents = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = false }
+sp-state-machine = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 
 [features]
@@ -38,4 +39,5 @@ std = [
 	"sp-api/std",
 	"sp-consensus-qpow/std",
 	"sp-runtime/std",
+	"sp-state-machine/std",
 ]

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -195,9 +195,8 @@ where
 
 		let parent_hash = *block_import_params.header.parent_hash();
 		let maybe_new_code = match &mut block_import_params.state_action {
-			StateAction::ApplyChanges(StorageChanges::Changes(changes)) => {
-				extract_code_change(changes)
-			},
+			StateAction::ApplyChanges(StorageChanges::Changes(changes)) =>
+				extract_code_change(changes),
 			StateAction::ApplyChanges(StorageChanges::Import(_)) => {
 				log::warn!(
 					target: LOG_TARGET,
@@ -519,13 +518,12 @@ where
 	let header = &mut block.header;
 	let block_hash = hash;
 	let seal_item = match header.digest_mut().pop() {
-		Some(DigestItem::Seal(id, seal)) => {
+		Some(DigestItem::Seal(id, seal)) =>
 			if id == POW_ENGINE_ID {
 				DigestItem::Seal(id, seal)
 			} else {
 				return Err(Error::<B>::WrongEngine(id).into());
-			}
-		},
+			},
 		_ => return Err(Error::<B>::HeaderUnsealed(block_hash).into()),
 	};
 

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -11,7 +11,7 @@ use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
 use sp_consensus_qpow::{QPoWApi, Seal as RawSeal};
 use sp_runtime::traits::Block as BlockT;
-use std::{marker::PhantomData, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use codec::Encode;
 use qp_header::DIGEST_LOGS_SIZE;
@@ -21,16 +21,18 @@ pub use crate::worker::{MiningBuild, MiningHandle, MiningMetadata, RebuildTrigge
 use futures::{Future, Stream, StreamExt};
 use log::*;
 use prometheus_endpoint::Registry;
-use sc_client_api::{self, backend::AuxStore, BlockOf, BlockchainEvents};
+use sc_client_api::{self, backend::AuxStore, BlockOf, BlockchainEvents, TrieCacheContext};
 use sc_consensus::{
 	BasicQueue, BlockCheckParams, BlockImport, BlockImportParams, BoxBlockImport,
-	BoxJustificationImport, ForkChoiceStrategy, ImportResult, JustificationSyncLink, Verifier,
+	BoxJustificationImport, ForkChoiceStrategy, ImportResult, JustificationSyncLink, StateAction,
+	StorageChanges, Verifier,
 };
+use sp_api::{ApiExt, CallContext, Core as CoreApi};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{Environment, Error as ConsensusError, Proposer, SyncOracle};
 use sp_consensus_qpow::POW_ENGINE_ID;
-
+use sp_core::storage::well_known_keys;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::{
 	generic::{Digest, DigestItem},
@@ -82,6 +84,17 @@ pub enum Error<B: BlockT> {
 	Runtime(String),
 	#[error("{0}")]
 	Other(String),
+	#[error("Runtime code hash is disallowed by local node policy: {0}")]
+	DisallowedRuntimeCode(String),
+}
+
+/// Local policy that may reject a newly enacted runtime wasm blob.
+///
+/// Called only when a block changes `:code`. Implementations should re-read any
+/// backing policy file on each call so operators can update it without restarting.
+pub trait RuntimeCodeGate: Send + Sync {
+	/// Return `Ok(())` to accept the new code, or `Err(reason)` to reject the block.
+	fn allow_new_code(&self, code: &[u8]) -> Result<(), String>;
 }
 
 impl<B: BlockT> From<Error<B>> for String {
@@ -100,9 +113,11 @@ impl<B: BlockT> From<Error<B>> for ConsensusError {
 pub struct PowBlockImport<B: BlockT<Hash = H256>, I, C, CIDP, BE, const LOGGING_FREQUENCY: u64> {
 	inner: I,
 	client: Arc<C>,
+	backend: Arc<BE>,
 	create_inherent_data_providers: Arc<CIDP>,
 	check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
-	_backend: PhantomData<BE>,
+	/// Optional local gate that can refuse blocks which change `:code`.
+	code_gate: Option<Arc<dyn RuntimeCodeGate>>,
 }
 
 impl<
@@ -118,9 +133,10 @@ impl<
 		Self {
 			inner: self.inner.clone(),
 			client: self.client.clone(),
+			backend: self.backend.clone(),
 			create_inherent_data_providers: self.create_inherent_data_providers.clone(),
 			check_inherents_after: self.check_inherents_after,
-			_backend: PhantomData,
+			code_gate: self.code_gate.clone(),
 		}
 	}
 }
@@ -141,6 +157,7 @@ where
 		+ 'static,
 	C::Api: QPoWApi<B>,
 	C::Api: BlockBuilderApi<B>,
+	C::Api: CoreApi<B> + ApiExt<B>,
 	CIDP: CreateInherentDataProviders<B, ()>,
 	BE: sc_client_api::Backend<B>,
 {
@@ -148,16 +165,84 @@ where
 	pub fn new(
 		inner: I,
 		client: Arc<C>,
+		backend: Arc<BE>,
 		check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
 		create_inherent_data_providers: CIDP,
+		code_gate: Option<Arc<dyn RuntimeCodeGate>>,
 	) -> Self {
 		Self {
 			inner,
 			client,
+			backend,
 			check_inherents_after,
 			create_inherent_data_providers: Arc::new(create_inherent_data_providers),
-			_backend: PhantomData,
+			code_gate,
 		}
+	}
+
+	/// If this block changes `:code`, consult [`RuntimeCodeGate`].
+	///
+	/// When `state_action` is `Execute`, the block is executed once here and the
+	/// resulting storage changes are installed as `ApplyChanges` so the client
+	/// does not re-execute.
+	fn enforce_runtime_code_policy(
+		&self,
+		block_import_params: &mut BlockImportParams<B>,
+	) -> Result<(), Error<B>> {
+		let Some(gate) = self.code_gate.as_ref() else {
+			return Ok(());
+		};
+
+		let parent_hash = *block_import_params.header.parent_hash();
+		let maybe_new_code = match &mut block_import_params.state_action {
+			StateAction::ApplyChanges(StorageChanges::Changes(changes)) => {
+				extract_code_change(changes)
+			},
+			StateAction::ApplyChanges(StorageChanges::Import(_)) => {
+				log::warn!(
+					target: LOG_TARGET,
+					"Skipping runtime disallow-list check for full-state import"
+				);
+				None
+			},
+			StateAction::Skip => None,
+			StateAction::Execute | StateAction::ExecuteIfPossible => {
+				let Some(body) = block_import_params.body.clone() else {
+					return Ok(());
+				};
+
+				let mut runtime_api = self.client.runtime_api();
+				runtime_api.set_call_context(CallContext::Onchain);
+				runtime_api
+					.execute_block(
+						parent_hash,
+						B::new(block_import_params.header.clone(), body).into(),
+					)
+					.map_err(|e| Error::Client(e.into()))?;
+
+				let state = self
+					.backend
+					.state_at(parent_hash, TrieCacheContext::Untrusted)
+					.map_err(Error::Client)?;
+				let changes = runtime_api
+					.into_storage_changes(&state, parent_hash)
+					.map_err(|e| Error::Other(format!("storage changes: {e}")))?;
+
+				if block_import_params.header.state_root() != &changes.transaction_storage_root {
+					return Err(Error::Other("Invalid state root after pre-execution".into()));
+				}
+
+				let new_code = extract_code_change(&changes);
+				block_import_params.state_action =
+					StateAction::ApplyChanges(StorageChanges::Changes(changes));
+				new_code
+			},
+		};
+
+		if let Some(code) = maybe_new_code {
+			gate.allow_new_code(&code).map_err(Error::DisallowedRuntimeCode)?;
+		}
+		Ok(())
 	}
 
 	async fn check_inherents(
@@ -194,6 +279,19 @@ where
 	}
 }
 
+/// Returns the new `:code` value if this block's storage changes update it.
+fn extract_code_change<H: sp_core::Hasher>(
+	changes: &sp_state_machine::StorageChanges<H>,
+) -> Option<Vec<u8>> {
+	changes.main_storage_changes.iter().find_map(|(key, value)| {
+		if key.as_slice() == well_known_keys::CODE {
+			value.clone()
+		} else {
+			None
+		}
+	})
+}
+
 #[async_trait::async_trait]
 impl<B, I, C, CIDP, BE, const LOGGING_FREQUENCY: u64> BlockImport<B>
 	for PowBlockImport<B, I, C, CIDP, BE, LOGGING_FREQUENCY>
@@ -210,7 +308,7 @@ where
 		+ BlockOf
 		+ sc_client_api::Finalizer<B, BE>
 		+ 'static,
-	C::Api: BlockBuilderApi<B> + QPoWApi<B>,
+	C::Api: BlockBuilderApi<B> + QPoWApi<B> + CoreApi<B> + ApiExt<B>,
 	CIDP: CreateInherentDataProviders<B, ()> + Send + Sync,
 	BE: sc_client_api::Backend<B> + 'static,
 {
@@ -289,6 +387,13 @@ where
 			log::error!("Invalid Seal {:?} for parent hash {:?}", inner_seal, parent_hash);
 			return Err(Error::<B>::InvalidSeal.into());
 		}
+
+		// Enforce the local runtime disallow-list. This may fully execute the
+		// block (to learn whether it changes `:code`), so it must only run
+		// after the seal has been verified — otherwise peers could feed us
+		// invalidly-sealed blocks with heavy bodies and make us execute each
+		// one for free.
+		self.enforce_runtime_code_policy(&mut block_import_params)?;
 
 		// Get parent's cumulative achieved work from aux storage
 		let parent_work = get_chain_work::<B, C>(&*self.client, parent_hash).unwrap_or_else(|e| {
@@ -414,12 +519,13 @@ where
 	let header = &mut block.header;
 	let block_hash = hash;
 	let seal_item = match header.digest_mut().pop() {
-		Some(DigestItem::Seal(id, seal)) =>
+		Some(DigestItem::Seal(id, seal)) => {
 			if id == POW_ENGINE_ID {
 				DigestItem::Seal(id, seal)
 			} else {
 				return Err(Error::<B>::WrongEngine(id).into());
-			},
+			}
+		},
 		_ => return Err(Error::<B>::HeaderUnsealed(block_hash).into()),
 	};
 
@@ -776,5 +882,26 @@ mod tests {
 			!result.header.digest().logs.iter().any(|l| matches!(l, DigestItem::Seal(..))),
 			"seal must be removed from the pre-seal header"
 		);
+	}
+
+	#[test]
+	fn extract_code_change_finds_new_code() {
+		let mut changes = sp_state_machine::StorageChanges::<sp_core::Blake2Hasher>::default();
+		changes.main_storage_changes = vec![
+			(b"unrelated".to_vec(), Some(vec![9])),
+			(well_known_keys::CODE.to_vec(), Some(vec![1, 2, 3])),
+		];
+		assert_eq!(extract_code_change(&changes), Some(vec![1, 2, 3]));
+	}
+
+	#[test]
+	fn extract_code_change_ignores_other_keys_and_deletions() {
+		let mut changes = sp_state_machine::StorageChanges::<sp_core::Blake2Hasher>::default();
+		changes.main_storage_changes = vec![(b"unrelated".to_vec(), Some(vec![9]))];
+		assert_eq!(extract_code_change(&changes), None);
+
+		// A deletion of `:code` (`None`) carries no new code to vet.
+		changes.main_storage_changes = vec![(well_known_keys::CODE.to_vec(), None)];
+		assert_eq!(extract_code_change(&changes), None);
 	}
 }

--- a/docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md
+++ b/docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md
@@ -58,6 +58,36 @@ Polkadot JS Apps and the standard `@polkadot/api` **do not support** this chain'
 
 When the referendum passes, confirms, and enacts, `system.set_code` executes with Root origin and the new runtime is live immediately. No node restart is required.
 
+## Opting out of a specific upgrade (node disallow-list)
+
+Each node keeps a local JSON file of runtime wasm hashes it will **refuse to import**:
+
+```text
+{base-path}/chains/<chain>/disallowed-runtimes.json
+```
+
+Default contents (created automatically on first start):
+
+```json
+{
+  "disallowed_code_hashes": []
+}
+```
+
+To reject a proposed upgrade, add its Blake2-256 code hash (`0x` + 64 hex chars — the same hash used by `system.authorize_upgrade` / printed by runtime compare tools) before the upgrade block is imported:
+
+```json
+{
+  "disallowed_code_hashes": [
+    "0x0123abcd..."
+  ]
+}
+```
+
+The file is re-read whenever a block changes `:code`, so you do not need to restart the node after editing it. Override the path with `--disallowed-runtimes-file <path>` if needed.
+
+This only affects **your** node (and any others that list the same hash). An empty list preserves normal forkless upgrades with no coordination.
+
 ## Gotchas
 
 - Only Tech Collective members can submit or vote on the Tech track.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -36,6 +36,14 @@ pub struct Cli {
 	/// Sync: block request timeout in seconds (default: 30).
 	#[arg(long, default_value_t = 30)]
 	pub sync_block_request_timeout: u64,
+
+	/// Path to the runtime disallow-list JSON file.
+	///
+	/// Defaults to `{base-path}/chains/<chain>/disallowed-runtimes.json`.
+	/// The file is created empty on first start. Add Blake2-256 hashes
+	/// (`0x…`) of runtime wasm blobs this node should refuse to import.
+	#[arg(long, value_name = "PATH")]
+	pub disallowed_runtimes_file: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -304,25 +304,21 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
-			"dev" => {
-				Box::new(chain_spec::development_chain_spec()?) as Box<dyn sc_service::ChainSpec>
-			},
-			"heisenberg_live_spec" => {
-				Box::new(chain_spec::heisenberg_chain_spec()?) as Box<dyn sc_service::ChainSpec>
-			},
+			"dev" =>
+				Box::new(chain_spec::development_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
+			"heisenberg_live_spec" =>
+				Box::new(chain_spec::heisenberg_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
 			"" | "heisenberg" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
 				"chain-specs/heisenberg.json"
 			))?) as Box<dyn sc_service::ChainSpec>,
-			"planck_live_spec" => {
-				Box::new(chain_spec::planck_chain_spec()?) as Box<dyn sc_service::ChainSpec>
-			},
+			"planck_live_spec" =>
+				Box::new(chain_spec::planck_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
 			"planck" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
 				"chain-specs/planck.json"
 			))?) as Box<dyn sc_service::ChainSpec>,
-			path => {
+			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
-					as Box<dyn sc_service::ChainSpec>
-			},
+					as Box<dyn sc_service::ChainSpec>,
 		})
 	}
 }
@@ -556,9 +552,8 @@ pub fn run() -> sc_cli::Result<()> {
 
 						cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
 					},
-					BenchmarkCmd::Machine(cmd) => {
-						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())
-					},
+					BenchmarkCmd::Machine(cmd) =>
+						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
 				}
 			})
 		},
@@ -670,9 +665,7 @@ pub fn run() -> sc_cli::Result<()> {
 							eprintln!("To generate an inner hash, run:");
 							eprintln!("  quantus-node key quantus --scheme wormhole\n");
 							eprintln!("Then pass the 'Inner Hash' value as --rewards-inner-hash.");
-							return Err(sc_cli::Error::Input(
-								"Missing --rewards-inner-hash".into(),
-							));
+							return Err(sc_cli::Error::Input("Missing --rewards-inner-hash".into()));
 						} else {
 							// unused for non-validator nodes, use zero placeholder.
 							AccountId32::new([0u8; 32])

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -304,21 +304,25 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
-			"dev" =>
-				Box::new(chain_spec::development_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
-			"heisenberg_live_spec" =>
-				Box::new(chain_spec::heisenberg_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
+			"dev" => {
+				Box::new(chain_spec::development_chain_spec()?) as Box<dyn sc_service::ChainSpec>
+			},
+			"heisenberg_live_spec" => {
+				Box::new(chain_spec::heisenberg_chain_spec()?) as Box<dyn sc_service::ChainSpec>
+			},
 			"" | "heisenberg" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
 				"chain-specs/heisenberg.json"
 			))?) as Box<dyn sc_service::ChainSpec>,
-			"planck_live_spec" =>
-				Box::new(chain_spec::planck_chain_spec()?) as Box<dyn sc_service::ChainSpec>,
+			"planck_live_spec" => {
+				Box::new(chain_spec::planck_chain_spec()?) as Box<dyn sc_service::ChainSpec>
+			},
 			"planck" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
 				"chain-specs/planck.json"
 			))?) as Box<dyn sc_service::ChainSpec>,
-			path =>
+			path => {
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
-					as Box<dyn sc_service::ChainSpec>,
+					as Box<dyn sc_service::ChainSpec>
+			},
 		})
 	}
 }
@@ -455,21 +459,23 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					service::new_partial(&config)?;
+					service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
 		Some(Subcommand::ExportBlocks(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
+				let PartialComponents { client, task_manager, .. } =
+					service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
 		},
 		Some(Subcommand::ExportState(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
+				let PartialComponents { client, task_manager, .. } =
+					service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
 		},
@@ -477,7 +483,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					service::new_partial(&config)?;
+					service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -489,7 +495,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } =
-					service::new_partial(&config)?;
+					service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 				let aux_revert = Box::new(|_client, _, _blocks| {
 					unimplemented!("TODO - g*randpa was removed.");
 				});
@@ -509,19 +515,21 @@ pub fn run() -> sc_cli::Result<()> {
 							config.chain_spec,
 						)),
 					BenchmarkCmd::Block(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
+						let PartialComponents { client, .. } =
+							service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 						cmd.run(client)
 					},
 					BenchmarkCmd::Storage(cmd) => {
 						let PartialComponents { client, backend, .. } =
-							service::new_partial(&config)?;
+							service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 						let db = backend.expose_db();
 						let storage = backend.expose_storage();
 
 						cmd.run(config, client, db, storage, None)
 					},
 					BenchmarkCmd::Overhead(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
+						let PartialComponents { client, .. } =
+							service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 						let ext_builder = RemarkBuilder::new(client.clone());
 
 						cmd.run(
@@ -534,7 +542,8 @@ pub fn run() -> sc_cli::Result<()> {
 						)
 					},
 					BenchmarkCmd::Extrinsic(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
+						let PartialComponents { client, .. } =
+							service::new_partial(&config, cli.disallowed_runtimes_file.clone())?;
 						// Register the *Remark* and *TKA* builders.
 						let ext_factory = ExtrinsicFactory(vec![
 							Box::new(RemarkBuilder::new(client.clone())),
@@ -547,8 +556,9 @@ pub fn run() -> sc_cli::Result<()> {
 
 						cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
 					},
-					BenchmarkCmd::Machine(cmd) =>
-						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
+					BenchmarkCmd::Machine(cmd) => {
+						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())
+					},
 				}
 			})
 		},
@@ -643,7 +653,7 @@ pub fn run() -> sc_cli::Result<()> {
 						);
 						AccountId32::new(inner_bytes)
 					},
-					None =>
+					None => {
 						if cli.run.shared_params.is_dev() {
 							let treasury_account =
 								quantus_runtime::configs::TreasuryPalletId::get()
@@ -660,11 +670,14 @@ pub fn run() -> sc_cli::Result<()> {
 							eprintln!("To generate an inner hash, run:");
 							eprintln!("  quantus-node key quantus --scheme wormhole\n");
 							eprintln!("Then pass the 'Inner Hash' value as --rewards-inner-hash.");
-							return Err(sc_cli::Error::Input("Missing --rewards-inner-hash".into()));
+							return Err(sc_cli::Error::Input(
+								"Missing --rewards-inner-hash".into(),
+							));
 						} else {
 							// unused for non-validator nodes, use zero placeholder.
 							AccountId32::new([0u8; 32])
-						},
+						}
+					},
 				};
 
 				// Allow mining without peers if --dev or --force-authoring is set
@@ -680,6 +693,7 @@ pub fn run() -> sc_cli::Result<()> {
 					cli.sync_disable_major_sync_gating,
 					cli.sync_block_request_timeout,
 					allow_mining_without_peers,
+					cli.disallowed_runtimes_file.clone(),
 				)
 				.map_err(sc_cli::Error::Service)
 			})

--- a/node/src/disallowed_runtimes.rs
+++ b/node/src/disallowed_runtimes.rs
@@ -1,0 +1,208 @@
+//! Local runtime disallow-list.
+//!
+//! Operators may refuse specific runtime wasm blobs by listing their Blake2-256
+//! code hashes in `{data_path}/disallowed-runtimes.json`. When a block would
+//! change `:code` to a listed hash, block import is rejected on this node only.
+//! An empty list (the default) accepts all upgrades — forkless upgrades keep
+//! working without coordination.
+
+use sc_consensus_qpow::RuntimeCodeGate;
+use serde::{Deserialize, Serialize};
+use sp_core::hashing::blake2_256;
+use std::{
+	collections::HashSet,
+	fs,
+	path::{Path, PathBuf},
+};
+
+const LOG_TARGET: &str = "disallowed-runtimes";
+
+/// Default filename under the chain data path.
+pub const DEFAULT_FILENAME: &str = "disallowed-runtimes.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct DisallowedRuntimesFile {
+	/// Blake2-256 hashes of disallowed runtime wasm, as `0x`-prefixed hex.
+	#[serde(default)]
+	disallowed_code_hashes: Vec<String>,
+}
+
+/// Ensures `path` exists with an empty disallow-list.
+pub fn ensure_default_file(path: &Path) -> std::io::Result<()> {
+	if path.exists() {
+		return Ok(());
+	}
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent)?;
+	}
+	let contents = serde_json::to_string_pretty(&DisallowedRuntimesFile::default())
+		.expect("empty disallow-list serializes")
+		+ "\n";
+	fs::write(path, contents)?;
+	log::info!(
+		target: LOG_TARGET,
+		"Created empty runtime disallow-list at {}",
+		path.display()
+	);
+	Ok(())
+}
+
+/// Resolve the disallow-list path: CLI override, or `{data_path}/disallowed-runtimes.json`.
+pub fn resolve_path(data_path: &Path, cli_override: Option<PathBuf>) -> PathBuf {
+	cli_override.unwrap_or_else(|| data_path.join(DEFAULT_FILENAME))
+}
+
+/// Gate that re-reads the JSON file on every `:code` change.
+pub struct DisallowedRuntimesGate {
+	path: PathBuf,
+}
+
+impl DisallowedRuntimesGate {
+	pub fn new(path: PathBuf) -> Self {
+		Self { path }
+	}
+
+	fn load_hashes(&self) -> HashSet<[u8; 32]> {
+		let raw = match fs::read_to_string(&self.path) {
+			Ok(s) => s,
+			Err(e) => {
+				log::warn!(
+					target: LOG_TARGET,
+					"Failed to read {}: {e}. Treating disallow-list as empty.",
+					self.path.display()
+				);
+				return HashSet::new();
+			},
+		};
+
+		let parsed: DisallowedRuntimesFile = match serde_json::from_str(&raw) {
+			Ok(v) => v,
+			Err(e) => {
+				log::warn!(
+					target: LOG_TARGET,
+					"Failed to parse {}: {e}. Treating disallow-list as empty.",
+					self.path.display()
+				);
+				return HashSet::new();
+			},
+		};
+
+		let mut out = HashSet::new();
+		for entry in parsed.disallowed_code_hashes {
+			match parse_code_hash(&entry) {
+				Ok(hash) => {
+					out.insert(hash);
+				},
+				Err(reason) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"Ignoring malformed disallow-list entry {entry:?}: {reason}"
+					);
+				},
+			}
+		}
+		out
+	}
+}
+
+impl RuntimeCodeGate for DisallowedRuntimesGate {
+	fn allow_new_code(&self, code: &[u8]) -> Result<(), String> {
+		let hash = blake2_256(code);
+		let disallowed = self.load_hashes();
+		if disallowed.contains(&hash) {
+			let hex = format!("0x{}", hex::encode(hash));
+			Err(format!(
+				"{hex} is listed in {} — refusing to import this runtime upgrade",
+				self.path.display()
+			))
+		} else {
+			Ok(())
+		}
+	}
+}
+
+fn parse_code_hash(s: &str) -> Result<[u8; 32], String> {
+	let hex_str = s.strip_prefix("0x").ok_or_else(|| "missing 0x prefix".to_string())?;
+	if hex_str.len() != 64 {
+		return Err(format!("expected 64 hex chars after 0x, got {}", hex_str.len()));
+	}
+	let bytes = hex::decode(hex_str).map_err(|e| format!("invalid hex: {e}"))?;
+	bytes.try_into().map_err(|_| "expected 32 bytes".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::io::Write;
+
+	#[test]
+	fn parse_code_hash_accepts_0x_hex() {
+		let h =
+			parse_code_hash("0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+				.expect("valid");
+		assert_eq!(h[0], 0x00);
+		assert_eq!(h[31], 0x1f);
+	}
+
+	#[test]
+	fn parse_code_hash_rejects_missing_prefix() {
+		assert!(parse_code_hash("00".repeat(32).as_str()).is_err());
+	}
+
+	#[test]
+	fn gate_rejects_listed_hash() {
+		let dir = tempfile_dir();
+		let path = dir.join(DEFAULT_FILENAME);
+		let code = b"fake-runtime-wasm";
+		let hash = blake2_256(code);
+		let file = DisallowedRuntimesFile {
+			disallowed_code_hashes: vec![format!("0x{}", hex::encode(hash))],
+		};
+		fs::write(&path, serde_json::to_string_pretty(&file).unwrap()).unwrap();
+
+		let gate = DisallowedRuntimesGate::new(path);
+		assert!(gate.allow_new_code(code).is_err());
+		assert!(gate.allow_new_code(b"other-runtime").is_ok());
+	}
+
+	#[test]
+	fn ensure_default_file_creates_empty_list() {
+		let dir = tempfile_dir();
+		let path = dir.join(DEFAULT_FILENAME);
+		ensure_default_file(&path).unwrap();
+		assert!(path.exists());
+		let parsed: DisallowedRuntimesFile =
+			serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+		assert!(parsed.disallowed_code_hashes.is_empty());
+	}
+
+	fn tempfile_dir() -> PathBuf {
+		let mut dir = std::env::temp_dir();
+		dir.push(format!("quantus-disallowed-runtimes-{}", std::process::id()));
+		dir.push(format!("{}", rand_suffix()));
+		fs::create_dir_all(&dir).unwrap();
+		dir
+	}
+
+	fn rand_suffix() -> u64 {
+		use std::time::{SystemTime, UNIX_EPOCH};
+		SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64
+	}
+
+	#[test]
+	fn malformed_entries_are_skipped() {
+		let dir = tempfile_dir();
+		let path = dir.join(DEFAULT_FILENAME);
+		let mut f = fs::File::create(&path).unwrap();
+		write!(f, r#"{{"disallowed_code_hashes":["not-a-hash","0xzz","0x{}"]}}"#, "ab".repeat(32))
+			.unwrap();
+		let gate = DisallowedRuntimesGate::new(path);
+		// "ab"*32 is valid; others warned and skipped
+		let mut expected = [0u8; 32];
+		expected.copy_from_slice(&hex::decode("ab".repeat(32)).unwrap());
+		let set = gate.load_hashes();
+		assert_eq!(set.len(), 1);
+		assert!(set.contains(&expected));
+	}
+}

--- a/node/src/disallowed_runtimes.rs
+++ b/node/src/disallowed_runtimes.rs
@@ -37,8 +37,8 @@ pub fn ensure_default_file(path: &Path) -> std::io::Result<()> {
 		fs::create_dir_all(parent)?;
 	}
 	let contents = serde_json::to_string_pretty(&DisallowedRuntimesFile::default())
-		.expect("empty disallow-list serializes")
-		+ "\n";
+		.expect("empty disallow-list serializes") +
+		"\n";
 	fs::write(path, contents)?;
 	log::info!(
 		target: LOG_TARGET,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -6,6 +6,7 @@ mod benchmarking;
 mod chain_spec;
 mod cli;
 mod command;
+mod disallowed_runtimes;
 mod miner_server;
 mod prometheus;
 mod rpc;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -20,16 +20,21 @@ use sc_transaction_pool_api::{OffchainTransactionPoolFactory, TransactionPool};
 use sp_inherents::CreateInherentDataProviders;
 use tokio_util::sync::CancellationToken;
 
-use crate::{miner_server::MinerServer, prometheus::BusinessMetrics};
+use crate::{
+	disallowed_runtimes::{self, DisallowedRuntimesGate},
+	miner_server::MinerServer,
+	prometheus::BusinessMetrics,
+};
 use codec::Encode;
 use jsonrpsee::tokio;
 use quantus_miner_api::{ApiResponseStatus, MiningRequest, MiningResult};
 use sc_basic_authorship::ProposerFactory;
+use sc_consensus_qpow::RuntimeCodeGate;
 use sp_api::ProvideRuntimeApi;
 use sp_consensus::SyncOracle;
 use sp_consensus_qpow::QPoWApi;
 use sp_core::{crypto::AccountId32, U512};
-use std::{sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 /// Frequency of block import logging. Every 1000 blocks.
 const LOG_FREQUENCY: u64 = 1000;
@@ -185,8 +190,8 @@ async fn handle_external_mining(
 	loop {
 		let (miner_id, seal) = match wait_for_mining_result(server, &job_id, || {
 			// Interrupt if cancelled, parent block changed, OR block template was rebuilt
-			cancellation_token.is_cancelled() ||
-				worker_handle
+			cancellation_token.is_cancelled()
+				|| worker_handle
 					.metadata()
 					.map(|m| m.best_hash != best_hash || m.pre_hash != original_pre_hash)
 					.unwrap_or(true)
@@ -578,7 +583,10 @@ pub type Service = sc_service::PartialComponents<
 >;
 
 #[allow(clippy::result_large_err)]
-pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
+pub fn new_partial(
+	config: &Configuration,
+	disallowed_runtimes_file: Option<PathBuf>,
+) -> Result<Service, ServiceError> {
 	let telemetry = config
 		.telemetry_endpoints
 		.clone()
@@ -604,6 +612,23 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 	if let Err(e) = sc_consensus_qpow::initialize_genesis_achieved_work::<Block, _>(&*client) {
 		log::warn!(target: "qpow", "Failed to initialize genesis achieved work: {:?}", e);
 	}
+
+	let disallowed_path =
+		disallowed_runtimes::resolve_path(&config.data_path, disallowed_runtimes_file);
+	if let Err(e) = disallowed_runtimes::ensure_default_file(&disallowed_path) {
+		log::warn!(
+			target: "disallowed-runtimes",
+			"Failed to create {}: {e}",
+			disallowed_path.display()
+		);
+	}
+	let code_gate: Arc<dyn RuntimeCodeGate> =
+		Arc::new(DisallowedRuntimesGate::new(disallowed_path.clone()));
+	log::info!(
+		target: "disallowed-runtimes",
+		"Runtime disallow-list: {}",
+		disallowed_path.display()
+	);
 
 	let telemetry = telemetry.map(|(worker, telemetry)| {
 		task_manager.spawn_handle().spawn("telemetry", None, worker.run());
@@ -638,8 +663,10 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 	let pow_block_import = sc_consensus_qpow::PowBlockImport::new(
 		Arc::clone(&client),
 		Arc::clone(&client),
+		Arc::clone(&backend),
 		0, // check inherents starting at block 0
 		inherent_data_providers,
+		Some(code_gate),
 	);
 
 	let import_queue = sc_consensus_qpow::import_queue::<Block, FullClient>(
@@ -674,6 +701,7 @@ pub fn new_full<
 	sync_disable_major_sync_gating: bool,
 	sync_block_request_timeout: u64,
 	allow_mining_without_peers: bool,
+	disallowed_runtimes_file: Option<PathBuf>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
@@ -684,7 +712,7 @@ pub fn new_full<
 		select_chain: _,
 		transaction_pool,
 		other: (pow_block_import, mut telemetry),
-	} = new_partial(&config)?;
+	} = new_partial(&config, disallowed_runtimes_file)?;
 
 	let tx_stream_for_worker = transaction_pool.clone().import_notification_stream();
 	#[cfg(feature = "tx-logging")]

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -190,8 +190,8 @@ async fn handle_external_mining(
 	loop {
 		let (miner_id, seal) = match wait_for_mining_result(server, &job_id, || {
 			// Interrupt if cancelled, parent block changed, OR block template was rebuilt
-			cancellation_token.is_cancelled()
-				|| worker_handle
+			cancellation_token.is_cancelled() ||
+				worker_handle
 					.metadata()
 					.map(|m| m.best_hash != best_hash || m.pre_hash != original_pre_hash)
 					.unwrap_or(true)


### PR DESCRIPTION
## Summary

- Add an optional **local runtime disallow-list**: nodes can refuse to import blocks that change `:code` to a listed Blake2-256 wasm hash, without requiring network-wide coordination.
- Default file is `{base-path}/chains/<chain>/disallowed-runtimes.json` (created empty on first start); override with `--disallowed-runtimes-file`. The file is re-read on each `:code` change (no restart).
- Wire the check into `PowBlockImport` **after** PoW seal verification so peers cannot force free block execution with invalid seals. Empty list preserves normal forkless upgrades.

## Test plan

- [ ] `cargo test -p sc-consensus-qpow --lib`
- [ ] `cargo test -p quantus-node disallowed_runtimes`
- [ ] Start a node and confirm `disallowed-runtimes.json` is created empty under the chain data path
- [ ] Add a known wasm Blake2-256 hash (`0x` + 64 hex) and verify a block that enacts that runtime is rejected with a clear log/error
- [ ] Confirm a non-listed upgrade still imports; confirm editing the file takes effect without restart on the next `:code` change
- [ ] Spot-check README / MINING.md / `docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md` for path and format accuracy