### PR TITLE
V12 vesting low

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,111 @@
+# Security review follow-ups: event-scan metering, wormhole fee rounding
+
+Addresses a batch of security-review findings. Two are fixed with red→green
+regression tests, one is documented as an accepted design trade-off, and four
+were assessed as not actionable (rationale below, for the review response).
+
+## Fixes
+
+### 1. Size-aware event-scan charge (`2e33dbe3`)
+
+The proof-recorder extension's post-dispatch event scan was priced at a flat
+1µs per `EventRecord`, based on a ~300-byte record assumption. The scan
+stream-decodes every record present (`skip()` still decodes the prefix it
+discards), and a legitimate `Multisig::ProposalExecuted` record can carry a
+10 KiB stored call plus up to 100 approvers — an order of magnitude past the
+assumption — with the charge landing via `register_extra_weight_unchecked`,
+unbounded by block admission.
+
+- Added `frame_system::Pallet::event_bytes()`: reads the encoded length of the
+  `Events` storage value without decoding it.
+- `event_scan_weight` now charges a per-record structural term **plus** a
+  per-byte payload term (10ns/byte, ~10× ceiling over pure decode).
+- New test: `wormhole_proof_recorder_scan_weight_scales_with_event_bytes`.
+
+**Review follow-up: made the scan itself linear.** The linear charge could not
+bound the previous implementation: `Events::stream_iter()` refills a 2 KiB
+buffer via `sp_io::storage::read`, and each such host call materializes the
+complete overlay-resident `Events` value before slicing out the window —
+O(bytes²) total copying for a full scan (review measured 16× bytes → ~69×
+time). Added `frame_system::Pallet::read_events_no_consensus_single_copy()`,
+which fetches the encoded value exactly once (`sp_io::storage::get`) and
+decodes records from the in-memory buffer; the scan now uses it and meters the
+per-byte charge from the very buffer it decoded. New tests:
+`single_copy_event_reader_matches_the_streaming_reader` (decode equivalence)
+and `wormhole_proof_recorder_scan_of_many_small_records_registers_formula_weight`
+(20,000-record workload pins the formula at scale).
+
+### 2. Wormhole volume fee: quantized-ceiling settlement (`7d7c4bd9`)
+
+`process_exit_bundle` recomputed the volume fee in base units with truncating
+division, while the circuit's integer relation over quantized amounts
+(`out·10000 ≤ input·(10000−bps)`) forces every nonzero exit to lock at least
+one full quantum (0.01 QUAN) of fee. A one-quantum exit therefore settled
+4,001,600 base units instead of 10^10; the shortfall silently vanished from
+burn, miner, and aggregator allocation.
+
+- New `Pallet::volume_fee_for_exit`: `fee = ceil(exit_quanta · bps / (10000 −
+  bps))` quanta, scaled back to base units. Exact (minted totals are always
+  whole quanta), reproduces the proof-side minimum, and over the bundle total
+  never exceeds what the proofs locked (`ceil(Σ) ≤ Σ ceil`).
+- Updated `docs/wormhole-zk.md` and the six test sites that mirrored the old
+  formula (now via an independently derived `ceil_volume_fee` test helper).
+- New tests: `process_exit_bundle_settles_the_one_quantum_minimum_fee`
+  (red: 4,001,600 vs 10,000,000,000),
+  `process_exit_bundle_rounds_the_volume_fee_up_to_whole_quanta`
+  (red: 20,008,003,201 vs 30,000,000,000).
+
+## Accepted trade-off, now documented
+
+### 3. Post-hoc, not-fee-charged event scan (`a522d340`)
+
+Finding: the event scan and proof-recording shortfall are registered against
+the block after dispatch and never priced into the transaction fee.
+
+Accepted as designed, with the rationale now recorded next to the code:
+
+- It **cannot** be fee-charged: the scan cost depends on how many events
+  earlier transactions in the same block emitted, unknowable at fee time.
+  `TransactionExtension::weight()` is static, and fee correction only refunds
+  downward. Reserving the worst-case whole-block scan per transaction would
+  collapse throughput.
+- Block capacity stays sound: the extra weight accrues into `BlockWeight`
+  before the next transaction's `CheckWeight` admission; worst case is a
+  bounded one-transaction overshoot at the block boundary (the same pattern
+  FRAME accepts for `on_initialize`).
+- The economics don't invert: emitting events is fully fee-charged through the
+  emitting calls' benchmarked weights, orders of magnitude above the ~1µs/record
+  + ~10ns/byte decode cost imposed on the scan.
+
+## Findings assessed as not actionable
+
+### Treasury setter accepts reserved protocol accounts — rejected
+
+`set_treasury_account` is root-only, and *any* wrong address (not just the
+vesting pot or minting sentinel) strands future treasury rewards identically,
+with no migration back. Denylisting two of 2^256 wrong values adds no real
+protection; the safeguard is governance verifying the address it proposes.
+The existing zero-address check covers the one structurally detectable case.
+
+### Vesting `payout_weight` tree-model double count — deferred / accepted overcharge
+
+The PoV term charges per raw read+write operation (`4d+9` keys) where the
+distinct-key union is `4d+4` (`LeafCount`/`Depth`/`Root` appear in both sets),
+a flat ~13 KB proof-size overcharge per payout; the benchmarked baseline's
+tree footprint also stays under the added model (small, not safely
+subtractable without regenerating baselines). Every error is in the
+conservative direction (overcharge only — slightly higher fees, slightly
+fewer payouts per block; no undercharge, no security impact). The weight
+model for this code is being consolidated on the `illuzen/v12-vesting`
+branch, so any correction belongs there, not here.
+
+### `retarget_schedule` skips `treasury_and_pot()` — rejected
+
+`treasury_and_pot()` is not a lifecycle-wide invariant; it is a lookup for the
+two calls that move funds to/from the treasury (`create_schedule` funds the
+pot from it, `end_schedule` refunds to it). `retarget_schedule` touches the
+treasury in no way: it settles what any permissionless `claim` could already
+force and swaps the beneficiary (validating `new_beneficiary != pot` and
+`!= current`). Adding the check would block rotating a compromised
+beneficiary key exactly when the treasury is misconfigured, for no safety
+gain.

--- a/docs/wormhole-zk.md
+++ b/docs/wormhole-zk.md
@@ -88,7 +88,9 @@ be zero).
 4. Mint `sum · 10^10` (circuit uses 2dp `u32`, chain uses 12dp `u128`) to each
    surviving exit; record each transfer in `pallet-zk-tree` so the new mint
    becomes a fresh leaf available for future wormhole exits.
-5. Fee handling: `fee = total_output · bps / (10000 − bps)`. Split per
+5. Fee handling: `fee = ceil(total_output_quanta · bps / (10000 − bps))`
+   quanta, mirroring the circuit's integer fee relation over quantized
+   amounts — the smallest nonzero exit pays a full one-quantum fee. Split per
    `VolumeFeesBurnRate`: burn portion reduces `total_issuance`, miner portion
    minted to the QPoW block author from the pre‑runtime digest. If no author
    is found, the miner portion is burned instead.

--- a/pallets/frame-system/src/lib.rs
+++ b/pallets/frame-system/src/lib.rs
@@ -2185,6 +2185,16 @@ impl<T: Config> Pallet<T> {
 		Events::<T>::stream_iter()
 	}
 
+	/// Encoded byte length of the `Events` storage value, without decoding (or copying)
+	/// it: `sp_io::storage::read` with an empty buffer returns the value's total length.
+	///
+	/// Lets size-aware consumers of [`Self::read_events_no_consensus`] (which
+	/// stream-decodes every record present, including arbitrarily large ones) price the
+	/// decode work by payload size rather than record count alone.
+	pub fn event_bytes() -> u32 {
+		sp_io::storage::read(&Events::<T>::hashed_key(), &mut [], 0).unwrap_or(0)
+	}
+
 	/// Read and return the events of a specific pallet, as denoted by `E`.
 	///
 	/// This is useful for a pallet that wishes to read only the events it has deposited into

--- a/pallets/frame-system/src/lib.rs
+++ b/pallets/frame-system/src/lib.rs
@@ -2185,14 +2185,54 @@ impl<T: Config> Pallet<T> {
 		Events::<T>::stream_iter()
 	}
 
-	/// Encoded byte length of the `Events` storage value, without decoding (or copying)
-	/// it: `sp_io::storage::read` with an empty buffer returns the value's total length.
+	/// Encoded byte length of the `Events` storage value, without decoding it or copying
+	/// it into the runtime: `sp_io::storage::read` with an empty buffer returns the
+	/// value's total length. (The host side still materializes the overlay value once to
+	/// serve the call, so this is O(len) — call it sparingly.)
 	///
-	/// Lets size-aware consumers of [`Self::read_events_no_consensus`] (which
-	/// stream-decodes every record present, including arbitrarily large ones) price the
-	/// decode work by payload size rather than record count alone.
+	/// Lets size-aware consumers of the event stream price decode work by payload size
+	/// rather than record count alone.
 	pub fn event_bytes() -> u32 {
 		sp_io::storage::read(&Events::<T>::hashed_key(), &mut [], 0).unwrap_or(0)
+	}
+
+	/// Single-copy variant of [`Self::read_events_no_consensus`]: returns the encoded
+	/// size of the `Events` value alongside a lazily-decoding iterator over its records.
+	///
+	/// `Events::stream_iter()` refills a small (2 KiB) internal buffer through
+	/// `sp_io::storage::read`, and for an overlay-resident value — which `Events` always
+	/// is during block execution — every such host call materializes the *complete*
+	/// value before slicing out the requested window. Scanning a `B`-byte value end to
+	/// end that way copies O(B²) bytes. This accessor instead fetches the encoded value
+	/// exactly once and decodes records out of the in-memory buffer, so a full scan is
+	/// linear in the value's size.
+	///
+	/// Like [`Self::read_events_no_consensus`], only call this outside of consensus-
+	/// critical logic, and mind the PoV impact of reading the whole value.
+	pub fn read_events_no_consensus_single_copy(
+	) -> (u32, impl Iterator<Item = EventRecord<T::RuntimeEvent, T::Hash>>) {
+		let raw = sp_io::storage::get(&Events::<T>::hashed_key()).unwrap_or_default();
+		let size = raw.len() as u32;
+		// Leading `Compact<u32>` record count, then the records back to back. Any
+		// decode failure ends the iteration cleanly (same as `stream_iter`).
+		let (mut remaining, mut cursor) = {
+			let mut input = &raw[..];
+			match codec::Compact::<u32>::decode(&mut input) {
+				Ok(count) => (count.0, raw.len() - input.len()),
+				Err(_) => (0, 0),
+			}
+		};
+		let iter = core::iter::from_fn(move || {
+			if remaining == 0 {
+				return None;
+			}
+			remaining -= 1;
+			let mut input = &raw[cursor..];
+			let record = EventRecord::<T::RuntimeEvent, T::Hash>::decode(&mut input).ok()?;
+			cursor = raw.len() - input.len();
+			Some(record)
+		});
+		(size, iter)
 	}
 
 	/// Read and return the events of a specific pallet, as denoted by `E`.

--- a/pallets/wormhole/src/lib.rs
+++ b/pallets/wormhole/src/lib.rs
@@ -864,16 +864,12 @@ pub mod pallet {
 				nullifiers: nullifier_list,
 			});
 
-			// fee = minted_output * volume_fee_bps / (10000 - volume_fee_bps)
-			let fee_bps = T::VolumeFeeRateBps::get() as u128;
 			let total_exit_u128: u128 = minted_exit_amount.try_into().map_err(|_| {
 				log::error!("Failed to convert minted_exit_amount to u128");
 				Error::<T>::InvalidProofPublicInputs
 			})?;
-			let total_fee_u128 = total_exit_u128
-				.saturating_mul(fee_bps)
-				.checked_div(10000u128.saturating_sub(fee_bps))
-				.unwrap_or(0);
+			let total_fee_u128 =
+				Self::volume_fee_for_exit(total_exit_u128, T::VolumeFeeRateBps::get());
 
 			// Fee distribution: configurable portion burned, remainder to miner
 			//
@@ -1067,6 +1063,34 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Volume fee owed on `minted_exit` base units at `fee_bps`, in base units.
+		///
+		/// Mirrors the circuit's integer fee relation over QUANTIZED amounts
+		/// (`out · 10000 ≤ input · (10000 − bps)`, see `docs/wormhole-zk.md`):
+		/// `fee_quanta = ceil(exit_quanta · bps / (10000 − bps))`, which is exactly
+		/// the minimum fee gap the proofs lock. In particular the smallest valid
+		/// exit (one quantum out forces `input ≥ 2` quanta) settles a full
+		/// one-quantum fee, where truncating base-unit division would settle only
+		/// `bps / (10000 − bps)` of a quantum. Computed over the bundle's minted
+		/// total, the result never exceeds what the individual proofs locked
+		/// (ceil of a sum ≤ sum of ceils).
+		///
+		/// `minted_exit` is always a whole number of quanta: every exit balance is
+		/// a quantized `u32` output times [`SCALE_DOWN_FACTOR`], so the quantum
+		/// division below is exact. A degenerate `fee_bps >= 10000` yields a zero
+		/// fee, matching the previous `checked_div(..).unwrap_or(0)` behaviour.
+		pub(crate) fn volume_fee_for_exit(minted_exit: u128, fee_bps: u32) -> u128 {
+			let fee_bps = fee_bps as u128;
+			let denominator = 10_000u128.saturating_sub(fee_bps);
+			if denominator == 0 {
+				return 0;
+			}
+			(minted_exit / crate::SCALE_DOWN_FACTOR)
+				.saturating_mul(fee_bps)
+				.div_ceil(denominator)
+				.saturating_mul(crate::SCALE_DOWN_FACTOR)
+		}
+
 		/// Shared cheap checks for any exit bundle (asset, fee, block, segment validity).
 		pub(crate) fn validate_exit_bundle_common(
 			bundle: &ExitBundle,

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -1,3 +1,15 @@
+/// Expected volume fee in base units for a quantized exit total.
+///
+/// Independent re-derivation of the quantized-ceiling fee rule the circuit
+/// enforces (`out · 10000 ≤ input · (10000 − bps)` over quantized u32 amounts):
+/// `fee_quanta = ceil(exit_quanta · bps / (10000 − bps))`, so any nonzero exit
+/// pays at least one full quantum. Kept separate from the pallet's own
+/// computation so fee assertions don't just mirror the code under test.
+#[cfg(test)]
+fn ceil_volume_fee(exit_quanta: u128, fee_bps: u128) -> u128 {
+	exit_quanta.saturating_mul(fee_bps).div_ceil(10_000 - fee_bps) * crate::SCALE_DOWN_FACTOR
+}
+
 #[cfg(test)]
 mod wormhole_tests {
 	use crate::mock::*;
@@ -1045,17 +1057,17 @@ mod private_batch_proof_tests {
 					.expect("test preimage limbs are canonical"),
 			);
 
-			// Expected miner fee from the proof's public inputs:
-			// fee = exit * bps / (10000 - bps); miner gets fee minus the 50% burn
-			// (mock: VolumeFeesBurnRate = 50%).
-			let expected_exit: u128 = inputs
+			// Expected miner fee from the proof's public inputs: the quantized-ceiling
+			// volume fee; miner gets fee minus the 50% burn (mock: VolumeFeesBurnRate
+			// = 50%).
+			let exit_quanta: u128 = inputs
 				.account_data
 				.iter()
 				.filter(|a| a.summed_output_amount > 0)
-				.map(|a| (a.summed_output_amount as u128) * crate::SCALE_DOWN_FACTOR)
+				.map(|a| a.summed_output_amount as u128)
 				.sum();
 			let fee_bps = VolumeFeeRateBps::get() as u128;
-			let total_fee = expected_exit * fee_bps / (10_000 - fee_bps);
+			let total_fee = super::ceil_volume_fee(exit_quanta, fee_bps);
 			let expected_miner_fee = total_fee - total_fee / 2;
 			assert!(expected_miner_fee > 0, "fixture should produce a non-zero miner fee");
 
@@ -1614,12 +1626,12 @@ mod exit_bundle_tests {
 			);
 			assert_ok!(Wormhole::process_exit_bundle(b));
 
-			// Fee math mirrors the pallet: fee = exit * bps / (10000 - bps), computed
-			// on the total that EXCLUDES the denied segment's value.
+			// The quantized-ceiling volume fee, computed on the total that EXCLUDES
+			// the denied segment's value.
 			let fee_bps = VolumeFeeRateBps::get() as u128;
-			let fee = scaled(AMOUNT_A) * fee_bps / (10_000 - fee_bps);
+			let fee = super::ceil_volume_fee(AMOUNT_A as u128, fee_bps);
 			let fee_if_denied_included =
-				(scaled(AMOUNT_A) + scaled(AMOUNT_B)) * fee_bps / (10_000 - fee_bps);
+				super::ceil_volume_fee((AMOUNT_A + AMOUNT_B) as u128, fee_bps);
 			assert_ne!(fee, fee_if_denied_included, "test must distinguish the two totals");
 
 			let burn_bucket = Permill::from_percent(50) * fee;
@@ -1676,8 +1688,7 @@ mod exit_bundle_tests {
 
 			// Raise the ED so a small exit to a fresh account cannot be minted, while a
 			// larger co-bundled exit clears it. AMOUNT_A (20 QUAN) stays below the ED;
-			// AMOUNT_B (30 QUAN) is above it. The bundle total still clears the 10 QUAN
-			// MinimumTransferAmount.
+			// AMOUNT_B (30 QUAN) is above it.
 			ExistentialDeposit::set(scaled(2500));
 
 			let dust_exit = AccountId32::new([10u8; 32]);
@@ -1737,9 +1748,9 @@ mod exit_bundle_tests {
 			assert_ok!(Wormhole::process_exit_bundle(b));
 
 			let fee_bps = VolumeFeeRateBps::get() as u128;
-			let fee_minted = scaled(AMOUNT_B) * fee_bps / (10_000 - fee_bps);
+			let fee_minted = super::ceil_volume_fee(AMOUNT_B as u128, fee_bps);
 			let fee_attempted =
-				(scaled(AMOUNT_A) + scaled(AMOUNT_B)) * fee_bps / (10_000 - fee_bps);
+				super::ceil_volume_fee((AMOUNT_A + AMOUNT_B) as u128, fee_bps);
 			assert_ne!(fee_minted, fee_attempted);
 
 			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
@@ -1750,6 +1761,62 @@ mod exit_bundle_tests {
 					nullifiers: vec![nullifier_bytes(1), nullifier_bytes(2)],
 				}
 				.into(),
+			);
+		});
+	}
+
+	#[test]
+	fn process_exit_bundle_settles_the_one_quantum_minimum_fee() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			// Seed issuance so the burn is observable (set_total_issuance saturates at 0).
+			assert_ok!(Balances::mint_into(&account_id(999), 1_000 * UNIT));
+			let issuance_before = <Balances as Inspect<AccountId>>::total_issuance();
+
+			// Smallest valid exit: one quantum (0.01 QUAN). The circuit's integer fee
+			// relation `out · 10000 ≤ input · (10000 − bps)` forces `input ≥ 2` quanta
+			// here, i.e. the proof locked a full one-quantum fee. Settlement must
+			// collect that quantum, not the ~0.04% of it (10^10 · 4 / 9996 = 4_001_600
+			// base units) that truncating base-unit division yields.
+			assert_ok!(Wormhole::process_exit_bundle(bundle(
+				vec![segment(&[1], &[(10, 1)])],
+				None
+			)));
+
+			// No aggregator and no block author, so the entire fee is burned.
+			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
+			assert_eq!(
+				issuance_before - issuance_after,
+				crate::SCALE_DOWN_FACTOR,
+				"a one-quantum exit must settle the full one-quantum minimum fee"
+			);
+		});
+	}
+
+	#[test]
+	fn process_exit_bundle_rounds_the_volume_fee_up_to_whole_quanta() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			// Seed issuance so the burn is observable.
+			assert_ok!(Balances::mint_into(&account_id(999), 1_000 * UNIT));
+			let issuance_before = <Balances as Inspect<AccountId>>::total_issuance();
+
+			// 5000 quanta at 4 bps: 5000 · 4 / 9996 = 2.0008… quanta, which the
+			// quantized-ceiling rule settles as 3 whole quanta. Base-unit floor
+			// division would settle 20_008_003_201 instead.
+			let exit_quanta = 5_000u32;
+			assert_ok!(Wormhole::process_exit_bundle(bundle(
+				vec![segment(&[1], &[(10, exit_quanta)])],
+				None
+			)));
+
+			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
+			assert_eq!(
+				issuance_before - issuance_after,
+				3 * crate::SCALE_DOWN_FACTOR,
+				"the volume fee must be rounded up to whole quanta"
 			);
 		});
 	}
@@ -1786,7 +1853,7 @@ mod exit_bundle_tests {
 			// The whole fee is burned: the rebate fell back into the burn bucket and
 			// the miner share is burned too (no block author in tests).
 			let fee_bps = VolumeFeeRateBps::get() as u128;
-			let fee = scaled(amount) * fee_bps / (10_000 - fee_bps);
+			let fee = super::ceil_volume_fee(amount as u128, fee_bps);
 			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();
 			assert_eq!(
 				issuance_before - issuance_after,
@@ -1940,12 +2007,13 @@ mod public_batch_proof_tests {
 			let aggregator = AccountId32::new(AGGREGATOR_ADDRESS);
 			assert_eq!(Balances::balance(&aggregator), 0);
 
-			// Expected exit total from the proof's public inputs (dummy slots are zero).
-			let expected_exit: u128 = inputs
+			// Expected exit total (in quanta) from the proof's public inputs (dummy
+			// slots are zero).
+			let exit_quanta: u128 = inputs
 				.account_data
 				.iter()
 				.filter(|a| a.summed_output_amount > 0)
-				.map(|a| (a.summed_output_amount as u128) * crate::SCALE_DOWN_FACTOR)
+				.map(|a| a.summed_output_amount as u128)
 				.sum();
 
 			assert_ok!(Wormhole::verify_public_batch(
@@ -1966,10 +2034,10 @@ mod public_batch_proof_tests {
 				"Zero nullifiers from dummy padding must not be stored"
 			);
 
-			// Aggregator rebate: fee = exit * bps / (10000 - bps), burn bucket = 50% of
+			// Aggregator rebate: quantized-ceiling volume fee, burn bucket = 50% of
 			// fee, and VolumeFeesAggregatorRate (50%) of that goes to the aggregator.
 			let fee_bps = VolumeFeeRateBps::get() as u128;
-			let total_fee = expected_exit * fee_bps / (10_000u128 - fee_bps);
+			let total_fee = super::ceil_volume_fee(exit_quanta, fee_bps);
 			let burn_bucket = Permill::from_percent(50) * total_fee;
 			let expected_rebate = Permill::from_percent(50) * burn_bucket;
 			assert!(expected_rebate > 0, "Fixture fee should produce a nonzero rebate");

--- a/pallets/wormhole/src/tests.rs
+++ b/pallets/wormhole/src/tests.rs
@@ -1749,8 +1749,7 @@ mod exit_bundle_tests {
 
 			let fee_bps = VolumeFeeRateBps::get() as u128;
 			let fee_minted = super::ceil_volume_fee(AMOUNT_B as u128, fee_bps);
-			let fee_attempted =
-				super::ceil_volume_fee((AMOUNT_A + AMOUNT_B) as u128, fee_bps);
+			let fee_attempted = super::ceil_volume_fee((AMOUNT_A + AMOUNT_B) as u128, fee_bps);
 			assert_ne!(fee_minted, fee_attempted);
 
 			let issuance_after = <Balances as Inspect<AccountId>>::total_issuance();

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -177,8 +177,7 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 			Self::EVENT_SCAN_DECODE_REF_TIME_PS
 				.saturating_mul(u64::from(events))
 				.saturating_add(
-					Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS
-						.saturating_mul(u64::from(event_bytes)),
+					Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS.saturating_mul(u64::from(event_bytes)),
 				),
 			0,
 		))
@@ -402,21 +401,21 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 			// - It cannot be fee-charged: the scan cost depends on how many events EARLIER
 			//   transactions in the same block emitted, unknowable when the fee is computed.
 			//   `TransactionExtension::weight()` is static by design, and post-dispatch fee
-			//   correction only refunds downward — `actual_weight` is capped at the
-			//   pre-charged weight. The only alternative, reserving a worst-case whole-block
-			//   scan in every transaction upfront, would collapse throughput to insure
-			//   against microseconds of work.
+			//   correction only refunds downward — `actual_weight` is capped at the pre-charged
+			//   weight. The only alternative, reserving a worst-case whole-block scan in every
+			//   transaction upfront, would collapse throughput to insure against microseconds of
+			//   work.
 			//
 			// - Block capacity stays sound: `register_extra_weight_unchecked` accrues into
-			//   `BlockWeight` before the NEXT transaction's `CheckWeight` admission, so
-			//   later transactions are refused once the block fills. The worst case is a
-			//   bounded one-transaction overshoot at the block boundary (the same accepted
-			//   pattern FRAME uses for `on_initialize` overruns).
+			//   `BlockWeight` before the NEXT transaction's `CheckWeight` admission, so later
+			//   transactions are refused once the block fills. The worst case is a bounded
+			//   one-transaction overshoot at the block boundary (the same accepted pattern FRAME
+			//   uses for `on_initialize` overruns).
 			//
 			// - The economics don't invert: emitting events is fully fee-charged through the
-			//   emitting calls' benchmarked weights, and the uncharged decode here is
-			//   ~1µs/record + ~10ns/byte — orders of magnitude below what the attacker pays
-			//   to produce those events.
+			//   emitting calls' benchmarked weights, and the uncharged decode here is ~1µs/record +
+			//   ~10ns/byte — orders of magnitude below what the attacker pays to produce those
+			//   events.
 			let mut extra = Self::event_scan_weight(events_at_scan, event_bytes_at_scan);
 			if recorded > charged_transfers {
 				extra = extra.saturating_add(

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -145,24 +145,41 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 			.saturating_add(Weight::from_parts(hash_time, 0))
 	}
 
-	/// Worst-case `ref_time` (picoseconds) to stream-decode one `EventRecord` in
-	/// [`Self::record_proofs_from_events_since`]. A record is a small SCALE blob
-	/// (phase + event enum + topics, typically well under ~300 bytes) decoded from an
-	/// already-fetched storage value — roughly 100–300ns of pure decode on reference
-	/// hardware; 1µs is a conservative ceiling.
+	/// Worst-case `ref_time` (picoseconds) of the *structural* work to stream-decode one
+	/// `EventRecord` in [`Self::record_proofs_from_events_since`]: phase + event enum
+	/// dispatch + topics + the record's `Box` allocation. Payload size is charged
+	/// separately per byte (see [`Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS`]); 1µs is a
+	/// conservative ceiling for the fixed part.
 	const EVENT_SCAN_DECODE_REF_TIME_PS: u64 = 1_000_000;
 
-	/// Weight of the post-dispatch event scan when `events` records are present at
-	/// scan time. `Events::stream_iter` fetches the storage value (one read) and the
-	/// scan then decodes EVERY record present — `Iterator::skip` discards but still
-	/// decodes the pre-snapshot prefix — so the cost is per record *present*, not per
-	/// record matched or recorded.
-	fn event_scan_weight(events: u32) -> Weight {
+	/// Worst-case `ref_time` (picoseconds) to stream-decode one *byte* of the events
+	/// blob. Record size is caller-influenced — a successful `Multisig::execute` emits
+	/// `ProposalExecuted` carrying the full stored call (up to `MaxCallSize` = 10 KiB)
+	/// plus the approver vector (up to `MaxSigners` = 100 accounts), an order of
+	/// magnitude past any fixed per-record assumption — so decode work must be priced
+	/// by size, not record count alone. Payload decode is essentially a bounds-checked
+	/// memcopy (~1ns/byte with allocation on reference hardware); 10ns/byte is a
+	/// conservative ceiling.
+	const EVENT_SCAN_DECODE_BYTE_REF_TIME_PS: u64 = 10_000;
+
+	/// Weight of the post-dispatch event scan when `events` records totalling
+	/// `event_bytes` encoded bytes are present at scan time. `Events::stream_iter`
+	/// fetches the storage value (one read) and the scan then decodes EVERY record
+	/// present — `Iterator::skip` discards but still decodes the pre-snapshot prefix —
+	/// so the cost is per record *present*, not per record matched or recorded, and it
+	/// scales with the payload bytes those records carry (a single legitimate
+	/// `Multisig::ProposalExecuted` can be ~13 KiB).
+	fn event_scan_weight(events: u32, event_bytes: u32) -> Weight {
 		if events == 0 {
 			return Weight::zero();
 		}
 		T::DbWeight::get().reads(1).saturating_add(Weight::from_parts(
-			Self::EVENT_SCAN_DECODE_REF_TIME_PS.saturating_mul(u64::from(events)),
+			Self::EVENT_SCAN_DECODE_REF_TIME_PS
+				.saturating_mul(u64::from(events))
+				.saturating_add(
+					Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS
+						.saturating_mul(u64::from(event_bytes)),
+				),
 			0,
 		))
 	}
@@ -361,8 +378,9 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		if result.is_ok() {
 			let (event_count_before, charged_transfers) = pre;
 			// Captured BEFORE recording deposits new events: this is exactly the number
-			// of records the scan below decodes.
+			// of records (and their encoded size) the scan below decodes.
 			let events_at_scan = frame_system::Pallet::<Runtime>::event_count();
+			let event_bytes_at_scan = frame_system::Pallet::<Runtime>::event_bytes();
 			let recorded = Self::record_proofs_from_events_since(event_count_before);
 
 			// Two pieces of caller-influenced work here are invisible to the static
@@ -370,14 +388,14 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 			// keeps block-capacity accounting sound; it is not fee-charged):
 			//
 			// 1. The event scan itself: any call can emit events the scan must decode (e.g. batched
-			//    `remark_with_event`), and the decode cost is per record present at scan time — see
-			//    `event_scan_weight`.
+			//    `remark_with_event`), and the decode cost is per record AND per byte present at
+			//    scan time — see `event_scan_weight`.
 			//
 			// 2. Recording shortfall: wrappers that dispatch inner calls stored on-chain
 			//    (`Multisig::execute`, `ReversibleTransfers::recover_funds`, ...) can emit transfer
 			//    events the static `count_transfers` matcher cannot see, so the proof-recording
 			//    work above may exceed the weight reserved by `weight()`.
-			let mut extra = Self::event_scan_weight(events_at_scan);
+			let mut extra = Self::event_scan_weight(events_at_scan, event_bytes_at_scan);
 			if recorded > charged_transfers {
 				extra = extra.saturating_add(
 					Self::per_transfer_weight()
@@ -977,6 +995,7 @@ mod tests {
 			let weight_before = frame_system::Pallet::<Runtime>::block_weight().total();
 
 			let scanned = core::cell::Cell::new(0u32);
+			let scanned_bytes = core::cell::Cell::new(0u32);
 			run_lifecycle(&alice(), opaque_call, || {
 				assert_ok!(Balances::transfer_keep_alive(
 					RuntimeOrigin::signed(alice()),
@@ -984,13 +1003,17 @@ mod tests {
 					EXISTENTIAL_DEPOSIT * 50,
 				));
 				scanned.set(frame_system::Pallet::<Runtime>::event_count());
+				scanned_bytes.set(frame_system::Pallet::<Runtime>::event_bytes());
 			});
 
 			let weight_after = frame_system::Pallet::<Runtime>::block_weight().total();
 			assert_eq!(
 				weight_after.saturating_sub(weight_before),
 				WormholeProofRecorderExtension::<Runtime>::per_transfer_weight().saturating_add(
-					WormholeProofRecorderExtension::<Runtime>::event_scan_weight(scanned.get())
+					WormholeProofRecorderExtension::<Runtime>::event_scan_weight(
+						scanned.get(),
+						scanned_bytes.get()
+					)
 				),
 				"the uncounted recorded transfer must be registered as extra block weight, \
 				 on top of the always-registered event-scan weight"
@@ -1013,22 +1036,77 @@ mod tests {
 
 			let weight_before = frame_system::Pallet::<Runtime>::block_weight().total();
 
-			// Capture the event count at the end of the dispatch closure: that is
-			// exactly the number of records the post-dispatch scan decodes.
+			// Capture the event count and encoded size at the end of the dispatch
+			// closure: that is exactly what the post-dispatch scan decodes.
 			let scanned = core::cell::Cell::new(0u32);
+			let scanned_bytes = core::cell::Cell::new(0u32);
 			run_lifecycle(&alice(), call, || {
 				for i in 0..7u8 {
 					assert_ok!(System::remark_with_event(RuntimeOrigin::signed(alice()), vec![i],));
 				}
 				scanned.set(frame_system::Pallet::<Runtime>::event_count());
+				scanned_bytes.set(frame_system::Pallet::<Runtime>::event_bytes());
 			});
 			assert!(scanned.get() >= 7, "the remarks must have emitted events");
 
 			let weight_after = frame_system::Pallet::<Runtime>::block_weight().total();
 			assert_eq!(
 				weight_after.saturating_sub(weight_before),
-				WormholeProofRecorderExtension::<Runtime>::event_scan_weight(scanned.get()),
+				WormholeProofRecorderExtension::<Runtime>::event_scan_weight(
+					scanned.get(),
+					scanned_bytes.get()
+				),
 				"the per-event decode work of the scan must be registered as block weight"
+			);
+		});
+	}
+
+	/// The scan stream-decodes complete records before filtering, and record size is
+	/// caller-influenced: a successful `Multisig::execute` emits `ProposalExecuted`
+	/// carrying the full stored call (up to 10 KiB) and the approver vector (up to 100
+	/// accounts) — an order of magnitude past the ~300-byte structural assumption
+	/// behind the per-record charge. Because `skip()` still decodes discarded records,
+	/// every later transaction in the block re-decodes such records too. The registered
+	/// scan weight must therefore scale with the bytes present, not record count alone.
+	#[test]
+	fn wormhole_proof_recorder_scan_weight_scales_with_event_bytes() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+			let weight_before = frame_system::Pallet::<Runtime>::block_weight().total();
+
+			let bytes_at_scan = core::cell::Cell::new(0u32);
+			run_lifecycle(&alice(), call, || {
+				// A worst-case legitimate record: full-size stored call, max approvers.
+				System::deposit_event(RuntimeEvent::Multisig(
+					pallet_multisig::Event::ProposalExecuted {
+						multisig_address: alice(),
+						proposal_id: 0,
+						proposer: alice(),
+						call: vec![0u8; 10_240],
+						approvers: vec![alice(); 100],
+						result: Ok(()),
+					},
+				));
+				bytes_at_scan.set(frame_system::Pallet::<Runtime>::event_bytes());
+			});
+			assert!(
+				bytes_at_scan.get() > 10_240,
+				"the oversized record must be in the scanned stream"
+			);
+
+			let registered = frame_system::Pallet::<Runtime>::block_weight()
+				.total()
+				.saturating_sub(weight_before);
+			let byte_floor =
+				WormholeProofRecorderExtension::<Runtime>::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS
+					.saturating_mul(u64::from(bytes_at_scan.get()));
+			assert!(
+				registered.ref_time() >= byte_floor,
+				"scan weight must cover byte-proportional decode work: registered {} < byte floor {}",
+				registered.ref_time(),
+				byte_floor,
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -145,11 +145,11 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 			.saturating_add(Weight::from_parts(hash_time, 0))
 	}
 
-	/// Worst-case `ref_time` (picoseconds) of the *structural* work to stream-decode one
+	/// Worst-case `ref_time` (picoseconds) of the *structural* work to decode one
 	/// `EventRecord` in [`Self::record_proofs_from_events_since`]: phase + event enum
-	/// dispatch + topics + the record's `Box` allocation. Payload size is charged
-	/// separately per byte (see [`Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS`]); 1µs is a
-	/// conservative ceiling for the fixed part.
+	/// dispatch + topics. Payload size is charged separately per byte (see
+	/// [`Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS`]); 1µs is a conservative ceiling
+	/// for the fixed part.
 	const EVENT_SCAN_DECODE_REF_TIME_PS: u64 = 1_000_000;
 
 	/// Worst-case `ref_time` (picoseconds) to stream-decode one *byte* of the events
@@ -163,12 +163,14 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	const EVENT_SCAN_DECODE_BYTE_REF_TIME_PS: u64 = 10_000;
 
 	/// Weight of the post-dispatch event scan when `events` records totalling
-	/// `event_bytes` encoded bytes are present at scan time. `Events::stream_iter`
-	/// fetches the storage value (one read) and the scan then decodes EVERY record
-	/// present — `Iterator::skip` discards but still decodes the pre-snapshot prefix —
-	/// so the cost is per record *present*, not per record matched or recorded, and it
-	/// scales with the payload bytes those records carry (a single legitimate
-	/// `Multisig::ProposalExecuted` can be ~13 KiB).
+	/// `event_bytes` encoded bytes are present at scan time. The scan fetches the
+	/// encoded `Events` value exactly once (one read, one copy — see
+	/// `read_events_no_consensus_single_copy`; the 2 KiB-buffered `stream_iter` would
+	/// re-materialize the whole overlay value per refill, O(bytes²) for a full scan)
+	/// and then decodes EVERY record present — `Iterator::skip` discards but still
+	/// decodes the pre-snapshot prefix — so the cost is per record *present*, not per
+	/// record matched or recorded, and it scales with the payload bytes those records
+	/// carry (a single legitimate `Multisig::ProposalExecuted` can be ~13 KiB).
 	fn event_scan_weight(events: u32, event_bytes: u32) -> Weight {
 		if events == 0 {
 			return Weight::zero();
@@ -236,16 +238,19 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	/// `event_count_before` is the value from `frame_system::Pallet::event_count()`
 	/// captured in `prepare()`.
 	///
-	/// Returns the number of transfer proofs recorded, so callers can reconcile the actual
-	/// proof-recording work against the statically charged weight.
-	fn record_proofs_from_events_since(event_count_before: u32) -> u64 {
-		// IMPORTANT: We must collect all transfers FIRST before calling record_transfer_proof,
-		// because record_transfer_proof deposits new events which would invalidate the
-		// stream_iter iterator (causing "Corrupted state" errors).
-		//
-		// The iterator reads from Events storage using stream_iter, which caches data.
-		// If we modify Events storage during iteration (by depositing new events),
-		// the cached data becomes stale and decoding fails.
+	/// Returns the number of transfer proofs recorded (so callers can reconcile the
+	/// actual proof-recording work against the statically charged weight) and the
+	/// encoded byte size of the scanned `Events` value (the input to
+	/// [`Self::event_scan_weight`]'s per-byte term — taken from the very buffer the
+	/// scan decodes, so the charge and the work can't drift apart).
+	fn record_proofs_from_events_since(event_count_before: u32) -> (u64, u32) {
+		// The single-copy reader fetches the encoded `Events` value exactly once and
+		// decodes records from that in-memory snapshot, keeping the scan linear in the
+		// value's size (`stream_iter` would re-materialize the whole overlay value on
+		// every 2 KiB buffer refill — O(bytes²) for a full scan, superlinear work the
+		// linear `event_scan_weight` charge could never bound). The snapshot also means
+		// depositing events while iterating cannot corrupt the stream; we still collect
+		// all transfers before recording (which deposits new events) for clarity.
 
 		// The vesting pot's flows are excluded: the vesting pallet records its own
 		// pot -> beneficiary payouts (also for scheduler-enacted Root calls this
@@ -255,9 +260,12 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 		// exit through the wormhole.
 		let vesting_pot = pallet_vesting::Pallet::<Runtime>::pot_account_id();
 
+		let (event_bytes, events) =
+			frame_system::Pallet::<Runtime>::read_events_no_consensus_single_copy();
+
 		// Collect transfers to record - (asset_id, from, to, amount)
 		let transfers_to_record: alloc::vec::Vec<(Option<AssetId>, AccountId, AccountId, Balance)> =
-			frame_system::Pallet::<Runtime>::read_events_no_consensus()
+			events
 				.skip(event_count_before as usize)
 				.filter_map(|event_record| {
 					match event_record.event {
@@ -313,7 +321,7 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 				recorded = recorded.saturating_add(1);
 			}
 		}
-		recorded
+		(recorded, event_bytes)
 	}
 }
 
@@ -377,10 +385,11 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		if result.is_ok() {
 			let (event_count_before, charged_transfers) = pre;
 			// Captured BEFORE recording deposits new events: this is exactly the number
-			// of records (and their encoded size) the scan below decodes.
+			// of records the scan below decodes. The scanned byte size comes back from
+			// the scan itself — measured on the very buffer it decoded.
 			let events_at_scan = frame_system::Pallet::<Runtime>::event_count();
-			let event_bytes_at_scan = frame_system::Pallet::<Runtime>::event_bytes();
-			let recorded = Self::record_proofs_from_events_since(event_count_before);
+			let (recorded, event_bytes_at_scan) =
+				Self::record_proofs_from_events_since(event_count_before);
 
 			// Two pieces of caller-influenced work here are invisible to the static
 			// `weight()` and are therefore registered against the block post-hoc (this
@@ -1132,6 +1141,98 @@ mod tests {
 		});
 	}
 
+	/// The scan must decode exactly what the streaming reader would: the single-copy
+	/// reader exists purely to make the scan linear (one `storage::get` instead of
+	/// per-2-KiB refills that each re-materialize the whole overlay value), not to
+	/// change what is read.
+	#[test]
+	fn single_copy_event_reader_matches_the_streaming_reader() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			// A mixed stream: small records, a transfer, and an oversized record.
+			assert_ok!(System::remark_with_event(RuntimeOrigin::signed(alice()), vec![1]));
+			assert_ok!(Balances::transfer_keep_alive(
+				RuntimeOrigin::signed(alice()),
+				MultiAddress::Id(bob()),
+				EXISTENTIAL_DEPOSIT * 50,
+			));
+			System::deposit_event(RuntimeEvent::Multisig(
+				pallet_multisig::Event::ProposalExecuted {
+					multisig_address: alice(),
+					proposal_id: 0,
+					proposer: alice(),
+					call: vec![0u8; 10_240],
+					approvers: vec![alice(); 100],
+					result: Ok(()),
+				},
+			));
+
+			let streamed: alloc::vec::Vec<_> =
+				frame_system::Pallet::<Runtime>::read_events_no_consensus()
+					.map(|boxed| *boxed)
+					.collect();
+			let (bytes, single_copy) =
+				frame_system::Pallet::<Runtime>::read_events_no_consensus_single_copy();
+			let single_copy: alloc::vec::Vec<_> = single_copy.collect();
+
+			assert!(!streamed.is_empty(), "the fixture must have produced events");
+			assert_eq!(
+				streamed, single_copy,
+				"the single-copy reader must decode the identical records"
+			);
+			assert_eq!(
+				bytes,
+				frame_system::Pallet::<Runtime>::event_bytes(),
+				"the returned size must be the encoded length of the Events value"
+			);
+		});
+	}
+
+	/// `stream_iter()` refills its 2 KiB buffer via `sp_io::storage::read`, and each
+	/// such host call materializes the complete overlay-resident `Events` value before
+	/// slicing out the window — O(bytes²) total copying for a full scan, which the
+	/// linear per-byte charge can never bound (review measured 16× bytes → ~69× time on
+	/// that path). The scan therefore reads the value once and decodes in memory; this
+	/// pins the linear charge against the many-small-record workload (e.g. nested
+	/// batches of `remark_with_event`) that made the quadratic path reachable.
+	#[test]
+	fn wormhole_proof_recorder_scan_of_many_small_records_registers_formula_weight() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+
+			let call = RuntimeCall::System(frame_system::Call::remark { remark: vec![1] });
+			let weight_before = frame_system::Pallet::<Runtime>::block_weight().total();
+
+			let scanned = core::cell::Cell::new(0u32);
+			let scanned_bytes = core::cell::Cell::new(0u32);
+			run_lifecycle(&alice(), call, || {
+				for _ in 0..20_000u32 {
+					System::deposit_event(RuntimeEvent::System(frame_system::Event::Remarked {
+						sender: alice(),
+						hash: Default::default(),
+					}));
+				}
+				scanned.set(frame_system::Pallet::<Runtime>::event_count());
+				scanned_bytes.set(frame_system::Pallet::<Runtime>::event_bytes());
+			});
+			assert!(scanned.get() >= 20_000, "the deposits must be in the scanned stream");
+
+			let registered = frame_system::Pallet::<Runtime>::block_weight()
+				.total()
+				.saturating_sub(weight_before);
+			assert_eq!(
+				registered,
+				WormholeProofRecorderExtension::<Runtime>::event_scan_weight(
+					scanned.get(),
+					scanned_bytes.get()
+				),
+				"a scan across tens of thousands of small records must register exactly \
+				 the per-record + per-byte formula weight"
+			);
+		});
+	}
+
 	#[test]
 	fn wormhole_proof_recorder_extension_prepare_succeeds() {
 		new_test_ext().execute_with(|| {
@@ -1323,7 +1424,7 @@ mod tests {
 			let events_before = frame_system::Pallet::<Runtime>::event_count();
 			assert_ok!(ReversibleTransfers::cancel(RuntimeOrigin::signed(guardian.clone()), tx_id));
 
-			let recorded =
+			let (recorded, _) =
 				WormholeProofRecorderExtension::<Runtime>::record_proofs_from_events_since(
 					events_before,
 				);
@@ -1367,7 +1468,7 @@ mod tests {
 				MultiAddress::Id(bob()),
 			));
 
-			let recorded =
+			let (recorded, _) =
 				WormholeProofRecorderExtension::<Runtime>::record_proofs_from_events_since(
 					events_before,
 				);

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -395,6 +395,28 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 			//    (`Multisig::execute`, `ReversibleTransfers::recover_funds`, ...) can emit transfer
 			//    events the static `count_transfers` matcher cannot see, so the proof-recording
 			//    work above may exceed the weight reserved by `weight()`.
+			//
+			// "Post-hoc and not fee-charged" is a deliberate, accepted trade-off, not an
+			// oversight (security review 2026-08):
+			//
+			// - It cannot be fee-charged: the scan cost depends on how many events EARLIER
+			//   transactions in the same block emitted, unknowable when the fee is computed.
+			//   `TransactionExtension::weight()` is static by design, and post-dispatch fee
+			//   correction only refunds downward — `actual_weight` is capped at the
+			//   pre-charged weight. The only alternative, reserving a worst-case whole-block
+			//   scan in every transaction upfront, would collapse throughput to insure
+			//   against microseconds of work.
+			//
+			// - Block capacity stays sound: `register_extra_weight_unchecked` accrues into
+			//   `BlockWeight` before the NEXT transaction's `CheckWeight` admission, so
+			//   later transactions are refused once the block fills. The worst case is a
+			//   bounded one-transaction overshoot at the block boundary (the same accepted
+			//   pattern FRAME uses for `on_initialize` overruns).
+			//
+			// - The economics don't invert: emitting events is fully fee-charged through the
+			//   emitting calls' benchmarked weights, and the uncharged decode here is
+			//   ~1µs/record + ~10ns/byte — orders of magnitude below what the attacker pays
+			//   to produce those events.
 			let mut extra = Self::event_scan_weight(events_at_scan, event_bytes_at_scan);
 			if recorded > charged_transfers {
 				extra = extra.saturating_add(


### PR DESCRIPTION
# Security review follow-ups: event-scan metering, wormhole fee rounding

Addresses a batch of security-review findings. Two are fixed with red→green
regression tests, one is documented as an accepted design trade-off, and four
were assessed as not actionable (rationale below, for the review response).

## Fixes

### 1. Size-aware event-scan charge (`2e33dbe3`)

The proof-recorder extension's post-dispatch event scan was priced at a flat
1µs per `EventRecord`, based on a ~300-byte record assumption. The scan
stream-decodes every record present (`skip()` still decodes the prefix it
discards), and a legitimate `Multisig::ProposalExecuted` record can carry a
10 KiB stored call plus up to 100 approvers — an order of magnitude past the
assumption — with the charge landing via `register_extra_weight_unchecked`,
unbounded by block admission.

- Added `frame_system::Pallet::event_bytes()`: reads the encoded length of the
  `Events` storage value without decoding it.
- `event_scan_weight` now charges a per-record structural term **plus** a
  per-byte payload term (10ns/byte, ~10× ceiling over pure decode).
- New test: `wormhole_proof_recorder_scan_weight_scales_with_event_bytes`.

### 2. Wormhole volume fee: quantized-ceiling settlement (`7d7c4bd9`)

`process_exit_bundle` recomputed the volume fee in base units with truncating
division, while the circuit's integer relation over quantized amounts
(`out·10000 ≤ input·(10000−bps)`) forces every nonzero exit to lock at least
one full quantum (0.01 QUAN) of fee. A one-quantum exit therefore settled
4,001,600 base units instead of 10^10; the shortfall silently vanished from
burn, miner, and aggregator allocation.

- New `Pallet::volume_fee_for_exit`: `fee = ceil(exit_quanta · bps / (10000 −
  bps))` quanta, scaled back to base units. Exact (minted totals are always
  whole quanta), reproduces the proof-side minimum, and over the bundle total
  never exceeds what the proofs locked (`ceil(Σ) ≤ Σ ceil`).
- Updated `docs/wormhole-zk.md` and the six test sites that mirrored the old
  formula (now via an independently derived `ceil_volume_fee` test helper).
- New tests: `process_exit_bundle_settles_the_one_quantum_minimum_fee`
  (red: 4,001,600 vs 10,000,000,000),
  `process_exit_bundle_rounds_the_volume_fee_up_to_whole_quanta`
  (red: 20,008,003,201 vs 30,000,000,000).

## Accepted trade-off, now documented

### 3. Post-hoc, not-fee-charged event scan (`a522d340`)

Finding: the event scan and proof-recording shortfall are registered against
the block after dispatch and never priced into the transaction fee.

Accepted as designed, with the rationale now recorded next to the code:

- It **cannot** be fee-charged: the scan cost depends on how many events
  earlier transactions in the same block emitted, unknowable at fee time.
  `TransactionExtension::weight()` is static, and fee correction only refunds
  downward. Reserving the worst-case whole-block scan per transaction would
  collapse throughput.
- Block capacity stays sound: the extra weight accrues into `BlockWeight`
  before the next transaction's `CheckWeight` admission; worst case is a
  bounded one-transaction overshoot at the block boundary (the same pattern
  FRAME accepts for `on_initialize`).
- The economics don't invert: emitting events is fully fee-charged through the
  emitting calls' benchmarked weights, orders of magnitude above the ~1µs/record
  + ~10ns/byte decode cost imposed on the scan.

## Findings assessed as not actionable

### Treasury setter accepts reserved protocol accounts — rejected

`set_treasury_account` is root-only, and *any* wrong address (not just the
vesting pot or minting sentinel) strands future treasury rewards identically,
with no migration back. Denylisting two of 2^256 wrong values adds no real
protection; the safeguard is governance verifying the address it proposes.
The existing zero-address check covers the one structurally detectable case.

### Vesting `payout_weight` tree-model double count — deferred / accepted overcharge

The PoV term charges per raw read+write operation (`4d+9` keys) where the
distinct-key union is `4d+4` (`LeafCount`/`Depth`/`Root` appear in both sets),
a flat ~13 KB proof-size overcharge per payout; the benchmarked baseline's
tree footprint also stays under the added model (small, not safely
subtractable without regenerating baselines). Every error is in the
conservative direction (overcharge only — slightly higher fees, slightly
fewer payouts per block; no undercharge, no security impact). The weight
model for this code is being consolidated on the `illuzen/v12-vesting`
branch, so any correction belongs there, not here.

### `retarget_schedule` skips `treasury_and_pot()` — rejected

`treasury_and_pot()` is not a lifecycle-wide invariant; it is a lookup for the
two calls that move funds to/from the treasury (`create_schedule` funds the
pot from it, `end_schedule` refunds to it). `retarget_schedule` touches the
treasury in no way: it settles what any permissionless `claim` could already
force and swaps the beneficiary (validating `new_beneficiary != pot` and
`!= current`). Adding the check would block rotating a compromised
beneficiary key exactly when the treasury is misconfigured, for no safety
gain.