### PR TITLE
ci: Dilithium version bump to dilithium-v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7295,7 +7295,7 @@ dependencies = [
 
 [[package]]
 name = "qp-dilithium-crypto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ pallet-reversible-transfers = { path = "./pallets/reversible-transfers", default
 pallet-scheduler = { path = "./pallets/scheduler", default-features = false }
 pallet-wormhole = { path = "./pallets/wormhole", default-features = false }
 pallet-zk-tree = { path = "./pallets/zk-tree", default-features = false }
-qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.5.0", default-features = false }
+qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.6.0", default-features = false }
 qp-header = { path = "./primitives/header", default-features = false }
 qp-high-security = { path = "./primitives/high-security", default-features = false }
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }

--- a/primitives/dilithium-crypto/Cargo.toml
+++ b/primitives/dilithium-crypto/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 name = "qp-dilithium-crypto"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/chain"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 codec = { workspace = true, default-features = false }


### PR DESCRIPTION
## Dilithium Crypto Release Proposal

This PR proposes releasing **qp-dilithium-crypto** version `0.6.0`.

### Changes
- Updated `primitives/dilithium-crypto/Cargo.toml` version to `0.6.0`
- Updated `Cargo.toml` workspace dependency version to `0.6.0`
- Updated `Cargo.lock`
