### PR TITLE
ci: Miner API version bump to quantus-miner-api-v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-miner-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ qp-high-security = { path = "./primitives/high-security", default-features = fal
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }
 qpow-math = { path = "./qpow-math", default-features = false }
-quantus-miner-api = { path = "./miner-api", version = "0.2.0", default-features = false }
+quantus-miner-api = { path = "./miner-api", version = "0.2.1", default-features = false }
 quantus-runtime = { path = "./runtime", default-features = false }
 sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
 sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = false }

--- a/miner-api/Cargo.toml
+++ b/miner-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 license.workspace = true
 name = "quantus-miner-api"
 repository.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 serde = { workspace = true, features = ["alloc", "derive"] }


### PR DESCRIPTION
## Miner API Release Proposal

This PR proposes releasing **quantus-miner-api** version `0.2.1`.

### Changes
- Updated `miner-api/Cargo.toml` version to `0.2.1`
- Updated `Cargo.toml` workspace dependency version to `0.2.1`
- Updated `Cargo.lock`
