### PR TITLE
Automate release for v0.9.0-endless-sky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.8.0-exodus"
+version = "0.9.0-endless-sky"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.8.0-exodus"
+version = "0.9.0-endless-sky"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.8.0-exodus"
+version = "0.9.0-endless-sky"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.8.0-exodus"
+version = "0.9.0-endless-sky"
 
 [lints]
 workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -76,7 +76,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 143,
+	spec_version: 144,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
Automated version bump for release v0.9.0-endless-sky.

https://github.com/Quantus-Network/chain/actions/runs/31361853329

Triggered by workflow run: major

Type: 