### PR TITLE
Checkpoint warp sync: mining-ready node in minutes (--sync warp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,12 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -868,7 +874,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2710,6 +2716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-display"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,7 +2806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3695,6 +3710,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -3704,7 +3738,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -3911,7 +3945,7 @@ dependencies = [
  "rand 0.10.1",
  "resolv-conf",
  "smallvec",
- "system-configuration",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3958,6 +3992,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -3969,12 +4014,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -3985,8 +4041,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4022,6 +4078,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -4030,9 +4110,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4045,19 +4125,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.32",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.3",
  "tower-service",
 ]
 
@@ -4071,9 +4165,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "libc",
  "pin-project-lite",
  "socket2 0.6.0",
@@ -4614,18 +4708,18 @@ version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "futures-util",
- "http",
+ "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
- "rustls",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.3",
  "tokio-util",
  "tracing",
  "url",
@@ -4641,8 +4735,8 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.4",
@@ -4677,10 +4771,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
 dependencies = [
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4703,7 +4797,7 @@ version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
 dependencies = [
- "http",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4715,7 +4809,7 @@ version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
 dependencies = [
- "http",
+ "http 1.3.1",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4886,7 +4980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.22.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -5267,6 +5361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5587,7 +5687,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6338,7 +6438,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -7180,7 +7280,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7200,7 +7300,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7637,8 +7737,9 @@ dependencies = [
  "quinn",
  "rand 0.8.6",
  "rcgen",
+ "reqwest",
  "rpassword",
- "rustls",
+ "rustls 0.23.32",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -7763,7 +7864,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.32",
  "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
@@ -7784,7 +7885,7 @@ dependencies = [
  "rand 0.9.5",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7804,7 +7905,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8098,6 +8199,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8263,7 +8405,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -8276,7 +8430,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -8291,6 +8445,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -8314,10 +8477,10 @@ dependencies = [
  "jni 0.21.1",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.32",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -8329,6 +8492,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -8364,6 +8537,12 @@ name = "ruzstd"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -8716,6 +8895,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.18",
 ]
@@ -9041,15 +9221,15 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "rand 0.8.6",
- "rustls",
+ "rustls 0.23.32",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -9139,9 +9319,9 @@ dependencies = [
  "forwarded-header-value",
  "futures",
  "governor",
- "http",
+ "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -9633,6 +9813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9841,12 +10031,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "serde",
@@ -10071,7 +10273,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
- "base64",
+ "base64 0.22.1",
  "bip39",
  "blake2-rfc",
  "bs58",
@@ -10124,7 +10326,7 @@ checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
 dependencies = [
  "async-channel 2.5.0",
  "async-lock",
- "base64",
+ "base64 0.22.1",
  "blake2-rfc",
  "bs58",
  "derive_more 2.0.1",
@@ -10184,10 +10386,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -11131,7 +11333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23e4bc8e910a312820d589047ab683928b761242dbe31dee081fbdb37cbe0be"
 dependencies = [
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
  "prometheus",
@@ -11342,7 +11544,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bip32",
  "bip39",
  "cfg-if",
@@ -11411,6 +11613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11438,13 +11646,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -11485,7 +11714,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -11726,11 +11955,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
- "rustls",
+ "rustls 0.23.32",
  "tokio",
 ]
 
@@ -11754,11 +11993,11 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.32",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.3",
  "tungstenite",
 ]
 
@@ -11870,8 +12109,8 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -12032,11 +12271,11 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -12734,7 +12973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
@@ -12931,6 +13170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12968,7 +13213,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/client/consensus/qpow/Cargo.toml
+++ b/client/consensus/qpow/Cargo.toml
@@ -28,6 +28,9 @@ sp-inherents = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+sp-state-machine = { workspace = true, default-features = true }
+
 [features]
 default = ["std"]
 std = [

--- a/client/consensus/qpow/src/chain_management.rs
+++ b/client/consensus/qpow/src/chain_management.rs
@@ -222,6 +222,14 @@ where
 	let finalize_number = best_number - finalize_depth.into();
 	log::debug!("Target block number to finalize: {:?}", finalize_number);
 
+	// Already finalized at or beyond the target — e.g. while the chain grows back
+	// past the reorg window after warp sync finalized the state target. Must
+	// return before the hash lookup: heights inside a not-yet-backfilled history
+	// gap have no number→hash mapping and would produce spurious errors.
+	if finalize_number <= client.info().finalized_number {
+		return Ok(());
+	}
+
 	// Get the hash for that block number in the current canonical chain
 	let finalize_hash = client
 		.hash(finalize_number)

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -24,7 +24,8 @@ use prometheus_endpoint::Registry;
 use sc_client_api::{self, backend::AuxStore, BlockOf, BlockchainEvents};
 use sc_consensus::{
 	BasicQueue, BlockCheckParams, BlockImport, BlockImportParams, BoxBlockImport,
-	BoxJustificationImport, ForkChoiceStrategy, ImportResult, JustificationSyncLink, Verifier,
+	BoxJustificationImport, ForkChoiceStrategy, ImportResult, JustificationSyncLink, StateAction,
+	StorageChanges, Verifier,
 };
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::HeaderBackend;
@@ -34,7 +35,7 @@ use sp_consensus_qpow::POW_ENGINE_ID;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::{
 	generic::{Digest, DigestItem},
-	traits::Header as HeaderT,
+	traits::{Header as HeaderT, NumberFor},
 };
 
 const LOG_TARGET: &str = "pow";
@@ -96,12 +97,53 @@ impl<B: BlockT> From<Error<B>> for ConsensusError {
 	}
 }
 
+/// How a block must be verified at import time, decided by where its state can
+/// come from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImportPolicy {
+	/// Parent state exists (or must exist): verify the seal via the runtime at
+	/// the parent block and account cumulative work. The only policy that can
+	/// make a block the new best.
+	FullVerify,
+	/// The state-sync target of warp sync: arrives with a complete state that
+	/// was proof-verified against the header's `state_root` by the state sync
+	/// protocol. No parent state exists by construction, so the seal cannot be
+	/// runtime-verified; the header itself is trusted by whoever resolved the
+	/// warp target (release anchor or checkpoint fetch).
+	StateImport,
+	/// A skip-execution import at or below the finalized head. History
+	/// backfill is disabled (see `create_gap` in the state import path), so
+	/// this is defense-in-depth: imported without execution, seals cannot be
+	/// runtime-verified without parent state, and never considered for best.
+	HistoricalSkip,
+}
+
+/// Classify an import. `StateAction::Skip` above the finalized head does NOT
+/// grant a verification skip: unsolicited near-tip blocks can arrive with
+/// `Skip` set by the sync layer, and they must still pass full verification
+/// (which fails closed when parent state is genuinely missing).
+fn import_policy<B: BlockT>(
+	state_action: &StateAction<B>,
+	number: NumberFor<B>,
+	finalized_number: NumberFor<B>,
+) -> ImportPolicy {
+	match state_action {
+		StateAction::ApplyChanges(StorageChanges::Import(_)) => ImportPolicy::StateImport,
+		StateAction::Skip if number <= finalized_number => ImportPolicy::HistoricalSkip,
+		_ => ImportPolicy::FullVerify,
+	}
+}
+
 /// A block importer for PoW.
 pub struct PowBlockImport<B: BlockT<Hash = H256>, I, C, CIDP, BE, const LOGGING_FREQUENCY: u64> {
 	inner: I,
 	client: Arc<C>,
 	create_inherent_data_providers: Arc<CIDP>,
 	check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
+	// Release-pinned checkpoint (number, post-seal hash). Any import at this
+	// height whose hash differs is rejected: the network's depth finalization
+	// makes the anchor irreversible, so a mismatch means a fabricated chain.
+	anchor: Option<(NumberFor<B>, B::Hash)>,
 	// Serializes the best-work read, fork-choice decision and inner import so
 	// concurrent imports cannot race on a stale best. Shared across clones.
 	import_lock: Arc<futures::lock::Mutex<()>>,
@@ -123,6 +165,7 @@ impl<
 			client: self.client.clone(),
 			create_inherent_data_providers: self.create_inherent_data_providers.clone(),
 			check_inherents_after: self.check_inherents_after,
+			anchor: self.anchor,
 			import_lock: self.import_lock.clone(),
 			_backend: PhantomData,
 		}
@@ -154,12 +197,14 @@ where
 		client: Arc<C>,
 		check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
 		create_inherent_data_providers: CIDP,
+		anchor: Option<(NumberFor<B>, B::Hash)>,
 	) -> Self {
 		Self {
 			inner,
 			client,
 			check_inherents_after,
 			create_inherent_data_providers: Arc::new(create_inherent_data_providers),
+			anchor,
 			import_lock: Arc::new(futures::lock::Mutex::new(())),
 			_backend: PhantomData,
 		}
@@ -245,6 +290,148 @@ where
 		}
 
 		let parent_hash = *block_import_params.header.parent_hash();
+		let block_number = *block_import_params.header.number();
+		let block_number_u64: u64 = block_number.try_into().unwrap_or(0);
+
+		// Get block hash (with seal). Must use the post-seal hash because that's how
+		// blocks are referenced:
+		// - parent_hash in child blocks references the post-seal hash
+		// - client.info().best_hash is the post-seal hash
+		let block_hash = block_import_params.post_header().hash();
+
+		let policy = import_policy::<B>(
+			&block_import_params.state_action,
+			block_number,
+			self.client.info().finalized_number,
+		);
+
+		// Anchor tripwire: the release-pinned checkpoint is network-final (depth
+		// finalization forbids reorgs across it), so any block at its height with a
+		// different hash — full sync fork, backfilled history, or a fabricated warp
+		// target's ancestry — is off the canonical chain and must be rejected.
+		if let Some((anchor_number, anchor_hash)) = self.anchor {
+			if block_number == anchor_number && block_hash != anchor_hash {
+				log::error!(
+					target: LOG_TARGET,
+					"Block #{} ({:?}) contradicts the pinned checkpoint {:?} at the same height; \
+					 rejecting import (chain does not contain the release checkpoint)",
+					block_number_u64,
+					block_hash,
+					anchor_hash
+				);
+				return Err(ConsensusError::ClientImport(format!(
+					"block {:?} contradicts pinned checkpoint {:?} at height {}",
+					block_hash, anchor_hash, block_number_u64
+				)));
+			}
+		}
+
+		// Every path requires a structurally sealed header (the verifier moved the
+		// seal into post_digests).
+		let inner_seal = fetch_seal::<B>(
+			block_import_params.post_digests.last(),
+			block_import_params.header.hash(),
+		)?;
+
+		// Log block import progress every LOGGING_FREQUENCY blocks
+		if block_number_u64.is_multiple_of(LOGGING_FREQUENCY) {
+			log::info!(
+				"⛏️ Imported blocks #{}-{}: {:?} - extrinsics_root={:?}, state_root={:?}",
+				block_number_u64.saturating_sub(LOGGING_FREQUENCY),
+				block_number,
+				block_import_params.header.hash(),
+				block_import_params.header.extrinsics_root(),
+				block_import_params.header.state_root()
+			);
+		} else {
+			log::debug!(
+				target: "qpow",
+				"⛏️ Importing block #{}: {:?} - extrinsics_root={:?}, state_root={:?}",
+				block_number,
+				block_import_params.header.hash(),
+				block_import_params.header.extrinsics_root(),
+				block_import_params.header.state_root()
+			);
+		}
+
+		match policy {
+			ImportPolicy::HistoricalSkip => {
+				// History at or below the finalized head, imported without
+				// execution. Gap backfill is disabled at the source (see
+				// `create_gap` below), so this path is defense-in-depth for stray
+				// skip-execution imports of already-finalized heights: no seal
+				// re-verification is possible without parent state, no work is
+				// accounted, and these blocks can never become best.
+				block_import_params.fork_choice = Some(ForkChoiceStrategy::Custom(false));
+				let _import_guard = self.import_lock.lock().await;
+				return self.inner.import_block(block_import_params).await.map_err(Into::into);
+			},
+			ImportPolicy::StateImport => {
+				// The warp/state-sync target: its state was proof-verified against
+				// the header's state_root by the state sync protocol, and the header
+				// itself is the resolved warp target. There is no parent state, so
+				// neither inherents nor the seal can be runtime-verified here.
+				block_import_params.fork_choice = Some(ForkChoiceStrategy::Custom(true));
+
+				// Do NOT record a block gap: gap backfill imports history ascending
+				// from genesis, where each header's linkage to the *canonical* chain
+				// cannot be verified until the fill meets this block — QPoW seals
+				// need parent state to verify, so a malicious peer could poison the
+				// canonical number→hash index with fabricated unverified history.
+				// Until backfill verifies linkage (descending fill or a pre-verified
+				// header chain), a warp-synced node serves history from this block
+				// forward only.
+				block_import_params.create_gap = false;
+
+				// Finalize atomically within the import operation: the network's
+				// depth rule already made the target irreversible, and a post-import
+				// `finalize_block()` call would fail — it walks the route from the
+				// last finalized block, and the target's ancestry headers do not
+				// exist. Import-time finalization marks the block Final directly
+				// and arms the depth-finalize guard for everything that follows.
+				block_import_params.finalized = true;
+
+				let _import_guard = self.import_lock.lock().await;
+
+				// Seed cumulative work at the pivot (mirrors genesis initialization):
+				// all post-pivot fork choice compares descendants of this block, so
+				// only relative work matters.
+				store_cumulative_achieved_work::<B, C>(&*self.client, block_hash, U512::one())
+					.map_err(|e| {
+						ConsensusError::ClientImport(format!(
+							"Failed to seed achieved work at state sync target {:?}: {:?}",
+							block_hash, e
+						))
+					})?;
+
+				let result = match self.inner.import_block(block_import_params).await {
+					Ok(result) => result,
+					Err(e) => {
+						if let Err(cleanup_err) =
+							delete_cumulative_achieved_work::<B, C>(&*self.client, block_hash)
+						{
+							log::warn!(
+								target: LOG_TARGET,
+								"Failed to clean up achieved work after failed state import for {:?}: {:?}",
+								block_hash,
+								cleanup_err
+							);
+						}
+						return Err(e.into());
+					},
+				};
+
+				log::info!(
+					"🎯 State sync target #{} ({:?}) imported and finalized; \
+					 serving chain from this block forward",
+					block_number_u64,
+					block_hash
+				);
+
+				return Ok(result);
+			},
+			ImportPolicy::FullVerify => {},
+		}
 
 		if let Some(inner_body) = block_import_params.body.take() {
 			let check_block = B::new(block_import_params.header.clone(), inner_body);
@@ -262,11 +449,6 @@ where
 
 			block_import_params.body = Some(check_block.deconstruct().1);
 		}
-
-		let inner_seal = fetch_seal::<B>(
-			block_import_params.post_digests.last(),
-			block_import_params.header.hash(),
-		)?;
 
 		let pre_hash = block_import_params.header.hash();
 
@@ -317,35 +499,6 @@ where
 			info.best_number,
 		);
 		block_import_params.fork_choice = Some(ForkChoiceStrategy::Custom(is_best));
-
-		// Get block hash (with seal) for achieved work storage.
-		// Must use the post-seal hash because that's how blocks are referenced:
-		// - parent_hash in child blocks references the post-seal hash
-		// - client.info().best_hash is the post-seal hash
-		let block_hash = block_import_params.post_header().hash();
-
-		// Log block import progress every LOGGING_FREQUENCY blocks
-		let block_number = block_import_params.header.number();
-		let block_number_u64: u64 = (*block_number).try_into().unwrap_or(0);
-		if block_number_u64.is_multiple_of(LOGGING_FREQUENCY) {
-			log::info!(
-				"⛏️ Imported blocks #{}-{}: {:?} - extrinsics_root={:?}, state_root={:?}",
-				block_number_u64.saturating_sub(LOGGING_FREQUENCY),
-				block_number,
-				block_import_params.header.hash(),
-				block_import_params.header.extrinsics_root(),
-				block_import_params.header.state_root()
-			);
-		} else {
-			log::debug!(
-				target: "qpow",
-				"⛏️ Importing block #{}: {:?} - extrinsics_root={:?}, state_root={:?}",
-				block_number,
-				block_import_params.header.hash(),
-				block_import_params.header.extrinsics_root(),
-				block_import_params.header.state_root()
-			);
-		}
 
 		// Store cumulative achieved work BEFORE inner import, because inner import
 		// triggers notifications that call best_chain which needs this data.
@@ -767,6 +920,59 @@ mod tests {
 
 		let err = result.err().expect("oversized digest must be rejected");
 		assert!(err.contains("exceeding the"), "expected the digest-length rejection, got: {err}");
+	}
+
+	fn state_import_action() -> StateAction<TestBlock> {
+		StateAction::ApplyChanges(StorageChanges::Import(sc_consensus::ImportedState {
+			block: Default::default(),
+			state: sp_state_machine::KeyValueStates(Vec::new()),
+		}))
+	}
+
+	/// A proof-verified state-sync target is always classified `StateImport`,
+	/// regardless of its height relative to the finalized head.
+	#[test]
+	fn policy_state_import_wins_over_height() {
+		assert_eq!(
+			import_policy::<TestBlock>(&state_import_action(), 50, 100),
+			ImportPolicy::StateImport
+		);
+		assert_eq!(
+			import_policy::<TestBlock>(&state_import_action(), 500, 100),
+			ImportPolicy::StateImport
+		);
+	}
+
+	/// `Skip` grants a verification skip only at or below the finalized head
+	/// (history backfill); above it, full verification stays mandatory so
+	/// unsolicited near-tip blocks cannot dodge the seal check.
+	#[test]
+	fn policy_skip_only_below_finalized() {
+		assert_eq!(
+			import_policy::<TestBlock>(&StateAction::Skip, 99, 100),
+			ImportPolicy::HistoricalSkip
+		);
+		assert_eq!(
+			import_policy::<TestBlock>(&StateAction::Skip, 100, 100),
+			ImportPolicy::HistoricalSkip
+		);
+		assert_eq!(
+			import_policy::<TestBlock>(&StateAction::Skip, 101, 100),
+			ImportPolicy::FullVerify
+		);
+	}
+
+	/// Execution paths (mined blocks, normal sync) always fully verify.
+	#[test]
+	fn policy_execution_paths_fully_verify() {
+		assert_eq!(
+			import_policy::<TestBlock>(&StateAction::Execute, 5, 100),
+			ImportPolicy::FullVerify
+		);
+		assert_eq!(
+			import_policy::<TestBlock>(&StateAction::ExecuteIfPossible, 5, 100),
+			ImportPolicy::FullVerify
+		);
 	}
 
 	/// The canonical digest fits the window exactly and must pass the length

--- a/docs/FAST_SYNC.md
+++ b/docs/FAST_SYNC.md
@@ -1,0 +1,136 @@
+# Fast sync (checkpoint warp sync)
+
+A new node normally replays every block from genesis (~1.5–2 h on a year-old
+chain, growing with chain age). Warp sync gets a mining-ready node in minutes,
+independent of chain age:
+
+1. Resolve a **checkpoint** — a single trusted header, normally the network's
+   current finalized head (`best − max_reorg_depth`).
+2. Download the checkpoint block from peers.
+3. Download the full state at the checkpoint from peers, with every chunk
+   Merkle-proof-verified against the checkpoint header's `state_root`.
+4. Sync checkpoint → tip with normal full verification (execution + seal
+   checks). Mining starts here.
+
+History below the checkpoint is **not** downloaded: a warp-synced node serves
+blocks and state from the checkpoint forward only. (Background backfill is
+deliberately disabled for now — ascending gap fill would write unverifiable
+history into the canonical index, see Follow-ups. Nodes that need full history
+must full-sync.)
+
+## Usage
+
+```sh
+quantus-node --chain heisenberg --sync warp
+```
+
+The checkpoint is resolved automatically (see below). To pin it manually:
+
+```sh
+# Explicit checkpoint endpoints (all reachable endpoints must agree):
+quantus-node --chain heisenberg --sync warp \
+    --checkpoint-url https://a1-heisenberg.quantus.cat \
+    --checkpoint-url https://a2-heisenberg.quantus.cat
+
+# Fully operator-pinned target (SCALE-encoded header, 0x hex):
+quantus-node --chain heisenberg --sync warp --checkpoint-header 0x...
+```
+
+`--sync fast` / `--sync fast-unsafe` are rejected: QPoW seal verification needs
+the parent block's state, which fast sync skips creating. Warp sync is the
+supported fast path.
+
+Warp-synced nodes keep a rolling state window (256 blocks) instead of archive
+state: archive pruning refuses warp sync by design, since pre-checkpoint state
+is never downloaded. Nodes that need full historical state must full-sync.
+
+## Checkpoint resolution
+
+First match wins:
+
+1. `--checkpoint-header` — operator-pinned SCALE header hex.
+2. Fetched from checkpoint endpoints (`--checkpoint-url`, or the chain spec
+   `checkpointUrls` property). Each endpoint reports its finalized head; the
+   returned header must hash to the reported finalized hash; the candidate is
+   the lowest finalized height among responders and every other responder must
+   confirm its hash at that height. Disagreement aborts the fetch.
+3. The **release anchor**: the `checkpointHeader` chain spec property. A stale
+   anchor still syncs — catch-up just re-executes the blocks mined since the
+   release (~25–30 min per month of staleness).
+
+If nothing resolves, the node exits with an error rather than silently full
+syncing.
+
+## Trust model
+
+- The network already runs on rolling finality: every node finalizes
+  `best − max_reorg_depth` (100 blocks ≈ 20 min) and refuses deeper reorgs, so
+  the canonical chain past that depth is already subjective. A checkpoint no
+  older than that is exactly as trusted as the binary, genesis, and bootnodes
+  it ships alongside.
+- Everything except the checkpoint header itself is verified: state by Merkle
+  proofs against `state_root`, checkpoint → tip by full execution and seal
+  verification.
+- Fetched checkpoints are fenced by the release anchor at resolution time: a
+  fetched target may never be older than the anchor, and at the anchor's own
+  height it must be the anchor. Independently, any imported block at the
+  anchor's height that is not the anchor is rejected (this also shields full
+  sync from deep fabricated forks).
+- Residual trust in the fetch path: if **every** queried checkpoint endpoint
+  colludes (and no `--checkpoint-header` is pinned), they can hand out a
+  fabricated chain above the anchor height, and nothing in v1 cross-checks its
+  ancestry against the real chain. Endpoints are operator-run over TLS and all
+  must agree, so this is the same class of trust as the bootnode/release
+  channel — but unlike the release anchor it is exercised on every sync. Use
+  independent hosts for `checkpointUrls`, or pin `--checkpoint-header` for
+  zero fetch trust. The header-chain verification follow-up below closes this
+  gap entirely.
+
+## Release process
+
+CI should refresh the anchor at release cut (follow-up: automate in the
+release workflow):
+
+```sh
+FINALIZED=$(curl -s -H 'Content-Type: application/json' \
+    -d '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]}' \
+    https://a1-heisenberg.quantus.cat | jq -r .result)
+HEADER_HEX=$(quantus-node key … )   # SCALE-encode the header at $FINALIZED
+jq --arg h "$HEADER_HEX" '.properties.checkpointHeader = $h' \
+    node/src/chain-specs/heisenberg.json > tmp && mv tmp node/src/chain-specs/heisenberg.json
+```
+
+(The SCALE encoding of a header is `chain_getHeader` fields in SCALE form;
+a small CI helper or `state_getReadProof`-free script can produce it. Until
+automated, `checkpointUrls` alone keeps warp sync fresh.)
+
+## Consensus changes behind this (client/consensus/qpow)
+
+- Imports are classified by state availability: the proof-verified state
+  target skips runtime verification (its parent's state cannot exist), stray
+  skip-execution imports at or below the finalized head skip seal
+  re-verification and can never become best, and **everything else keeps
+  today's full verification** — near-tip blocks always have their seals
+  runtime-verified.
+- The state target is imported without recording a block gap (no backfill)
+  and is finalized on import, which arms the depth-finalization guard.
+- Cumulative work is seeded at the state target (like genesis): post-target
+  fork choice only ever compares descendants of the target.
+
+## Follow-ups
+
+- **Verified history backfill.** Upstream gap sync fills ascending from
+  genesis and trusts the verifier to validate headers statelessly — possible
+  for BABE (epoch data chains forward from genesis), impossible for QPoW
+  (target difficulty lives in state). Backfill therefore needs either
+  descending fill (each block checked against the parent hash its
+  already-imported child commits to) or a pre-verified header chain walked
+  down from the checkpoint. Until then `create_gap` stays off.
+- **Header-chain verification of fetched targets**: walk anchor → target
+  headers (hash linkage + stateless achieved-work via qpow-math, with capped
+  per-block contribution to blunt the achieved-work heavy tail). Removes the
+  residual collusion trust in checkpoint endpoints and doubles as the
+  pre-verified chain for backfill.
+- CI automation for the release anchor (`checkpointHeader` injection).
+- In-protocol checkpoint fetch (peer quorum over the p2p network) instead of
+  RPC endpoints, removing the URL configuration entirely.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -50,6 +50,7 @@ rand = { workspace = true, default-features = false, features = [
 	"getrandom",
 ] }
 rcgen = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 rpassword = { workspace = true }
 rustls = { workspace = true }
 sc-basic-authorship.default-features = true

--- a/node/src/chain-specs/heisenberg.json
+++ b/node/src/chain-specs/heisenberg.json
@@ -16,7 +16,11 @@
   "properties": {
     "ss58Format": 189,
     "tokenDecimals": 12,
-    "tokenSymbol": "HEI"
+    "tokenSymbol": "HEI",
+    "checkpointUrls": [
+      "https://a1-heisenberg.quantus.cat",
+      "https://a2-heisenberg.quantus.cat"
+    ]
   },
   "codeSubstitutes": {},
   "genesis": {

--- a/node/src/chain-specs/planck.json
+++ b/node/src/chain-specs/planck.json
@@ -17,7 +17,11 @@
   "properties": {
     "ss58Format": 189,
     "tokenDecimals": 12,
-    "tokenSymbol": "PLK"
+    "tokenSymbol": "PLK",
+    "checkpointUrls": [
+      "https://a1-planck.quantus.cat",
+      "https://a2-planck.quantus.cat"
+    ]
   },
   "codeSubstitutes": {},
   "genesis": {

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -42,6 +42,10 @@ pub fn heisenberg_chain_spec() -> Result<ChainSpec, String> {
 	properties.insert("tokenDecimals".into(), json!(12));
 	properties.insert("tokenSymbol".into(), json!("HEI"));
 	properties.insert("ss58Format".into(), json!(189));
+	properties.insert(
+		"checkpointUrls".into(),
+		json!(["https://a1-heisenberg.quantus.cat", "https://a2-heisenberg.quantus.cat"]),
+	);
 
 	let telemetry_endpoints = TelemetryEndpoints::new(vec![(
 		"/dns/shard-telemetry.quantus.cat/tcp/443/x-parity-wss/%2Fsubmit%2F".to_string(),
@@ -79,6 +83,10 @@ pub fn planck_chain_spec() -> Result<ChainSpec, String> {
 	properties.insert("tokenDecimals".into(), json!(12));
 	properties.insert("tokenSymbol".into(), json!("PLK"));
 	properties.insert("ss58Format".into(), json!(189));
+	properties.insert(
+		"checkpointUrls".into(),
+		json!(["https://a1-planck.quantus.cat", "https://a2-planck.quantus.cat"]),
+	);
 
 	let telemetry_endpoints = TelemetryEndpoints::new(vec![(
 		"/dns/shard-telemetry.quantus.cat/tcp/443/x-parity-wss/%2Fsubmit%2F".to_string(),

--- a/node/src/checkpoint.rs
+++ b/node/src/checkpoint.rs
@@ -1,0 +1,300 @@
+//! Warp sync checkpoint resolution.
+//!
+//! A checkpoint is a single trusted header: the warp sync target whose
+//! `state_root` the downloaded state is proof-verified against. Everything
+//! else about fast sync is verified; the checkpoint header is the one input
+//! that must come from a trusted place. Resolution ladder (first match wins):
+//!
+//! 1. `--checkpoint-header` — operator-pinned SCALE-encoded header hex.
+//! 2. Fetched from checkpoint RPC endpoints (`--checkpoint-url`, or the chain spec `checkpointUrls`
+//!    property): the network's current finalized head. Every endpoint that responds must agree on
+//!    the chosen block, and the result must not contradict the release anchor.
+//! 3. The release anchor baked into the chain spec (`checkpointHeader` property) — refreshed by CI
+//!    at release cut. Stale anchors still sync, they just re-execute the blocks mined since the
+//!    release.
+//!
+//! Independent of resolution, the release anchor is enforced at import time:
+//! backfilled history must contain the anchor block, so a fabricated target
+//! from compromised endpoints is detected minutes after joining.
+
+use codec::Decode;
+use quantus_runtime::opaque::Block;
+use sc_service::ChainSpec;
+use serde::Deserialize;
+use sp_core::H256;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use std::time::Duration;
+
+/// The node's header type (Poseidon block hash, BlakeTwo256 state trie).
+pub type Header = <Block as BlockT>::Header;
+
+const CHECKPOINT_HEADER_PROPERTY: &str = "checkpointHeader";
+const CHECKPOINT_URLS_PROPERTY: &str = "checkpointUrls";
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn parse_h256(value: &str) -> Result<H256, String> {
+	let bytes = hex::decode(value.trim_start_matches("0x"))
+		.map_err(|e| format!("invalid hex in hash {value:?}: {e}"))?;
+	if bytes.len() != 32 {
+		return Err(format!("hash {value:?} is {} bytes, expected 32", bytes.len()));
+	}
+	Ok(H256::from_slice(&bytes))
+}
+
+/// Decode a SCALE-encoded header from 0x-prefixed hex.
+pub fn decode_header_hex(value: &str) -> Result<Header, String> {
+	let bytes = hex::decode(value.trim_start_matches("0x"))
+		.map_err(|e| format!("checkpoint header is not valid hex: {e}"))?;
+	Header::decode(&mut &bytes[..])
+		.map_err(|e| format!("checkpoint header does not SCALE-decode: {e}"))
+}
+
+/// The release anchor pinned in the chain spec, if any.
+pub fn anchor_from_spec(spec: &dyn ChainSpec) -> Result<Option<Header>, String> {
+	match spec.properties().get(CHECKPOINT_HEADER_PROPERTY) {
+		Some(value) => {
+			let hex = value.as_str().ok_or_else(|| {
+				format!("chain spec property {CHECKPOINT_HEADER_PROPERTY} must be a hex string")
+			})?;
+			decode_header_hex(hex).map(Some)
+		},
+		None => Ok(None),
+	}
+}
+
+/// Checkpoint RPC endpoints listed in the chain spec, if any.
+pub fn urls_from_spec(spec: &dyn ChainSpec) -> Vec<String> {
+	spec.properties()
+		.get(CHECKPOINT_URLS_PROPERTY)
+		.and_then(|v| v.as_array().cloned())
+		.map(|urls| urls.iter().filter_map(|u| u.as_str().map(str::to_owned)).collect())
+		.unwrap_or_default()
+}
+
+/// A fetched target must extend (or be) the release anchor's chain: it can
+/// never be older than the anchor, and at the anchor's own height it must be
+/// the anchor.
+fn validate_against_anchor(target: &Header, anchor: Option<&Header>) -> Result<(), String> {
+	let Some(anchor) = anchor else { return Ok(()) };
+	if target.number() < anchor.number() {
+		return Err(format!(
+			"fetched checkpoint #{} is older than the release anchor #{}; \
+			 endpoints are stale or on a different chain",
+			target.number(),
+			anchor.number()
+		));
+	}
+	if target.number() == anchor.number() && target.hash() != anchor.hash() {
+		return Err(format!(
+			"fetched checkpoint {:?} contradicts the release anchor {:?} at height {}",
+			target.hash(),
+			anchor.hash(),
+			anchor.number()
+		));
+	}
+	Ok(())
+}
+
+#[derive(Deserialize)]
+struct RpcEnvelope<T> {
+	result: Option<T>,
+	error: Option<serde_json::Value>,
+}
+
+async fn rpc_call<T: serde::de::DeserializeOwned>(
+	client: &reqwest::Client,
+	url: &str,
+	method: &str,
+	params: serde_json::Value,
+) -> Result<T, String> {
+	let body = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params });
+	let response = client
+		.post(url)
+		.json(&body)
+		.send()
+		.await
+		.map_err(|e| format!("{method} request to {url} failed: {e}"))?;
+	let envelope: RpcEnvelope<T> = response
+		.json()
+		.await
+		.map_err(|e| format!("{method} response from {url} malformed: {e}"))?;
+	if let Some(error) = envelope.error {
+		return Err(format!("{method} on {url} returned error: {error}"));
+	}
+	envelope.result.ok_or_else(|| format!("{method} on {url} returned no result"))
+}
+
+/// Fetch an endpoint's finalized head and verify the returned header actually
+/// hashes to it, so an endpoint cannot pair a plausible hash with a body of
+/// its choosing.
+async fn fetch_finalized_header(client: &reqwest::Client, url: &str) -> Result<Header, String> {
+	let finalized: String =
+		rpc_call(client, url, "chain_getFinalizedHead", serde_json::json!([])).await?;
+	let header: Header =
+		rpc_call(client, url, "chain_getHeader", serde_json::json!([finalized])).await?;
+	let expected = parse_h256(&finalized)?;
+	if header.hash() != expected {
+		return Err(format!(
+			"{url} returned a header hashing to {:?} for finalized head {expected:?}",
+			header.hash()
+		));
+	}
+	Ok(header)
+}
+
+/// Fetch the network's finalized head from every endpoint. The candidate is
+/// the lowest finalized height among responders (every other responder has
+/// finalized at least that height, so all honest endpoints agree on its hash),
+/// and every other responder must confirm the candidate's hash at that height.
+async fn fetch_agreed_target(urls: &[String]) -> Result<Header, String> {
+	let client = reqwest::Client::builder()
+		.timeout(RPC_TIMEOUT)
+		.build()
+		.map_err(|e| format!("failed to build checkpoint HTTP client: {e}"))?;
+
+	let mut fetched: Vec<(&str, Header)> = Vec::new();
+	for url in urls {
+		match fetch_finalized_header(&client, url).await {
+			Ok(header) => fetched.push((url, header)),
+			Err(e) => log::warn!("Checkpoint endpoint unavailable: {e}"),
+		}
+	}
+	let Some((candidate_url, candidate)) = fetched.iter().min_by_key(|(_, h)| *h.number()).cloned()
+	else {
+		return Err(format!("no checkpoint endpoint reachable (tried {})", urls.join(", ")));
+	};
+
+	let candidate_hash = candidate.hash();
+	for (url, _) in fetched.iter().filter(|(url, _)| *url != candidate_url) {
+		let confirmed: Option<String> =
+			rpc_call(&client, url, "chain_getBlockHash", serde_json::json!([candidate.number()]))
+				.await?;
+		let confirmed = confirmed
+			.ok_or_else(|| format!("{url} has no block at height {}", candidate.number()))
+			.and_then(|h| parse_h256(&h))?;
+		if confirmed != candidate_hash {
+			return Err(format!(
+				"checkpoint endpoints disagree at height {}: {candidate_url} has {candidate_hash:?}, \
+				 {url} has {confirmed:?}; refusing to pick a side",
+				candidate.number()
+			));
+		}
+	}
+
+	if fetched.len() < urls.len() {
+		log::warn!(
+			"Checkpoint agreed by {}/{} endpoints (the rest were unreachable)",
+			fetched.len(),
+			urls.len()
+		);
+	}
+	Ok(candidate)
+}
+
+/// Resolve the warp sync target via the ladder described in the module docs.
+pub async fn resolve_warp_target(
+	cli_header_hex: Option<&str>,
+	cli_urls: &[String],
+	spec: &dyn ChainSpec,
+) -> Result<Header, String> {
+	if let Some(hex) = cli_header_hex {
+		let header = decode_header_hex(hex)?;
+		log::info!(
+			"🎯 Warp sync target pinned via --checkpoint-header: #{} ({:?})",
+			header.number(),
+			header.hash()
+		);
+		return Ok(header);
+	}
+
+	let anchor = anchor_from_spec(spec)?;
+	let urls = if cli_urls.is_empty() { urls_from_spec(spec) } else { cli_urls.to_vec() };
+
+	if !urls.is_empty() {
+		match fetch_agreed_target(&urls).await {
+			Ok(target) => match validate_against_anchor(&target, anchor.as_ref()) {
+				Ok(()) => {
+					log::info!(
+						"🎯 Warp sync target fetched from checkpoint endpoints: #{} ({:?})",
+						target.number(),
+						target.hash()
+					);
+					return Ok(target);
+				},
+				Err(e) => log::warn!("Fetched checkpoint rejected: {e}"),
+			},
+			Err(e) => log::warn!("Checkpoint fetch failed: {e}"),
+		}
+		if anchor.is_some() {
+			log::warn!("Falling back to the release anchor checkpoint");
+		}
+	}
+
+	if let Some(anchor) = anchor {
+		log::warn!(
+			"🎯 Warp sync target is the release anchor #{} ({:?}); blocks mined since the \
+			 release will be re-executed during catch-up",
+			anchor.number(),
+			anchor.hash()
+		);
+		return Ok(anchor);
+	}
+
+	Err(format!(
+		"warp sync needs a checkpoint: pass --checkpoint-header or --checkpoint-url, or use a \
+		 chain spec with {CHECKPOINT_HEADER_PROPERTY}/{CHECKPOINT_URLS_PROPERTY} properties"
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::Encode;
+	use sp_core::Hasher;
+	use sp_runtime::traits::BlakeTwo256;
+
+	fn header(number: u32) -> Header {
+		<Header as HeaderT>::new(
+			number,
+			BlakeTwo256::hash(b"extrinsics"),
+			BlakeTwo256::hash(b"state"),
+			H256::repeat_byte(number as u8),
+			Default::default(),
+		)
+	}
+
+	#[test]
+	fn header_hex_round_trips() {
+		let original = header(856_000);
+		let hex = format!("0x{}", hex::encode(original.encode()));
+		let decoded = decode_header_hex(&hex).expect("round trip");
+		assert_eq!(decoded, original);
+		assert_eq!(decoded.hash(), original.hash());
+	}
+
+	#[test]
+	fn malformed_header_hex_is_rejected() {
+		assert!(decode_header_hex("0xzz").is_err());
+		assert!(decode_header_hex("0x0102").is_err());
+	}
+
+	#[test]
+	fn target_must_extend_the_anchor() {
+		let anchor = header(100);
+		assert!(validate_against_anchor(&header(101), Some(&anchor)).is_ok());
+		assert!(validate_against_anchor(&anchor.clone(), Some(&anchor)).is_ok());
+		assert!(validate_against_anchor(&header(99), Some(&anchor)).is_err());
+		// Same height, different content: contradicts the anchor.
+		let mut impostor = header(100);
+		impostor.set_parent_hash(H256::repeat_byte(0xEE));
+		assert!(validate_against_anchor(&impostor, Some(&anchor)).is_err());
+		assert!(validate_against_anchor(&header(1), None).is_ok());
+	}
+
+	#[test]
+	fn spec_without_checkpoint_properties_yields_nothing() {
+		let spec = crate::chain_spec::development_chain_spec().expect("dev spec");
+		assert!(anchor_from_spec(&spec).expect("no anchor is fine").is_none());
+		assert!(urls_from_spec(&spec).is_empty());
+	}
+}

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -36,6 +36,17 @@ pub struct Cli {
 	/// Sync: block request timeout in seconds (default: 30).
 	#[arg(long, default_value_t = 30)]
 	pub sync_block_request_timeout: u64,
+
+	/// Warp sync: pin the checkpoint (warp target) to this SCALE-encoded header
+	/// (0x-prefixed hex). Overrides checkpoint fetching and the chain spec anchor.
+	#[arg(long, value_name = "HEX_HEADER")]
+	pub checkpoint_header: Option<String>,
+
+	/// Warp sync: RPC endpoint to fetch the checkpoint (network finalized head)
+	/// from. Repeatable; all reachable endpoints must agree. Overrides the chain
+	/// spec's checkpointUrls.
+	#[arg(long, value_name = "URL")]
+	pub checkpoint_url: Vec<String>,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -559,9 +559,29 @@ pub fn run() -> sc_cli::Result<()> {
 			log::info!("Run until exit ....");
 			let runner = cli.create_runner(&cli.run)?;
 			runner.run_node_until_exit(|mut config| async move {
+				// Fast sync cannot verify QPoW seals for the history it skips
+				// executing; warp sync is the supported fast path.
+				if matches!(
+					cli.run.network_params.sync,
+					sc_cli::arg_enums::SyncMode::Fast | sc_cli::arg_enums::SyncMode::FastUnsafe
+				) {
+					return Err(sc_cli::Error::Input(
+						"--sync fast/fast-unsafe is not supported on this chain; use --sync warp"
+							.into(),
+					));
+				}
+				let warp_sync =
+					matches!(cli.run.network_params.sync, sc_cli::arg_enums::SyncMode::Warp);
+
 				//Obligatory configuration for all node holders
 				config.blocks_pruning = BlocksPruning::KeepFinalized;
-				config.state_pruning = Some(PruningMode::ArchiveCanonical);
+				// Archive state refuses warp sync by design (pre-checkpoint state is
+				// never downloaded), so warp nodes keep a rolling state window instead.
+				config.state_pruning = Some(if warp_sync {
+					PruningMode::blocks_pruning(256)
+				} else {
+					PruningMode::ArchiveCanonical
+				});
 
 				// Note: We parse node_key_file here to make a Dilithium keypair.
 				// We then override the net config object parsed by sc_cli so we don't have to
@@ -669,6 +689,20 @@ pub fn run() -> sc_cli::Result<()> {
 				// Allow mining without peers if --dev or --force-authoring is set
 				let allow_mining_without_peers = config.force_authoring;
 
+				let warp_target = if warp_sync {
+					Some(
+						crate::checkpoint::resolve_warp_target(
+							cli.checkpoint_header.as_deref(),
+							&cli.checkpoint_url,
+							&*config.chain_spec,
+						)
+						.await
+						.map_err(sc_cli::Error::Input)?,
+					)
+				} else {
+					None
+				};
+
 				log::info!("Using litep2p network backend (with Dilithium)");
 				service::new_full::<sc_network::litep2p::Litep2pNetworkBackend>(
 					config,
@@ -679,6 +713,7 @@ pub fn run() -> sc_cli::Result<()> {
 					cli.sync_disable_major_sync_gating,
 					cli.sync_block_request_timeout,
 					allow_mining_without_peers,
+					warp_target,
 				)
 				.map_err(sc_cli::Error::Service)
 			})

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -322,6 +322,33 @@ impl SubstrateCli for Cli {
 	}
 }
 
+/// Resolve the enforced state pruning mode against an explicit `--state-pruning`
+/// request. Full-sync nodes are fixed to archive-canonical; warp-sync nodes never
+/// download pre-checkpoint state, so they keep a rolling window of at least 256
+/// finalized blocks.
+fn resolve_state_pruning(
+	warp_sync: bool,
+	requested: Option<PruningMode>,
+) -> Result<PruningMode, String> {
+	const WARP_MIN_WINDOW: u32 = 256;
+	match (warp_sync, requested) {
+		(true, None) => Ok(PruningMode::blocks_pruning(WARP_MIN_WINDOW)),
+		(true, Some(PruningMode::Constrained(c)))
+			if c.max_blocks.unwrap_or(0) >= WARP_MIN_WINDOW =>
+			Ok(PruningMode::Constrained(c)),
+		(true, Some(_)) => Err(format!(
+			"--sync warp keeps a rolling state window; pass --state-pruning {WARP_MIN_WINDOW} \
+			 or larger (archive modes cannot warp sync)"
+		)),
+		(false, None) | (false, Some(PruningMode::ArchiveCanonical)) =>
+			Ok(PruningMode::ArchiveCanonical),
+		(false, Some(_)) =>
+			Err("--state-pruning is fixed to archive-canonical on full-sync nodes; drop the flag \
+			 (use --sync warp for a pruned node)"
+				.to_string()),
+	}
+}
+
 /// Parse and run command line arguments
 #[allow(clippy::result_large_err)]
 pub fn run() -> sc_cli::Result<()> {
@@ -573,21 +600,39 @@ pub fn run() -> sc_cli::Result<()> {
 				let warp_sync =
 					matches!(cli.run.network_params.sync, sc_cli::arg_enums::SyncMode::Warp);
 
-				//Obligatory configuration for all node holders
-				config.blocks_pruning = BlocksPruning::KeepFinalized;
-				// Archive state refuses warp sync by design (pre-checkpoint state is
-				// never downloaded), so warp nodes keep a rolling state window instead.
-				config.state_pruning = Some(if warp_sync {
-					PruningMode::blocks_pruning(256)
-				} else {
-					PruningMode::ArchiveCanonical
-				});
+				if !warp_sync && (cli.checkpoint_header.is_some() || !cli.checkpoint_url.is_empty())
+				{
+					return Err(sc_cli::Error::Input(
+						"--checkpoint-header/--checkpoint-url require --sync warp".into(),
+					));
+				}
 
-				// Note: We parse node_key_file here to make a Dilithium keypair.
-				// We then override the net config object parsed by sc_cli so we don't have to
-				// fork sc_cli.
-				let key_path =
-					if let Some(path_str) = &cli.run.network_params.node_key_params.node_key_file {
+				//Obligatory configuration for all node holders. Explicit pruning flags
+				// must match what the node enforces — anything else fails loudly
+				// instead of being silently overridden.
+				if cli.run.import_params.pruning_params.blocks_pruning()? !=
+					BlocksPruning::KeepFinalized
+				{
+					return Err(sc_cli::Error::Input(
+						"--blocks-pruning is fixed to archive-canonical on this node".into(),
+					));
+				}
+				config.blocks_pruning = BlocksPruning::KeepFinalized;
+				config.state_pruning = Some(
+					resolve_state_pruning(
+						warp_sync,
+						cli.run.import_params.pruning_params.state_pruning()?,
+					)
+					.map_err(sc_cli::Error::Input)?,
+				);
+
+				// An explicit --node-key was already parsed into the config by sc_cli
+				// (Dilithium secret input); otherwise the identity comes from a key
+				// file, resolved here to an absolute path.
+				if cli.run.network_params.node_key_params.node_key.is_none() {
+					let key_path = if let Some(path_str) =
+						&cli.run.network_params.node_key_params.node_key_file
+					{
 						let path = std::path::Path::new(path_str);
 						if path.is_absolute() {
 							path.to_path_buf()
@@ -599,9 +644,10 @@ pub fn run() -> sc_cli::Result<()> {
 						config.network.net_config_path.clone().unwrap().join("secret_dilithium")
 					};
 
-				log::debug!(target: "network", "node identity file: {:?}", key_path);
+					log::debug!(target: "network", "node identity file: {:?}", key_path);
 
-				config.network.node_key = NodeKeyConfig::Dilithium(Secret::File(key_path));
+					config.network.node_key = NodeKeyConfig::Dilithium(Secret::File(key_path));
+				}
 
 				// Network backend is set via --network-backend flag (handled by sc_cli)
 				// Both libp2p and litep2p backends use Dilithium for node identity
@@ -987,5 +1033,28 @@ mod tests {
 			TEST_WORMHOLE_ADDRESS
 		);
 		assert_eq!(hex::encode(pair.first_hash()), TEST_WORMHOLE_PREIMAGE);
+	}
+
+	/// Explicit `--state-pruning` values must match the enforced mode (full sync)
+	/// or a warp-compatible window; everything else fails instead of being
+	/// silently overridden.
+	#[test]
+	fn state_pruning_flags_match_enforced_modes_or_fail() {
+		assert_eq!(resolve_state_pruning(false, None).unwrap(), PruningMode::ArchiveCanonical);
+		assert_eq!(
+			resolve_state_pruning(false, Some(PruningMode::ArchiveCanonical)).unwrap(),
+			PruningMode::ArchiveCanonical
+		);
+		assert!(resolve_state_pruning(false, Some(PruningMode::ArchiveAll)).is_err());
+		assert!(resolve_state_pruning(false, Some(PruningMode::blocks_pruning(512))).is_err());
+
+		assert_eq!(resolve_state_pruning(true, None).unwrap(), PruningMode::blocks_pruning(256));
+		assert_eq!(
+			resolve_state_pruning(true, Some(PruningMode::blocks_pruning(512))).unwrap(),
+			PruningMode::blocks_pruning(512)
+		);
+		assert!(resolve_state_pruning(true, Some(PruningMode::blocks_pruning(64))).is_err());
+		assert!(resolve_state_pruning(true, Some(PruningMode::ArchiveAll)).is_err());
+		assert!(resolve_state_pruning(true, Some(PruningMode::ArchiveCanonical)).is_err());
 	}
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod chain_spec;
+mod checkpoint;
 mod cli;
 mod command;
 mod miner_server;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -18,6 +18,7 @@ use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::InPoolTransaction;
 use sc_transaction_pool_api::{OffchainTransactionPoolFactory, TransactionPool};
 use sp_inherents::CreateInherentDataProviders;
+use sp_runtime::traits::Header as HeaderT;
 use tokio_util::sync::CancellationToken;
 
 use crate::{miner_server::MinerServer, prometheus::BusinessMetrics};
@@ -641,11 +642,19 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 			>,
 		>;
 
+	// The release anchor doubles as an import-time tripwire: any block at its
+	// height that isn't the anchor is rejected, so a fabricated warp target's
+	// ancestry is caught as soon as backfill reaches the anchor height.
+	let anchor = crate::checkpoint::anchor_from_spec(&*config.chain_spec)
+		.map_err(|e| ServiceError::Other(format!("Invalid checkpointHeader in chain spec: {e}")))?
+		.map(|header| (*header.number(), header.hash()));
+
 	let pow_block_import = sc_consensus_qpow::PowBlockImport::new(
 		Arc::clone(&client),
 		Arc::clone(&client),
 		0, // check inherents starting at block 0
 		inherent_data_providers,
+		anchor,
 	);
 
 	let import_queue = sc_consensus_qpow::import_queue::<Block, FullClient>(
@@ -680,6 +689,7 @@ pub fn new_full<
 	sync_disable_major_sync_gating: bool,
 	sync_block_request_timeout: u64,
 	allow_mining_without_peers: bool,
+	warp_target: Option<crate::checkpoint::Header>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
@@ -707,6 +717,15 @@ pub fn new_full<
 	>::new(&config.network, config.prometheus_registry().cloned());
 	let metrics = N::register_notification_metrics(config.prometheus_registry());
 
+	let warp_sync_config = match (config.network.sync_mode.is_warp(), warp_target) {
+		(true, Some(header)) => Some(sc_service::WarpSyncConfig::WithTarget(header)),
+		(true, None) =>
+			return Err(ServiceError::Other(
+				"warp sync requires a resolved checkpoint target".into(),
+			)),
+		(false, _) => None,
+	};
+
 	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &config,
@@ -716,7 +735,7 @@ pub fn new_full<
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_config: None,
+			warp_sync_config,
 			block_relay: None,
 			metrics,
 		})?;


### PR DESCRIPTION
Adds checkpoint-based warp sync: a new node reaches the network tip and can start mining in minutes — bounded by state-download bandwidth, not chain age — instead of re-executing the whole chain (currently 1.5–2 h and growing).

## How it works

1. At startup (`--sync warp`) the node resolves a **checkpoint** — a single trusted header, normally the network's current finalized head (`best − max_reorg_depth`).
2. The existing `WarpSyncConfig::WithTarget` machinery (the parachain path — no GRANDPA needed) downloads the checkpoint block, then state-syncs the full state at that block, **Merkle-proof-verified against the header's `state_root`**.
3. From the checkpoint to the tip the node syncs with normal full verification (execution + runtime seal checks). Mining gates open exactly here (`is_major_syncing` already covers warp/state phases).

History below the checkpoint is not downloaded; the node serves chain data from the checkpoint forward (see "Backfill" below).

## Checkpoint resolution (documented in `docs/FAST_SYNC.md`)

First match wins:

1. `--checkpoint-header 0x…` — operator-pinned SCALE header.
2. Fetched from checkpoint endpoints (`--checkpoint-url …`, or the chain spec `checkpointUrls` property, now set for Heisenberg and Planck). Each endpoint's returned header must hash (Poseidon) to its reported finalized head; the candidate is the lowest finalized height among responders; every other responder must confirm that hash via `chain_getBlockHash`. Any disagreement aborts.
3. The **release anchor** — a `checkpointHeader` chain spec property refreshed by CI at release cut (CI wiring is a follow-up; stale anchors still sync, catch-up just re-executes blocks mined since the release).

A fetched target may never be older than the anchor, and at the anchor's height it must equal the anchor. Independently, `PowBlockImport` rejects any imported block that contradicts the anchor at its height.

## Consensus changes (`client/consensus/qpow`)

Imports are classified by where their state can come from:

- **StateImport** (`StateAction::ApplyChanges(StorageChanges::Import)`) — the proof-verified state-sync target. No parent state exists by construction, so inherent/seal runtime checks are skipped; cumulative work is seeded (like genesis — post-target fork choice only compares its descendants); the block is finalized on import; `create_gap = false` (see below).
- **HistoricalSkip** (`StateAction::Skip` at or below the finalized head) — defense-in-depth for skip-execution imports of already-finalized heights: no work accounting, never best.
- **FullVerify** — everything else keeps today's exact behavior. `Skip` above the finalized head does **not** grant a verification skip, so unsolicited near-tip blocks still get their seals runtime-verified.

`finalize_canonical_at_depth` gained an early return when the target is at or below the current finalized head (post-warp, best − 100 points below the finalized target for the first 100 blocks).

## Why backfill is disabled (`create_gap = false`)

Upstream gap backfill fills ascending from genesis and relies on the verifier to validate headers statelessly — possible for BABE (epoch data chains forward from genesis), impossible for QPoW (target difficulty lives in state, and retarget rules changed across runtime upgrades). Ascending fill would let a malicious peer write fabricated, unverified history into the canonical number→hash index. Until backfill verifies linkage (descending fill, or a pre-verified header chain walked down from the checkpoint), warp-synced nodes simply don't backfill. Nodes needing full history full-sync as today.

`--sync fast`/`fast-unsafe` are rejected with a pointer to `--sync warp` for the same reason (and fast sync's pivot trigger is incompatible with depth-based finality anyway). Warp nodes get a rolling 256-block state window instead of the forced `ArchiveCanonical` (archive refuses warp by design).

## Validated live against Heisenberg

Fresh node, `--sync warp`, default spec (checkpoint fetched from the a1/a2 endpoints, both agreeing):

```
13:45:25 🎯 Warp sync target fetched from checkpoint endpoints: #802314 (0x4f9b…f4e0)
13:45:27 Warp sync is complete, continuing with state sync.
13:58:35 🎯 State sync target #802314 (0x4f9b…f4e0) imported and finalized; serving chain from this block forward
13:58:35 State sync is complete, continuing with block sync.
13:58:36 💤 Idle (2 peers), best: #802467 (0x0d6d…e98d), finalized #802367 (0xb886…2de4)
```

- Depth finalization runs correctly over the warp base (`finalized = best − 100` one second after reaching the tip); catch-up of the 153 blocks mined during state download executed in ~1 s with full seal verification.
- Zero errors or warnings in the entire node log; no gap/backfill activity.
- RPC behaves as designed: `chain_getBlockHash(1) → null` (no pre-checkpoint history), tip queries and `system_syncState` track the live chain.

Wall clock was 13 min, essentially all state download at the ~150 KiB/s the public endpoints currently serve — on unthrottled state serving this is minutes. Chain-age-independent either way.

Unit tests cover the import-policy classification, checkpoint hex parsing, and anchor validation.

## Follow-ups

- CI: inject a fresh `checkpointHeader` anchor into the bundled chain specs at release cut.
- Verified history backfill (descending fill or pre-verified header chain), then re-enable `create_gap`.
- Header-chain verification of fetched targets (hash linkage + stateless achieved-work via qpow-math) to remove the residual all-endpoints-collude trust.
- In-protocol checkpoint fetch via peer quorum, removing URL configuration.
