### PR TITLE
zk-tree perf

### DIFF
--- a/docs/zk-trie-architecture.md
+++ b/docs/zk-trie-architecture.md
@@ -190,9 +190,8 @@ Every balance transfer on the chain is automatically captured and recorded into 
    │ ZkTrie::insert_leaf()                         │
    │                                               │
    │  1. Store leaf data at next index             │
-   │  2. Compute leaf_hash = poseidon(leaf_data)   │
-   │  3. Mark the leaf as pending                  │
-   │  4. Emit LeafInserted event                   │
+   │  2. Mark the leaf as pending                  │
+   │  3. Emit LeafInserted event                   │
    └───────────────────────┬───────────────────────┘
                            │  (once per block)
                            ▼

--- a/docs/zk-trie-architecture.md
+++ b/docs/zk-trie-architecture.md
@@ -191,11 +191,29 @@ Every balance transfer on the chain is automatically captured and recorded into 
    │                                               │
    │  1. Store leaf data at next index             │
    │  2. Compute leaf_hash = poseidon(leaf_data)   │
-   │  3. Update path from leaf to root             │
-   │  4. Store new root                            │
-   │  5. Emit LeafInserted event                   │
+   │  3. Mark the leaf as pending                  │
+   │  4. Emit LeafInserted event                   │
+   └───────────────────────┬───────────────────────┘
+                           │  (once per block)
+                           ▼
+   ┌──────────────────────────────────────────────┐
+   │ ZkTrie on_finalize                            │
+   │                                               │
+   │  1. Fold ALL leaves appended this block into  │
+   │     the tree in one bottom-up pass (shared    │
+   │     parents hashed once, not once per leaf)   │
+   │  2. Grow the tree if capacity was crossed     │
+   │  3. Store new root                            │
+   │  4. Publish root to the block header          │
    └──────────────────────────────────────────────┘
 ```
+
+Root recomputation is deliberately **batched per block**: a per-insert path update
+costs `depth` Poseidon hashes and `3·depth` sibling reads for every transfer, while
+the batched pass costs roughly `n/4 + n/16 + … + depth` hashes for a block with `n`
+transfers. Nothing on-chain needs the root mid-block — exit proofs verify against
+historical block headers — so during block execution `Root` is simply the root as of
+the end of the previous block.
 
 ### 2. Generating a ZK Proof
 

--- a/pallets/mining-rewards/src/weights.rs
+++ b/pallets/mining-rewards/src/weights.rs
@@ -79,8 +79,10 @@ const BASE_KEY_POV: u64 = 2700;
 /// Weights for `pallet_mining_rewards` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	/// Reserved in `on_initialize` before extrinsics run. Leaf inserts are flat-
-	/// priced at [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`].
+	/// Reserved in `on_initialize` before extrinsics run. Leaf appends are priced
+	/// at the flat marginal per-insert share ([`pallet_zk_tree::INSERT_LEAF_DB_OPS`]);
+	/// the batched root recomputation's depth-dependent tail is reserved by the
+	/// zk-tree pallet's own `on_initialize`.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 150_000_000 picoseconds.
 		let (tree_reads, tree_writes) = pallet_zk_tree::INSERT_LEAF_DB_OPS;
@@ -103,7 +105,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
-	/// Same flat circuit-depth pricing as `SubstrateWeight`, with `RocksDbWeight`
+	/// Same marginal per-insert pricing as `SubstrateWeight`, with `RocksDbWeight`
 	/// in place of the runtime's configured `DbWeight`.
 	fn on_finalize_rewarded_miner() -> Weight {
 		// Minimum execution time: 150_000_000 picoseconds.

--- a/pallets/reversible-transfers/src/weights.rs
+++ b/pallets/reversible-transfers/src/weights.rs
@@ -64,10 +64,11 @@ const EXECUTE_TRANSFER_BASE_READS: u64 = 5;
 const EXECUTE_TRANSFER_BASE_WRITES: u64 = 5;
 
 /// `execute_transfer`'s weight: the benchmarked base (compute + non-tree storage)
-/// plus the depth-dependent ZK-tree leaf insert performed by the wormhole proof
-/// recorder. `insert_leaf` walks the tree leaf-to-root, so DB ops and PoV scale
-/// with `tree_ops` via [`pallet_zk_tree::TREE_KEY_POV`], and the path update also
-/// computes one Poseidon hash per level (`tree_hash_time`).
+/// plus the ZK-tree leaf append performed by the wormhole proof recorder, priced at
+/// the flat marginal per-insert share of the block's batched root recomputation
+/// (`tree_ops` DB ops, PoV via [`pallet_zk_tree::TREE_KEY_POV`], Poseidon compute
+/// via `tree_hash_time`); the depth-dependent tail is reserved per block by the
+/// zk-tree pallet's `on_initialize`.
 fn execute_transfer_weight(
 	db: RuntimeDbWeight,
 	(tree_reads, tree_writes): (u64, u64),
@@ -85,8 +86,8 @@ fn execute_transfer_weight(
 
 /// Weights for `pallet_reversible_transfers` using the Substrate node and recommended hardware.
 ///
-/// `execute_transfer` records a wormhole proof (ZK-tree leaf insert); that component is
-/// flat-priced at [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`] via
+/// `execute_transfer` records a wormhole proof (ZK-tree leaf append); that component
+/// is priced at the flat marginal per-insert share via
 /// [`pallet_zk_tree::INSERT_LEAF_*`].
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
@@ -295,7 +296,9 @@ impl WeightInfo for () {
 	/// Proof: `ZkTree::Root` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
 	/// Storage: `ZkTree::Nodes` (r:3·depth w:depth)
 	///
-	/// Tree component flat-priced at [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`].
+	/// (Storage table from the benchmark, generated against the per-insert path
+	/// update.) Tree component priced at the flat marginal per-insert share via
+	/// [`pallet_zk_tree::INSERT_LEAF_DB_OPS`].
 	fn execute_transfer() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `638`

--- a/pallets/vesting/src/weights.rs
+++ b/pallets/vesting/src/weights.rs
@@ -31,12 +31,8 @@ const BENCHMARK_TREE_WRITES: u64 = 4;
 const CLAIM_BENCHMARK_TREE_WRITES: u64 = 3;
 
 /// Benchmarked base with its benchmark-time tree ops swapped for the flat marginal
-/// insert cost — DB ops, Poseidon hashing and PoV all priced by
-/// [`pallet_zk_tree::INSERT_LEAF_*`]. The benchmarks were generated against the
-/// per-insert path-update code, so the marginal append can be cheaper than the ops
-/// it replaces; clamp to the measured base rather than under-charging it until the
-/// benchmarks are regenerated.
-fn payout_weight(
+/// insert cost, before the clamp — see [`payout_weight`].
+fn payout_weight_unclamped(
 	base: Weight,
 	db: RuntimeDbWeight,
 	benchmark_tree_writes: u64,
@@ -53,7 +49,25 @@ fn payout_weight(
 		))
 		.saturating_add(db.reads(tree_reads))
 		.saturating_add(db.writes(tree_writes))
-		.max(base)
+}
+
+/// Benchmarked base with its benchmark-time tree ops swapped for the flat marginal
+/// insert cost — DB ops, Poseidon hashing and PoV all priced by
+/// [`pallet_zk_tree::INSERT_LEAF_*`]. The benchmarks were generated against the
+/// per-insert path-update code, so the marginal append can be cheaper than the ops
+/// it replaces; clamp to the measured base rather than under-charging it until the
+/// benchmarks are regenerated.
+/// [`tests::payout_clamp_engagement_matches_current_benchmarks`] pins, per call,
+/// whether the clamp is currently live, so regenerated benchmarks that flip the
+/// direction fail loudly instead of leaving a dead clamp behind.
+fn payout_weight(
+	base: Weight,
+	db: RuntimeDbWeight,
+	benchmark_tree_writes: u64,
+	tree_ops: (u64, u64),
+	tree_hash_time: u64,
+) -> Weight {
+	payout_weight_unclamped(base, db, benchmark_tree_writes, tree_ops, tree_hash_time).max(base)
 }
 
 pub struct SubstrateWeight<T>(PhantomData<T>);
@@ -144,26 +158,61 @@ mod tests {
 		]
 	}
 
-	/// The augmentation subtracts hand-maintained `BENCHMARK_TREE_*` counts from the
-	/// generated base and adds the flat marginal insert back. The marginal append is
-	/// cheaper (in DB ops) than the benchmark-time path update it replaces, so
-	/// `payout_weight` clamps to the measured base — pin that the clamp keeps the
-	/// augmented weight from ever falling below it.
+	/// Pins, per payout call, whether the marginal-insert substitution currently
+	/// falls below the benchmarked base — i.e. whether `payout_weight`'s
+	/// `.max(base)` clamp is live. (Asserting `payout_weight().all_gte(base)`
+	/// would be tautological: the clamp makes it true for any constants.)
+	///
+	/// With the current generated bases: `claim` swaps 3 benchmark tree writes for
+	/// 4 marginal ones, so the substitution over-covers and the clamp is idle;
+	/// `end_schedule` / `retarget_schedule` swap 4 writes for 4 and drop 2 reads,
+	/// so the substitution under-covers and the clamp is what holds the floor.
+	/// When the benchmarks are regenerated against the batched-settlement code,
+	/// these directions change and this test fails — that is the signal to
+	/// re-derive the model and drop the clamp if it has gone dead.
 	#[test]
-	fn payout_weight_never_undercharges_the_benchmarked_base() {
+	fn payout_clamp_engagement_matches_current_benchmarks() {
 		let db = RocksDbWeight::get();
-		for (base, benchmark_tree_writes) in payout_bases() {
-			let augmented = payout_weight(
+		let cases = [
+			("claim", <() as generated::WeightInfo>::claim(), CLAIM_BENCHMARK_TREE_WRITES, false),
+			(
+				"end_schedule",
+				<() as generated::WeightInfo>::end_schedule(),
+				BENCHMARK_TREE_WRITES,
+				true,
+			),
+			(
+				"retarget_schedule",
+				<() as generated::WeightInfo>::retarget_schedule(),
+				BENCHMARK_TREE_WRITES,
+				true,
+			),
+		];
+		for (name, base, benchmark_tree_writes, clamp_live) in cases {
+			let unclamped = payout_weight_unclamped(
 				base,
 				db,
 				benchmark_tree_writes,
 				pallet_zk_tree::INSERT_LEAF_DB_OPS,
 				pallet_zk_tree::INSERT_LEAF_HASH_REF_TIME_PS,
 			);
-			assert!(
-				augmented.all_gte(base),
-				"augmented {augmented:?} falls below benchmarked {base:?}"
+			assert_eq!(
+				!unclamped.all_gte(base),
+				clamp_live,
+				"{name}: clamp engagement flipped — benchmarks were regenerated; \
+				 re-derive the substitution model and drop the clamp if it is dead \
+				 (unclamped {unclamped:?}, base {base:?})"
 			);
+
+			let clamped = payout_weight(
+				base,
+				db,
+				benchmark_tree_writes,
+				pallet_zk_tree::INSERT_LEAF_DB_OPS,
+				pallet_zk_tree::INSERT_LEAF_HASH_REF_TIME_PS,
+			);
+			assert!(clamped.all_gte(base), "{name}: clamp must hold the benchmarked floor");
+			assert!(clamped.all_gte(unclamped), "{name}: clamp must never reduce the charge");
 		}
 	}
 }

--- a/pallets/vesting/src/weights.rs
+++ b/pallets/vesting/src/weights.rs
@@ -1,6 +1,8 @@
 //! Weights for `pallet_vesting`. Payout paths replace the benchmarked tree component
-//! with flat [`pallet_zk_tree::INSERT_LEAF_*`] pricing at
-//! [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`].
+//! with the flat marginal [`pallet_zk_tree::INSERT_LEAF_*`] insert pricing (the
+//! batched root recomputation's depth-dependent tail is reserved per block by the
+//! zk-tree pallet's `on_initialize`), clamped to never fall below the benchmarked
+//! base.
 
 use crate::weights_generated as generated;
 use core::marker::PhantomData;
@@ -21,16 +23,19 @@ pub trait WeightInfo {
 /// `LeafCount` + `Leaves` + `Root` writes (= 3); `Depth` is written too once the insert
 /// grows the tree, which the shallow benchmark tree does for `end_schedule` /
 /// `retarget_schedule` (= 4) but not for `claim` (= 3). They are subtracted back out so
-/// the flat circuit-depth insert cost can replace them;
+/// the flat marginal insert cost can replace them;
 /// [`tests::payout_weight_never_undercharges_the_benchmarked_base`] pins that the
 /// replacement never under-charges the measured base.
 const BENCHMARK_TREE_READS: u64 = 5;
 const BENCHMARK_TREE_WRITES: u64 = 4;
 const CLAIM_BENCHMARK_TREE_WRITES: u64 = 3;
 
-/// Benchmarked base with its benchmark-depth tree ops swapped for the flat
-/// circuit-depth insert cost — DB ops, Poseidon path hashing and PoV all priced by
-/// [`pallet_zk_tree::INSERT_LEAF_*`] at [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`].
+/// Benchmarked base with its benchmark-time tree ops swapped for the flat marginal
+/// insert cost — DB ops, Poseidon hashing and PoV all priced by
+/// [`pallet_zk_tree::INSERT_LEAF_*`]. The benchmarks were generated against the
+/// per-insert path-update code, so the marginal append can be cheaper than the ops
+/// it replaces; clamp to the measured base rather than under-charging it until the
+/// benchmarks are regenerated.
 fn payout_weight(
 	base: Weight,
 	db: RuntimeDbWeight,
@@ -48,6 +53,7 @@ fn payout_weight(
 		))
 		.saturating_add(db.reads(tree_reads))
 		.saturating_add(db.writes(tree_writes))
+		.max(base)
 }
 
 pub struct SubstrateWeight<T>(PhantomData<T>);
@@ -139,11 +145,10 @@ mod tests {
 	}
 
 	/// The augmentation subtracts hand-maintained `BENCHMARK_TREE_*` counts from the
-	/// generated base and adds the flat circuit-depth insert back. If a zk-tree
-	/// cost-model change ever made that insert cheaper (in DB ops) than the
-	/// benchmark-time ops it replaces, the subtraction would silently under-charge —
-	/// no compile error, no failing benchmark. Pin it: the augmented weight must still
-	/// cover the measured base.
+	/// generated base and adds the flat marginal insert back. The marginal append is
+	/// cheaper (in DB ops) than the benchmark-time path update it replaces, so
+	/// `payout_weight` clamps to the measured base — pin that the clamp keeps the
+	/// augmented weight from ever falling below it.
 	#[test]
 	fn payout_weight_never_undercharges_the_benchmarked_base() {
 		let db = RocksDbWeight::get();

--- a/pallets/wormhole/src/weights.rs
+++ b/pallets/wormhole/src/weights.rs
@@ -133,8 +133,10 @@ fn storage_tail(
 
 /// Weights for `pallet_wormhole` using the Substrate node and recommended hardware.
 ///
-/// Every processed exit inserts a ZK-tree leaf; that component is flat-priced at
-/// [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`] via [`pallet_zk_tree::INSERT_LEAF_*`].
+/// Every processed exit appends a ZK-tree leaf; that component is priced at the
+/// flat *marginal* per-insert share via [`pallet_zk_tree::INSERT_LEAF_*`] — the
+/// root recomputation is batched per block, and its depth-dependent tail is
+/// reserved by the zk-tree pallet's `on_initialize`.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `System::BlockHash` (r:1 w:0)
@@ -163,7 +165,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	/// Inclusion path: ZK verify + pre-validation twice (`pre_dispatch` and dispatch
 	/// body), each charged in full (compute + DB + PoV), plus exit-processing storage
-	/// and the per-exit ZK-tree Poseidon hashing (one hash per tree level per insert).
+	/// and the per-exit marginal share of the block's batched ZK-tree hashing.
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::INSERT_LEAF_DB_OPS;
 		let (reads, writes, proof_size) =
@@ -214,8 +216,8 @@ impl WeightInfo for () {
 		Weight::from_parts(PUBLIC_BATCH_PRE_VALIDATE_REF_TIME_PS, proof_size)
 			.saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add(nullifier_reads)))
 	}
-	/// See `SubstrateWeight::verify_private_batch`. Tree component flat-priced at
-	/// [`pallet_zk_tree::CIRCUIT_MAX_TREE_DEPTH`].
+	/// See `SubstrateWeight::verify_private_batch`. Tree component priced at the
+	/// flat marginal per-insert share via [`pallet_zk_tree::INSERT_LEAF_DB_OPS`].
 	fn verify_private_batch() -> Weight {
 		let tree_ops = pallet_zk_tree::INSERT_LEAF_DB_OPS;
 		let (reads, writes, proof_size) =

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -8,8 +8,8 @@
 //! - 4-ary tree (4 children per node) for optimal ZK circuit efficiency
 //! - Leaves hashed as 8 field elements (injective: values are ≤32 bits)
 //! - Internal nodes hashed as 16 field elements (8 bytes/felt compact encoding)
-//! - Inserts only append; the root is recomputed once per block in `on_finalize`,
-//!   folding all of the block's leaves in a single bottom-up pass
+//! - Inserts only append; the root is recomputed once per block in `on_finalize`, folding all of
+//!   the block's leaves in a single bottom-up pass
 //! - Tree root published in block header for ZK verification
 //!
 //! ## Tree Structure
@@ -87,13 +87,12 @@ pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 10_000_000;
 /// depth-dependent tail that is the same no matter how many leaves the block has.
 ///
 /// The split keeps `price × n` sound for any multi-insert call:
-/// - this constant covers the per-leaf marginal cost: 2 insert-phase reads
-///   (`LeafCount`, `UnprocessedLeaves`) + the finalize-phase `Leaves` read, and 3
-///   insert-phase writes (`Leaves`, `LeafCount`, `UnprocessedLeaves`) + the
-///   amortized `⌈n/3⌉ ≤ n` internal-node writes;
-/// - the depth-dependent tail (boundary siblings, the path above the batch, grow
-///   bookkeeping) is charged once per block by [`FINALIZE_BASE_DB_OPS`], reserved
-///   unconditionally in this pallet's `on_initialize`.
+/// - this constant covers the per-leaf marginal cost: 2 insert-phase reads (`LeafCount`,
+///   `UnprocessedLeaves`) + the finalize-phase `Leaves` read, and 3 insert-phase writes (`Leaves`,
+///   `LeafCount`, `UnprocessedLeaves`) + the amortized `⌈n/3⌉ ≤ n` internal-node writes;
+/// - the depth-dependent tail (boundary siblings, the path above the batch, grow bookkeeping) is
+///   charged once per block by [`FINALIZE_BASE_DB_OPS`], reserved unconditionally in this pallet's
+///   `on_initialize`.
 ///
 /// Charge together with [`INSERT_LEAF_HASH_REF_TIME_PS`].
 pub const INSERT_LEAF_DB_OPS: (u64, u64) = (3, 4);
@@ -114,13 +113,13 @@ pub const INSERT_LEAF_HASH_REF_TIME_PS: u64 =
 ///
 /// This is everything the finalize pass costs *beyond* the per-leaf marginal ops
 /// already charged through [`INSERT_LEAF_DB_OPS`]. At `d = CIRCUIT_MAX_TREE_DEPTH`:
-/// - reads: `UnprocessedLeaves` + `LeafCount` + `Depth` + `grow_tree`'s `Root` +
-///   the header-publish `Root` + up to 3 boundary leaves and `3·(d − 1)` boundary
-///   sibling nodes (only the parent containing the batch's first leaf can have
-///   pre-existing children; everything right of the batch is empty and skipped);
-/// - writes: `UnprocessedLeaves` + `Depth` + `grow_tree`'s parked node + `Root` +
-///   the `frame_system` header root + the `≤ d` per-level path tail of node writes
-///   not covered by the amortized per-leaf share.
+/// - reads: `UnprocessedLeaves` + `LeafCount` + `Depth` + `grow_tree`'s `Root` + the header-publish
+///   `Root` + up to 3 boundary leaves and `3·(d − 1)` boundary sibling nodes (only the parent
+///   containing the batch's first leaf can have pre-existing children; everything right of the
+///   batch is empty and skipped);
+/// - writes: `UnprocessedLeaves` + `Depth` + `grow_tree`'s parked node + `Root` + the
+///   `frame_system` header root + the `≤ d` per-level path tail of node writes not covered by the
+///   amortized per-leaf share.
 ///
 /// Out-deepening the circuit ceiling would take ~4.3 billion leaves — see
 /// [`CIRCUIT_MAX_TREE_DEPTH`]; the trade-off is a modest overcharge while the tree

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -68,8 +68,13 @@ pub const MAX_TREE_DEPTH: u8 = 32;
 pub const CIRCUIT_MAX_TREE_DEPTH: u8 = 16;
 
 /// Worst-case `ref_time` (picoseconds) of one Poseidon evaluation
-/// ([`tree::hash_node`] / [`tree::hash_leaf`]). Padded for wasm / slower hardware.
-pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 50_000_000;
+/// ([`tree::hash_node`] / [`tree::hash_leaf`]).
+///
+/// Native release on the reference host measures ~3.3µs/eval
+/// (`measure_hash_node_time`). 10µs is ~3× that — enough headroom for wasm /
+/// slower boxes without the previous 15× (50µs) pad that capped blocks at
+/// ~500 transfers while prepare only took ~1.5s wall clock.
+pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 10_000_000;
 
 /// Flat `(reads, writes)` for one [`Pallet::insert_leaf`], priced at
 /// [`CIRCUIT_MAX_TREE_DEPTH`].

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -72,10 +72,16 @@ pub const CIRCUIT_MAX_TREE_DEPTH: u8 = 16;
 /// Worst-case `ref_time` (picoseconds) of one Poseidon evaluation
 /// ([`tree::hash_node`] / [`tree::hash_leaf`]).
 ///
-/// Native release on the reference host measures ~3.3µs/eval
-/// (`measure_hash_node_time`). 10µs is ~3× that — enough headroom for wasm /
-/// slower boxes without the previous 15× (50µs) pad that capped blocks at
-/// ~500 transfers while prepare only took ~1.5s wall clock.
+/// ~3.3µs/eval is a *native lower bound*, measured on the reference host by the
+/// `#[ignore]`d `measure_hash_node_time` (run it manually; nothing in CI pins
+/// this constant). The runtime executes wasm32, where Goldilocks' u64×u64→u128
+/// products are emulated instead of compiling to a single `mulq`, so the wasm
+/// cost is higher and the margin under this 10µs budget is thinner than the
+/// native 3× suggests. The generated benchmarks bound it from the wasm side
+/// (e.g. vesting `claim` − `create_schedule` leaves a ~43µs delta covering a
+/// whole vested transfer plus the insert's Poseidon work). Still far below the
+/// previous 15× (50µs) pad that capped blocks at ~500 transfers while prepare
+/// took only ~1.5s wall clock. Re-measure when touching the hashing code.
 pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 10_000_000;
 
 /// Flat *marginal* `(reads, writes)` charged per [`Pallet::insert_leaf`].
@@ -97,11 +103,12 @@ pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 10_000_000;
 /// Charge together with [`INSERT_LEAF_HASH_REF_TIME_PS`].
 pub const INSERT_LEAF_DB_OPS: (u64, u64) = (3, 4);
 
-/// Marginal Poseidon evaluations per insert: `hash_leaf` for the `LeafInserted`
-/// event at insert time, `hash_leaf` again in the finalize batch, plus the
-/// amortized share (`≤ 1` for any `n ≥ 1`) of the batch's internal-node hashes.
-/// The depth-dependent remainder is in [`FINALIZE_BASE_POSEIDON_EVALS`].
-pub const INSERT_LEAF_POSEIDON_EVALS: u64 = 3;
+/// Marginal Poseidon evaluations per insert: one `hash_leaf` in the finalize
+/// batch (the insert itself hashes nothing — the `LeafInserted` event carries
+/// only the index), plus the amortized share (`≤ 1` for any `n ≥ 1`) of the
+/// batch's internal-node hashes. The depth-dependent remainder is in
+/// [`FINALIZE_BASE_POSEIDON_EVALS`].
+pub const INSERT_LEAF_POSEIDON_EVALS: u64 = 2;
 
 /// Marginal insert compute (`ref_time` picoseconds).
 pub const INSERT_LEAF_HASH_REF_TIME_PS: u64 =
@@ -263,8 +270,11 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A new leaf was inserted into the tree. The root including this leaf is
-		/// computed at the end of the block and published in the block header.
-		LeafInserted { index: u64, leaf_hash: Hash256 },
+		/// computed at the end of the block and published in the block header. The
+		/// leaf hash is deliberately not included: it is derivable from `Leaves`
+		/// (and served by the RPC), and hashing it here would double the per-leaf
+		/// Poseidon work the batched settlement saves.
+		LeafInserted { index: u64 },
 		/// Tree depth increased.
 		TreeGrew { new_depth: u8 },
 	}
@@ -275,6 +285,9 @@ pub mod pallet {
 		LeafIndexOutOfBounds,
 		/// Leaf not found.
 		LeafNotFound,
+		/// Leaf was appended this block and is not yet folded into the root; it
+		/// becomes provable once the block is finalized.
+		LeafNotYetSettled,
 	}
 
 	#[pallet::hooks]
@@ -299,10 +312,7 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> Pallet<T>
-	where
-		AccountIdOf<T>: AsRef<[u8]>,
-	{
+	impl<T: Config> Pallet<T> {
 		/// Append a new leaf to the tree.
 		///
 		/// Returns the leaf index. The leaf is *not* folded into the Merkle root
@@ -324,12 +334,11 @@ pub mod pallet {
 			let leaf = ZkLeaf { to, transfer_count, asset_id, amount };
 			let leaf_index = LeafCount::<T>::get();
 
-			let leaf_hash = tree::hash_leaf::<T>(&leaf);
 			Leaves::<T>::insert(leaf_index, leaf);
 			LeafCount::<T>::put(leaf_index + 1);
 			UnprocessedLeaves::<T>::mutate(|pending| *pending = pending.saturating_add(1));
 
-			Self::deposit_event(Event::LeafInserted { index: leaf_index, leaf_hash });
+			Self::deposit_event(Event::LeafInserted { index: leaf_index });
 
 			leaf_index
 		}
@@ -387,8 +396,11 @@ pub mod pallet {
 		/// the previous block; all leaves once `on_finalize` has run) are provable
 		/// — `Nodes` does not yet cover leaves still pending in this block.
 		pub fn get_merkle_proof(leaf_index: u64) -> Result<ZkMerkleProof, Error<T>> {
-			let processed = LeafCount::<T>::get().saturating_sub(UnprocessedLeaves::<T>::get());
-			ensure!(leaf_index < processed, Error::<T>::LeafIndexOutOfBounds);
+			let leaf_count = LeafCount::<T>::get();
+			ensure!(leaf_index < leaf_count, Error::<T>::LeafIndexOutOfBounds);
+
+			let processed = leaf_count.saturating_sub(UnprocessedLeaves::<T>::get());
+			ensure!(leaf_index < processed, Error::<T>::LeafNotYetSettled);
 
 			let depth = Depth::<T>::get();
 			tree::generate_proof::<T>(leaf_index, depth)
@@ -436,10 +448,7 @@ impl<AccountId, AssetId, Balance> ZkTreeRecorder<AccountId, AssetId, Balance> fo
 	}
 }
 
-impl<T: Config> ZkTreeRecorder<T::AccountId, T::AssetId, T::Balance> for Pallet<T>
-where
-	T::AccountId: AsRef<[u8]>,
-{
+impl<T: Config> ZkTreeRecorder<T::AccountId, T::AssetId, T::Balance> for Pallet<T> {
 	fn record_transfer(
 		to: T::AccountId,
 		transfer_count: u64,

--- a/pallets/zk-tree/src/lib.rs
+++ b/pallets/zk-tree/src/lib.rs
@@ -8,6 +8,8 @@
 //! - 4-ary tree (4 children per node) for optimal ZK circuit efficiency
 //! - Leaves hashed as 8 field elements (injective: values are ≤32 bits)
 //! - Internal nodes hashed as 16 field elements (8 bytes/felt compact encoding)
+//! - Inserts only append; the root is recomputed once per block in `on_finalize`,
+//!   folding all of the block's leaves in a single bottom-up pass
 //! - Tree root published in block header for ZK verification
 //!
 //! ## Tree Structure
@@ -76,32 +78,62 @@ pub const CIRCUIT_MAX_TREE_DEPTH: u8 = 16;
 /// ~500 transfers while prepare only took ~1.5s wall clock.
 pub const POSEIDON_EVAL_REF_TIME_PS: u64 = 10_000_000;
 
-/// Flat `(reads, writes)` for one [`Pallet::insert_leaf`], priced at
-/// [`CIRCUIT_MAX_TREE_DEPTH`].
+/// Flat *marginal* `(reads, writes)` charged per [`Pallet::insert_leaf`].
 ///
-/// The insert's *real* cost is depth-dependent (`update_path` reads 3 siblings and
-/// writes one internal node per level), but metering is deliberately FLAT at the
-/// circuit ceiling so `price × n` is sound for any multi-insert call. Out-deepening
-/// that ceiling would take ~3.2 billion inserts in one block (impossible under block
-/// limits); the trade-off is a modest overcharge while the tree is young. At
-/// `d = CIRCUIT_MAX_TREE_DEPTH`:
-/// - reads: `LeafCount` + `Depth` (twice) + `grow_tree`'s `Root` + `3·d` siblings
-/// - writes: `Leaves` + `LeafCount` + `Root` + `d − 1` internal nodes, plus `grow_tree`'s
-///   `Nodes`/`Root`/`Depth` writes
+/// Root recomputation is batched: inserts only append (`Leaves`, `LeafCount`,
+/// `UnprocessedLeaves`), and `on_finalize` folds all of a block's leaves into the
+/// tree in one bottom-up pass. In that pass dirty parents are shared, so `n`
+/// leaves touch about `n/4 + n/16 + …` internal nodes — bounded by `n/3` — plus a
+/// depth-dependent tail that is the same no matter how many leaves the block has.
+///
+/// The split keeps `price × n` sound for any multi-insert call:
+/// - this constant covers the per-leaf marginal cost: 2 insert-phase reads
+///   (`LeafCount`, `UnprocessedLeaves`) + the finalize-phase `Leaves` read, and 3
+///   insert-phase writes (`Leaves`, `LeafCount`, `UnprocessedLeaves`) + the
+///   amortized `⌈n/3⌉ ≤ n` internal-node writes;
+/// - the depth-dependent tail (boundary siblings, the path above the batch, grow
+///   bookkeeping) is charged once per block by [`FINALIZE_BASE_DB_OPS`], reserved
+///   unconditionally in this pallet's `on_initialize`.
 ///
 /// Charge together with [`INSERT_LEAF_HASH_REF_TIME_PS`].
-pub const INSERT_LEAF_DB_OPS: (u64, u64) = {
-	let d = CIRCUIT_MAX_TREE_DEPTH as u64;
-	(3 * d + 4, d + 5)
-};
+pub const INSERT_LEAF_DB_OPS: (u64, u64) = (3, 4);
 
-/// Flat Poseidon evaluations for one insert (`hash_leaf` + per-level `hash_node` +
-/// grow), priced at [`CIRCUIT_MAX_TREE_DEPTH`].
-pub const INSERT_LEAF_POSEIDON_EVALS: u64 = CIRCUIT_MAX_TREE_DEPTH as u64 + 2;
+/// Marginal Poseidon evaluations per insert: `hash_leaf` for the `LeafInserted`
+/// event at insert time, `hash_leaf` again in the finalize batch, plus the
+/// amortized share (`≤ 1` for any `n ≥ 1`) of the batch's internal-node hashes.
+/// The depth-dependent remainder is in [`FINALIZE_BASE_POSEIDON_EVALS`].
+pub const INSERT_LEAF_POSEIDON_EVALS: u64 = 3;
 
-/// Flat insert compute (`ref_time` picoseconds); priced at [`CIRCUIT_MAX_TREE_DEPTH`].
+/// Marginal insert compute (`ref_time` picoseconds).
 pub const INSERT_LEAF_HASH_REF_TIME_PS: u64 =
 	INSERT_LEAF_POSEIDON_EVALS * POSEIDON_EVAL_REF_TIME_PS;
+
+/// Once-per-block `(reads, writes)` ceiling for the batched root recomputation in
+/// `on_finalize`, priced at [`CIRCUIT_MAX_TREE_DEPTH`] and reserved unconditionally
+/// by this pallet's `on_initialize` (see [`Pallet::finalize_base_weight`]).
+///
+/// This is everything the finalize pass costs *beyond* the per-leaf marginal ops
+/// already charged through [`INSERT_LEAF_DB_OPS`]. At `d = CIRCUIT_MAX_TREE_DEPTH`:
+/// - reads: `UnprocessedLeaves` + `LeafCount` + `Depth` + `grow_tree`'s `Root` +
+///   the header-publish `Root` + up to 3 boundary leaves and `3·(d − 1)` boundary
+///   sibling nodes (only the parent containing the batch's first leaf can have
+///   pre-existing children; everything right of the batch is empty and skipped);
+/// - writes: `UnprocessedLeaves` + `Depth` + `grow_tree`'s parked node + `Root` +
+///   the `frame_system` header root + the `≤ d` per-level path tail of node writes
+///   not covered by the amortized per-leaf share.
+///
+/// Out-deepening the circuit ceiling would take ~4.3 billion leaves — see
+/// [`CIRCUIT_MAX_TREE_DEPTH`]; the trade-off is a modest overcharge while the tree
+/// is young.
+pub const FINALIZE_BASE_DB_OPS: (u64, u64) = {
+	let d = CIRCUIT_MAX_TREE_DEPTH as u64;
+	(3 * d + 8, d + 6)
+};
+
+/// Once-per-block Poseidon-evaluation ceiling for the finalize batch beyond the
+/// per-leaf marginal share: up to 3 boundary leaf hashes plus the `≤ d` per-level
+/// path tail, priced at [`CIRCUIT_MAX_TREE_DEPTH`].
+pub const FINALIZE_BASE_POSEIDON_EVALS: u64 = CIRCUIT_MAX_TREE_DEPTH as u64 + 3;
 
 /// Conservative PoV bound (bytes) per ZK-tree storage key touched during a path
 /// update. Tree entries are 32-byte hashes with small keys; comparable to the
@@ -177,7 +209,9 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
+	pub trait Config:
+		frame_system::Config<RuntimeEvent: From<Event<Self>>, AccountId: AsRef<[u8]>>
+	{
 		/// Asset ID type.
 		type AssetId: Parameter + Member + Copy + Default + MaxEncodedLen + Into<u128>;
 
@@ -212,15 +246,26 @@ pub mod pallet {
 	pub type Depth<T: Config> = StorageValue<_, u8, ValueQuery>;
 
 	/// Current root hash of the tree.
+	///
+	/// Covers exactly the first `LeafCount - UnprocessedLeaves` leaves: root
+	/// recomputation is batched once per block in `on_finalize`, so during block
+	/// execution this is the root as of the end of the previous block.
 	#[pallet::storage]
 	#[pallet::getter(fn root)]
 	pub type Root<T: Config> = StorageValue<_, Hash256, ValueQuery>;
 
+	/// Number of trailing leaves appended this block but not yet folded into
+	/// `Nodes`/`Root`. Always drained back to 0 by `on_finalize`.
+	#[pallet::storage]
+	#[pallet::getter(fn unprocessed_leaves)]
+	pub type UnprocessedLeaves<T: Config> = StorageValue<_, u64, ValueQuery>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// A new leaf was inserted into the tree.
-		LeafInserted { index: u64, leaf_hash: Hash256, new_root: Hash256 },
+		/// A new leaf was inserted into the tree. The root including this leaf is
+		/// computed at the end of the block and published in the block header.
+		LeafInserted { index: u64, leaf_hash: Hash256 },
 		/// Tree depth increased.
 		TreeGrew { new_depth: u8 },
 	}
@@ -235,7 +280,20 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			// Reserve the once-per-block ceiling of the batched root recomputation
+			// in on_finalize. The per-leaf marginal cost is charged to whoever
+			// triggers each insert (see `INSERT_LEAF_DB_OPS`).
+			Self::finalize_base_weight()
+		}
+
 		fn on_finalize(_n: BlockNumberFor<T>) {
+			// Fold all leaves appended during this block into the tree. This must
+			// run after every hook that inserts leaves (e.g. mining-rewards'
+			// on_finalize); on_finalize executes in pallet declaration order, and
+			// this pallet is declared after all inserters in the runtime.
+			Self::process_pending_leaves();
+
 			// Set ZK Merkle tree root in frame_system for inclusion in block header
 			let root: Hash256 = Root::<T>::get();
 			<frame_system::Pallet<T>>::set_zk_tree_root(root.into());
@@ -246,9 +304,12 @@ pub mod pallet {
 	where
 		AccountIdOf<T>: AsRef<[u8]>,
 	{
-		/// Insert a new leaf into the tree.
+		/// Append a new leaf to the tree.
 		///
-		/// Returns the leaf index and new root hash.
+		/// Returns the leaf index. The leaf is *not* folded into the Merkle root
+		/// here: root recomputation is batched once per block in `on_finalize`
+		/// (see [`Self::process_pending_leaves`]), which is what puts the root
+		/// covering this leaf into this block's header.
 		///
 		/// # Infallibility
 		///
@@ -260,49 +321,75 @@ pub mod pallet {
 			transfer_count: u64,
 			asset_id: T::AssetId,
 			amount: T::Balance,
-		) -> (u64, Hash256) {
+		) -> u64 {
 			let leaf = ZkLeaf { to, transfer_count, asset_id, amount };
 			let leaf_index = LeafCount::<T>::get();
 
-			// Check if we need to grow the tree
-			let current_depth = Depth::<T>::get();
-			let capacity = tree::capacity_at_depth(current_depth);
+			let leaf_hash = tree::hash_leaf::<T>(&leaf);
+			Leaves::<T>::insert(leaf_index, leaf);
+			LeafCount::<T>::put(leaf_index + 1);
+			UnprocessedLeaves::<T>::mutate(|pending| *pending = pending.saturating_add(1));
 
-			if leaf_index >= capacity {
-				// Need to grow the tree
-				// saturating_add ensures we never overflow; MAX_TREE_DEPTH=32 means 4^32 leaves
-				// which is ~18 quintillion - far beyond any practical blockchain state
-				let new_depth = current_depth.saturating_add(1);
-				debug_assert!(
-					new_depth <= MAX_TREE_DEPTH,
-					"ZK tree exceeded max depth - this should never happen in practice"
-				);
+			Self::deposit_event(Event::LeafInserted { index: leaf_index, leaf_hash });
 
-				tree::grow_tree::<T>(current_depth, new_depth);
-				Depth::<T>::put(new_depth);
+			leaf_index
+		}
 
-				Self::deposit_event(Event::TreeGrew { new_depth });
+		/// Fold all leaves appended since the last call into `Nodes` and `Root`.
+		///
+		/// Called from `on_finalize`; public so tests can settle the tree without
+		/// running the whole block lifecycle. No-op when nothing is pending.
+		pub fn process_pending_leaves() {
+			let pending = UnprocessedLeaves::<T>::take();
+			if pending == 0 {
+				return;
 			}
 
-			// Store the leaf
-			Leaves::<T>::insert(leaf_index, leaf.clone());
-			LeafCount::<T>::put(leaf_index + 1);
+			let leaf_count = LeafCount::<T>::get();
+			let start = leaf_count.saturating_sub(pending);
 
-			// Compute leaf hash and update tree
-			let leaf_hash = tree::hash_leaf::<T>(&leaf);
-			let new_root = tree::update_path::<T>(leaf_index, leaf_hash);
+			// Grow the tree enough to fit every pending leaf. saturating_add can
+			// never overflow in practice; MAX_TREE_DEPTH=32 means 4^32 leaves,
+			// far beyond any practical blockchain state.
+			let old_depth = Depth::<T>::get();
+			let mut depth = old_depth;
+			while tree::capacity_at_depth(depth) < leaf_count {
+				depth = depth.saturating_add(1);
+			}
+			debug_assert!(
+				depth <= MAX_TREE_DEPTH,
+				"ZK tree exceeded max depth - this should never happen in practice"
+			);
+			if depth > old_depth {
+				tree::grow_tree::<T>(old_depth);
+				Depth::<T>::put(depth);
+				Self::deposit_event(Event::TreeGrew { new_depth: depth });
+			}
 
+			let new_root = tree::update_range::<T>(start, leaf_count, depth);
 			Root::<T>::put(new_root);
+		}
 
-			Self::deposit_event(Event::LeafInserted { index: leaf_index, leaf_hash, new_root });
-
-			(leaf_index, new_root)
+		/// Once-per-block weight ceiling of [`Self::process_pending_leaves`] beyond
+		/// the marginal cost charged per insert; reserved in `on_initialize`.
+		pub fn finalize_base_weight() -> Weight {
+			let (reads, writes) = FINALIZE_BASE_DB_OPS;
+			<T as frame_system::Config>::DbWeight::get()
+				.reads_writes(reads, writes)
+				.saturating_add(Weight::from_parts(
+					FINALIZE_BASE_POSEIDON_EVALS.saturating_mul(POSEIDON_EVAL_REF_TIME_PS),
+					reads.saturating_mul(TREE_KEY_POV),
+				))
 		}
 
 		/// Get a Merkle proof for a leaf at the given index.
+		///
+		/// Only leaves already folded into the root (everything up to the end of
+		/// the previous block; all leaves once `on_finalize` has run) are provable
+		/// — `Nodes` does not yet cover leaves still pending in this block.
 		pub fn get_merkle_proof(leaf_index: u64) -> Result<ZkMerkleProof, Error<T>> {
-			let leaf_count = LeafCount::<T>::get();
-			ensure!(leaf_index < leaf_count, Error::<T>::LeafIndexOutOfBounds);
+			let processed = LeafCount::<T>::get().saturating_sub(UnprocessedLeaves::<T>::get());
+			ensure!(leaf_index < processed, Error::<T>::LeafIndexOutOfBounds);
 
 			let depth = Depth::<T>::get();
 			tree::generate_proof::<T>(leaf_index, depth)
@@ -360,8 +447,7 @@ where
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> u64 {
-		let (leaf_index, _root) = Self::insert_leaf(to, transfer_count, asset_id, amount);
-		leaf_index
+		Self::insert_leaf(to, transfer_count, asset_id, amount)
 	}
 }
 

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -74,6 +74,24 @@ fn make_account(seed: u8) -> AccountId {
 	AccountId::new([seed; 32])
 }
 
+/// Fold pending leaves into the root, as `on_finalize` does once per block.
+fn settle() {
+	ZkTree::process_pending_leaves();
+}
+
+/// Insert a leaf and immediately settle it, mirroring the pre-batching
+/// "every insert recomputes the root" behavior. Returns `(index, root)`.
+fn insert_and_settle(
+	to: AccountId,
+	transfer_count: u64,
+	asset_id: u32,
+	amount: u128,
+) -> (u64, Hash256) {
+	let index = ZkTree::insert_leaf(to, transfer_count, asset_id, amount);
+	settle();
+	(index, ZkTree::root())
+}
+
 #[test]
 fn test_capacity_at_depth() {
 	assert_eq!(tree::capacity_at_depth(0), 0);
@@ -182,13 +200,21 @@ fn hash_leaf_saturates_oversized_amounts_at_u32_max() {
 fn insert_first_leaf_works() {
 	new_test_ext().execute_with(|| {
 		let to = make_account(1);
-		let (index, root) = ZkTree::insert_leaf(to.clone(), 0, 0u32, 100u128);
+		let index = ZkTree::insert_leaf(to.clone(), 0, 0u32, 100u128);
 
 		assert_eq!(index, 0);
-		assert_ne!(root, [0u8; 32]);
 		assert_eq!(ZkTree::leaf_count(), 1);
+
+		// The insert only appends; the root is computed at end of block.
+		assert_eq!(ZkTree::unprocessed_leaves(), 1);
+		assert_eq!(ZkTree::root(), [0u8; 32]);
+		assert_eq!(ZkTree::depth(), 0);
+
+		settle();
+
+		assert_eq!(ZkTree::unprocessed_leaves(), 0);
+		assert_ne!(ZkTree::root(), [0u8; 32]);
 		assert_eq!(ZkTree::depth(), 1);
-		assert_eq!(ZkTree::root(), root);
 
 		// Check leaf was stored
 		let leaf = ZkTree::leaf(0).unwrap();
@@ -206,7 +232,7 @@ fn insert_multiple_leaves_works() {
 
 		for i in 0..4 {
 			let to = make_account(i + 1);
-			let (index, root) = ZkTree::insert_leaf(to, i as u64, 0u32, (i + 1) as u128 * 100);
+			let (index, root) = insert_and_settle(to, i as u64, 0u32, (i + 1) as u128 * 100);
 			assert_eq!(index, i as u64);
 			roots.push(root);
 		}
@@ -214,7 +240,7 @@ fn insert_multiple_leaves_works() {
 		assert_eq!(ZkTree::leaf_count(), 4);
 		assert_eq!(ZkTree::depth(), 1); // 4 leaves fit in depth 1
 
-		// Each insert should change the root
+		// Each settled insert should change the root
 		for i in 1..roots.len() {
 			assert_ne!(roots[i], roots[i - 1]);
 		}
@@ -229,11 +255,14 @@ fn tree_grows_at_capacity() {
 			let to = make_account(i + 1);
 			ZkTree::insert_leaf(to, i as u64, 0u32, 100u128);
 		}
+		settle();
 		assert_eq!(ZkTree::depth(), 1);
 
-		// 5th leaf should trigger growth to depth 2
+		// 5th leaf starts exactly at the old capacity boundary and should
+		// trigger growth to depth 2 when settled.
 		let to = make_account(5);
 		ZkTree::insert_leaf(to, 4, 0u32, 100u128);
+		settle();
 
 		assert_eq!(ZkTree::leaf_count(), 5);
 		assert_eq!(ZkTree::depth(), 2);
@@ -243,11 +272,13 @@ fn tree_grows_at_capacity() {
 #[test]
 fn tree_grows_multiple_times() {
 	new_test_ext().execute_with(|| {
-		// Insert 20 leaves (need depth 3 to fit: 4^3 = 64)
+		// Insert 20 leaves in ONE batch (need depth 3 to fit: 4^3 = 64), so a
+		// single settlement grows the tree by two levels at once.
 		for i in 0..20 {
 			let to = make_account((i % 255) as u8 + 1);
 			ZkTree::insert_leaf(to, i as u64, 0u32, 100u128);
 		}
+		settle();
 
 		assert_eq!(ZkTree::leaf_count(), 20);
 		assert_eq!(ZkTree::depth(), 3); // 4^2 = 16 < 20 <= 64 = 4^3
@@ -262,6 +293,7 @@ fn merkle_proof_works() {
 			let to = make_account(i + 1);
 			ZkTree::insert_leaf(to, i as u64, 0u32, (i + 1) as u128 * 100);
 		}
+		settle();
 
 		// Get proof for leaf 0
 		let proof = ZkTree::get_merkle_proof(0).unwrap();
@@ -282,6 +314,7 @@ fn merkle_proof_all_leaves() {
 			let to = make_account(i + 1);
 			ZkTree::insert_leaf(to, i as u64, i as u32, (i + 1) as u128 * 100);
 		}
+		settle();
 
 		// Verify proof for each leaf
 		for i in 0..10 {
@@ -300,6 +333,7 @@ fn invalid_proof_fails() {
 			let to = make_account(i + 1);
 			ZkTree::insert_leaf(to, i as u64, 0u32, (i + 1) as u128 * 100);
 		}
+		settle();
 
 		// Get proof for leaf 0
 		let proof = ZkTree::get_merkle_proof(0).unwrap();
@@ -315,6 +349,7 @@ fn invalid_proof_fails() {
 fn proof_for_nonexistent_leaf_fails() {
 	new_test_ext().execute_with(|| {
 		ZkTree::insert_leaf(make_account(1), 0, 0u32, 100u128);
+		settle();
 
 		// Try to get proof for leaf index 5 (doesn't exist)
 		let result = ZkTree::get_merkle_proof(5);
@@ -323,10 +358,28 @@ fn proof_for_nonexistent_leaf_fails() {
 }
 
 #[test]
-fn root_changes_on_insert() {
+fn proof_for_pending_leaf_fails_until_settled() {
 	new_test_ext().execute_with(|| {
-		let (_, root1) = ZkTree::insert_leaf(make_account(1), 0, 0u32, 100u128);
-		let (_, root2) = ZkTree::insert_leaf(make_account(2), 1, 0u32, 200u128);
+		ZkTree::insert_leaf(make_account(1), 0, 0u32, 100u128);
+		settle();
+		ZkTree::insert_leaf(make_account(2), 0, 0u32, 200u128);
+
+		// Leaf 1 is appended but not yet folded into the root: `Nodes` doesn't
+		// cover it, so no valid proof can exist for it yet.
+		assert!(ZkTree::get_merkle_proof(1).is_err());
+		// Settled leaves stay provable.
+		assert!(ZkTree::get_merkle_proof(0).is_ok());
+
+		settle();
+		assert!(ZkTree::get_merkle_proof(1).is_ok());
+	});
+}
+
+#[test]
+fn root_changes_on_settle() {
+	new_test_ext().execute_with(|| {
+		let (_, root1) = insert_and_settle(make_account(1), 0, 0u32, 100u128);
+		let (_, root2) = insert_and_settle(make_account(2), 1, 0u32, 200u128);
 
 		assert_ne!(root1, root2);
 		assert_eq!(ZkTree::root(), root2);
@@ -343,7 +396,7 @@ fn different_amounts_give_different_hashes() {
 		let one_dev = 1_000_000_000_000u128; // 10^12
 		let two_dev = 2_000_000_000_000u128; // 2*10^12
 
-		let (_, root1) = ZkTree::insert_leaf(make_account(1), 0, 0u32, one_dev);
+		let (_, root1) = insert_and_settle(make_account(1), 0, 0u32, one_dev);
 
 		// Reset and insert with different amount
 		crate::Leaves::<Test>::remove(0);
@@ -353,7 +406,7 @@ fn different_amounts_give_different_hashes() {
 		// Also reset the internal nodes
 		let _ = crate::Nodes::<Test>::clear(u32::MAX, None);
 
-		let (_, root2) = ZkTree::insert_leaf(make_account(1), 0, 0u32, two_dev);
+		let (_, root2) = insert_and_settle(make_account(1), 0, 0u32, two_dev);
 
 		assert_ne!(root1, root2);
 	});
@@ -363,10 +416,14 @@ fn different_amounts_give_different_hashes() {
 fn zk_tree_root_set_in_frame_system() {
 	new_test_ext().execute_with(|| {
 		ZkTree::insert_leaf(make_account(1), 0, 0u32, 100u128);
-		let expected_root = ZkTree::root();
 
-		// Trigger on_finalize which sets the root in frame_system
+		// on_finalize folds the block's pending leaves into the root and then
+		// publishes it to frame_system for the block header.
 		ZkTree::on_finalize(1);
+
+		let expected_root = ZkTree::root();
+		assert_ne!(expected_root, [0u8; 32], "finalize must fold the pending leaf into the root");
+		assert_eq!(ZkTree::unprocessed_leaves(), 0, "finalize must drain pending leaves");
 
 		// Check that the root was set in frame_system storage using the getter
 		let stored_root: H256 = frame_system::Pallet::<Test>::zk_tree_root();
@@ -383,12 +440,7 @@ fn extract_zk_root_from_frame_system() -> Option<Hash256> {
 
 /// Simulate a transfer by inserting a leaf into the ZK trie.
 /// In production, pallet-wormhole would call this.
-fn simulate_transfer(
-	to: AccountId,
-	transfer_count: u64,
-	asset_id: u32,
-	amount: u128,
-) -> (u64, Hash256) {
+fn simulate_transfer(to: AccountId, transfer_count: u64, asset_id: u32, amount: u128) -> u64 {
 	ZkTree::insert_leaf(to, transfer_count, asset_id, amount)
 }
 
@@ -399,12 +451,14 @@ fn integration_many_transfers_updates_root() {
 		let bob = make_account(2);
 		let charlie = make_account(3);
 
-		// === Insert many transfers and verify tree grows correctly ===
+		// === Insert many transfers (settling per "block") and verify the tree
+		// grows correctly ===
 
-		// First 3 transfers
-		let (idx0, _) = simulate_transfer(alice.clone(), 0, 0, 1000);
-		let (idx1, _) = simulate_transfer(bob.clone(), 0, 0, 2000);
-		let (idx2, _) = simulate_transfer(charlie.clone(), 0, 0, 3000);
+		// First block: 3 transfers
+		let idx0 = simulate_transfer(alice.clone(), 0, 0, 1000);
+		let idx1 = simulate_transfer(bob.clone(), 0, 0, 2000);
+		let idx2 = simulate_transfer(charlie.clone(), 0, 0, 3000);
+		settle();
 
 		assert_eq!(idx0, 0);
 		assert_eq!(idx1, 1);
@@ -420,12 +474,14 @@ fn integration_many_transfers_updates_root() {
 			assert!(ZkTree::verify_proof(&leaf, &proof), "proof {} should verify", idx);
 		}
 
-		// 5 more transfers - tree will grow from depth 1 (capacity 4) to depth 2 (capacity 16)
+		// Second block: 5 more transfers - the batch spans the depth-1 capacity
+		// boundary (4), so this settlement grows the tree to depth 2.
 		simulate_transfer(alice.clone(), 1, 0, 500);
 		simulate_transfer(bob.clone(), 1, 0, 600);
 		simulate_transfer(charlie.clone(), 1, 0, 700);
 		simulate_transfer(alice.clone(), 2, 1, 100); // Different asset
 		simulate_transfer(bob.clone(), 2, 1, 200); // Different asset
+		settle();
 
 		assert_eq!(ZkTree::leaf_count(), 8);
 		assert!(ZkTree::depth() >= 2, "tree should have grown to depth 2");
@@ -440,11 +496,12 @@ fn integration_many_transfers_updates_root() {
 			assert!(ZkTree::verify_proof(&leaf, &proof), "proof {} should verify", idx);
 		}
 
-		// Add 10 more transfers (total 18, tree needs depth 3 for capacity 64)
+		// Third block: 10 more transfers (total 18, tree needs depth 3 for capacity 64)
 		for i in 0..10u64 {
 			let recipient = make_account((i % 5) as u8 + 10);
 			simulate_transfer(recipient, i, 0, (i as u128 + 1) * 1000);
 		}
+		settle();
 
 		assert_eq!(ZkTree::leaf_count(), 18);
 
@@ -502,25 +559,28 @@ fn integration_empty_tree_has_zero_root_in_frame_system() {
 }
 
 #[test]
-fn integration_root_changes_only_on_insert() {
+fn integration_root_changes_only_on_finalize() {
 	new_test_ext().execute_with(|| {
 		let alice = make_account(1);
 
-		// Insert a leaf
+		// Inserting alone must NOT change the root: the batch runs at finalize.
 		simulate_transfer(alice.clone(), 0, 0, 1000);
-		let root_after_insert = ZkTree::root();
+		assert_eq!(ZkTree::root(), [0u8; 32], "insert alone should not change root");
 
-		// Finalize - root should not change
+		// Finalize folds the pending leaf in.
 		ZkTree::on_finalize(1);
-		assert_eq!(ZkTree::root(), root_after_insert, "finalize should not change root");
+		let root_after_block_1 = ZkTree::root();
+		assert_ne!(root_after_block_1, [0u8; 32], "finalize should compute the root");
 
-		// Another finalize - still same root
+		// A block without inserts leaves the root untouched.
 		ZkTree::on_finalize(2);
-		assert_eq!(ZkTree::root(), root_after_insert, "second finalize should not change root");
+		assert_eq!(ZkTree::root(), root_after_block_1, "empty finalize should not change root");
 
-		// Insert another leaf - NOW root should change
+		// Another insert + finalize changes it again.
 		simulate_transfer(alice.clone(), 1, 0, 2000);
-		assert_ne!(ZkTree::root(), root_after_insert, "insert should change root");
+		assert_eq!(ZkTree::root(), root_after_block_1, "root must stay fixed until finalize");
+		ZkTree::on_finalize(3);
+		assert_ne!(ZkTree::root(), root_after_block_1, "finalize should fold the new leaf in");
 	});
 }
 
@@ -532,6 +592,7 @@ fn integration_proof_siblings_at_correct_depth() {
 			let account = make_account(i as u8);
 			simulate_transfer(account, 0, 0, (i as u128 + 1) * 100);
 		}
+		settle();
 
 		assert_eq!(ZkTree::depth(), 2);
 
@@ -551,4 +612,167 @@ fn integration_proof_siblings_at_correct_depth() {
 			assert!(ZkTree::verify_proof(&leaf, &proof), "proof for leaf {} should verify", i);
 		}
 	});
+}
+
+// ============================================================================
+// Batched settlement equivalence
+// ============================================================================
+
+/// Leaf fixture shared by the equivalence tests.
+fn equivalence_leaf(i: u64) -> ZkLeaf<AccountId, u32, u128> {
+	ZkLeaf {
+		to: make_account((i % 250) as u8 + 1),
+		transfer_count: i,
+		asset_id: (i % 3) as u32,
+		amount: (i + 1) as u128 * 100,
+	}
+}
+
+fn insert_equivalence_leaf(i: u64) {
+	let leaf = equivalence_leaf(i);
+	ZkTree::insert_leaf(leaf.to, leaf.transfer_count, leaf.asset_id, leaf.amount);
+}
+
+/// Independent reference: build the whole positional 4-ary tree in memory.
+///
+/// Mirrors the pallet's storage semantics where an absent (never written) node
+/// reads as the zero hash: a subtree with all-empty children stays the zero hash
+/// instead of being hashed.
+fn reference_root(leaf_hashes: &[Hash256]) -> Hash256 {
+	assert!(!leaf_hashes.is_empty());
+	let mut depth = 0u8;
+	while tree::capacity_at_depth(depth) < leaf_hashes.len() as u64 {
+		depth += 1;
+	}
+
+	let mut level = leaf_hashes.to_vec();
+	level.resize(tree::capacity_at_depth(depth) as usize, tree::empty_hash());
+	for _ in 0..depth {
+		level = level
+			.chunks(4)
+			.map(|children| {
+				let children: [Hash256; 4] =
+					[children[0], children[1], children[2], children[3]];
+				if children == [tree::empty_hash(); 4] {
+					tree::empty_hash()
+				} else {
+					tree::hash_node(&children)
+				}
+			})
+			.collect();
+	}
+	level[0]
+}
+
+/// The once-per-block batch must produce exactly the same root as settling after
+/// every single insert (the pre-batching behavior), and both must match an
+/// independent in-memory reference. Sizes cross the depth-1 (4) and depth-2 (16)
+/// capacity boundaries, including multi-level growth inside one batch.
+#[test]
+fn batched_settlement_matches_per_insert_settlement_and_reference() {
+	for n in [1u64, 2, 3, 4, 5, 7, 15, 16, 17, 20, 40, 65] {
+		let batch_root = new_test_ext().execute_with(|| {
+			for i in 0..n {
+				insert_equivalence_leaf(i);
+			}
+			settle();
+			ZkTree::root()
+		});
+
+		let per_insert_root = new_test_ext().execute_with(|| {
+			for i in 0..n {
+				insert_equivalence_leaf(i);
+				settle();
+			}
+			ZkTree::root()
+		});
+
+		let reference = new_test_ext().execute_with(|| {
+			let hashes: Vec<Hash256> =
+				(0..n).map(|i| tree::hash_leaf::<Test>(&equivalence_leaf(i))).collect();
+			reference_root(&hashes)
+		});
+
+		assert_eq!(batch_root, per_insert_root, "batch vs per-insert mismatch for n={n}");
+		assert_eq!(batch_root, reference, "batch vs reference mismatch for n={n}");
+	}
+}
+
+/// Split the same leaf sequence into blocks at every possible point (including
+/// splits landing exactly on capacity boundaries): the final root must never
+/// depend on how the inserts were grouped, and all leaves must stay provable.
+#[test]
+fn root_is_independent_of_block_grouping() {
+	let total = 21u64; // spans the 4 and 16 capacity boundaries
+
+	let all_at_once = new_test_ext().execute_with(|| {
+		for i in 0..total {
+			insert_equivalence_leaf(i);
+		}
+		settle();
+		ZkTree::root()
+	});
+
+	for split in 1..total {
+		let grouped = new_test_ext().execute_with(|| {
+			for i in 0..split {
+				insert_equivalence_leaf(i);
+			}
+			settle();
+			for i in split..total {
+				insert_equivalence_leaf(i);
+			}
+			settle();
+
+			// Every settled leaf must still be provable against the final root.
+			for i in 0..total {
+				let proof = ZkTree::get_merkle_proof(i).expect("proof should exist");
+				let leaf = ZkTree::leaf(i).expect("leaf should exist");
+				assert!(
+					ZkTree::verify_proof(&leaf, &proof),
+					"proof {i} should verify (split={split})"
+				);
+			}
+			ZkTree::root()
+		});
+		assert_eq!(grouped, all_at_once, "root mismatch for split={split}");
+	}
+}
+
+/// A settlement starting exactly at the old capacity (start == 4^depth) relies on
+/// `grow_tree` parking the old root at `(old_depth, 0)`; a settlement spanning
+/// the boundary overwrites the parked value. Both must agree with the reference.
+#[test]
+fn growth_boundary_settlements_are_consistent() {
+	// Exactly at the boundary: 4 leaves settled, then 1 more in its own block.
+	let at_boundary = new_test_ext().execute_with(|| {
+		for i in 0..4 {
+			insert_equivalence_leaf(i);
+		}
+		settle();
+		insert_equivalence_leaf(4);
+		settle();
+		ZkTree::root()
+	});
+
+	// Spanning the boundary: 3 settled, then 2 in one block.
+	let spanning = new_test_ext().execute_with(|| {
+		for i in 0..3 {
+			insert_equivalence_leaf(i);
+		}
+		settle();
+		insert_equivalence_leaf(3);
+		insert_equivalence_leaf(4);
+		settle();
+		ZkTree::root()
+	});
+
+	let reference = new_test_ext().execute_with(|| {
+		let hashes: Vec<Hash256> =
+			(0..5).map(|i| tree::hash_leaf::<Test>(&equivalence_leaf(i))).collect();
+		reference_root(&hashes)
+	});
+
+	assert_eq!(at_boundary, reference);
+	assert_eq!(spanning, reference);
 }

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -352,8 +352,7 @@ fn proof_for_nonexistent_leaf_fails() {
 		settle();
 
 		// Try to get proof for leaf index 5 (doesn't exist)
-		let result = ZkTree::get_merkle_proof(5);
-		assert!(result.is_err());
+		assert!(matches!(ZkTree::get_merkle_proof(5), Err(Error::<Test>::LeafIndexOutOfBounds)));
 	});
 }
 
@@ -366,7 +365,7 @@ fn proof_for_pending_leaf_fails_until_settled() {
 
 		// Leaf 1 is appended but not yet folded into the root: `Nodes` doesn't
 		// cover it, so no valid proof can exist for it yet.
-		assert!(ZkTree::get_merkle_proof(1).is_err());
+		assert!(matches!(ZkTree::get_merkle_proof(1), Err(Error::<Test>::LeafNotYetSettled)));
 		// Settled leaves stay provable.
 		assert!(ZkTree::get_merkle_proof(0).is_ok());
 

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -651,8 +651,7 @@ fn reference_root(leaf_hashes: &[Hash256]) -> Hash256 {
 		level = level
 			.chunks(4)
 			.map(|children| {
-				let children: [Hash256; 4] =
-					[children[0], children[1], children[2], children[3]];
+				let children: [Hash256; 4] = [children[0], children[1], children[2], children[3]];
 				if children == [tree::empty_hash(); 4] {
 					tree::empty_hash()
 				} else {

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -96,10 +96,7 @@ fn bytes_to_felts_compact_lossy(input: &[u8]) -> impl Iterator<Item = Goldilocks
 /// the leaf's `to_account` felts to `WA(secret)` (a canonical Poseidon output), so
 /// canonicalizing the recipient never changes who can exit a leaf. The
 /// `debug_assert` below enforces the caller contract in test/dev builds.
-pub fn hash_leaf<T: Config>(leaf: &ZkLeaf<AccountIdOf<T>, T::AssetId, T::Balance>) -> Hash256
-where
-	AccountIdOf<T>: AsRef<[u8]>,
-{
+pub fn hash_leaf<T: Config>(leaf: &ZkLeaf<AccountIdOf<T>, T::AssetId, T::Balance>) -> Hash256 {
 	use qp_poseidon_core::serialization::u64_to_felts;
 
 	let mut felts = Vec::with_capacity(8);
@@ -188,10 +185,7 @@ pub fn empty_hash() -> Hash256 {
 }
 
 /// Get the hash of a leaf by index, or empty hash if not present.
-fn get_leaf_hash<T: Config>(index: u64) -> Hash256
-where
-	AccountIdOf<T>: AsRef<[u8]>,
-{
+fn get_leaf_hash<T: Config>(index: u64) -> Hash256 {
 	match crate::Leaves::<T>::get(index) {
 		Some(leaf) => hash_leaf::<T>(&leaf),
 		None => empty_hash(),
@@ -215,10 +209,7 @@ fn get_node_hash<T: Config>(level: u8, index: u64) -> Hash256 {
 /// a batch of `n` leaves costs about `n/4 + n/16 + … + depth` node hashes instead
 /// of the `n · depth` a per-insert path update would pay. This is what makes the
 /// once-per-block (`on_finalize`) root computation cheap.
-pub fn update_range<T: Config>(start: u64, end: u64, depth: u8) -> Hash256
-where
-	AccountIdOf<T>: AsRef<[u8]>,
-{
+pub fn update_range<T: Config>(start: u64, end: u64, depth: u8) -> Hash256 {
 	debug_assert!(start < end, "leaf range must be non-empty");
 	debug_assert!(capacity_at_depth(depth) >= end, "depth must fit the whole range");
 
@@ -289,10 +280,7 @@ pub fn grow_tree<T: Config>(old_depth: u8) {
 ///
 /// Returns siblings at each level. No path indices needed because children
 /// are sorted before hashing - the verifier can reconstruct by sorting.
-pub fn generate_proof<T: Config>(leaf_index: u64, depth: u8) -> Result<ZkMerkleProof, Error<T>>
-where
-	AccountIdOf<T>: AsRef<[u8]>,
-{
+pub fn generate_proof<T: Config>(leaf_index: u64, depth: u8) -> Result<ZkMerkleProof, Error<T>> {
 	if depth == 0 {
 		return Err(Error::<T>::LeafNotFound);
 	}
@@ -347,10 +335,7 @@ pub fn verify_proof<T: Config>(
 	leaf: &ZkLeaf<AccountIdOf<T>, T::AssetId, T::Balance>,
 	proof: &ZkMerkleProof,
 	expected_root: Hash256,
-) -> bool
-where
-	AccountIdOf<T>: AsRef<[u8]>,
-{
+) -> bool {
 	let mut current_hash = hash_leaf::<T>(leaf);
 
 	for level_siblings in &proof.siblings {

--- a/pallets/zk-tree/src/tree.rs
+++ b/pallets/zk-tree/src/tree.rs
@@ -3,7 +3,7 @@
 //! This module provides the core tree operations:
 //! - Leaf hashing (8 felts, injective for ≤32-bit values)
 //! - Node hashing (16 felts, 8 bytes/felt compact encoding)
-//! - Path updates on insert
+//! - Batched (once-per-block) folding of appended leaves into the tree
 //! - Proof generation and verification
 //! - Tree growth when capacity is exceeded
 
@@ -203,92 +203,86 @@ fn get_node_hash<T: Config>(level: u8, index: u64) -> Hash256 {
 	crate::Nodes::<T>::get((level, index)).unwrap_or_else(empty_hash)
 }
 
-/// Update the path from a leaf to the root after insertion.
+/// Fold the contiguous, freshly appended leaf range `[start, end)` into the tree
+/// in one bottom-up pass and return the new root hash.
 ///
-/// Returns the new root hash.
-pub fn update_path<T: Config>(leaf_index: u64, leaf_hash: Hash256) -> Hash256
+/// Callers must ensure that every leaf `< start` is already reflected in `Nodes`
+/// (and `Root`), that `depth` is large enough to fit `end` leaves, and — when the
+/// tree grew to reach `depth` — that [`grow_tree`] has parked the old root first.
+///
+/// Because the appended leaves are contiguous, the dirty nodes at every level form
+/// a contiguous index range `[lo, hi]`. Each dirty node is hashed exactly once, so
+/// a batch of `n` leaves costs about `n/4 + n/16 + … + depth` node hashes instead
+/// of the `n · depth` a per-insert path update would pay. This is what makes the
+/// once-per-block (`on_finalize`) root computation cheap.
+pub fn update_range<T: Config>(start: u64, end: u64, depth: u8) -> Hash256
 where
 	AccountIdOf<T>: AsRef<[u8]>,
 {
-	let depth = crate::Depth::<T>::get();
+	debug_assert!(start < end, "leaf range must be non-empty");
+	debug_assert!(capacity_at_depth(depth) >= end, "depth must fit the whole range");
 
-	if depth == 0 {
-		// Special case: first leaf in empty tree - need to initialize
-		crate::Depth::<T>::put(1);
-		return leaf_hash;
-	}
-
-	// Start from leaf level and work up to root
-	let mut current_index = leaf_index;
-	let mut current_hash = leaf_hash;
+	// Hashes of the dirty nodes at the current level, covering indices [lo, hi].
+	let mut lo = start;
+	let mut hi = end - 1;
+	let mut dirty: Vec<Hash256> = (start..end).map(get_leaf_hash::<T>).collect();
 
 	for level in 1..=depth {
-		// Find which group of 4 this node belongs to
-		let parent_index = current_index / (ARITY as u64);
+		let parent_lo = lo / (ARITY as u64);
+		let parent_hi = hi / (ARITY as u64);
+		let mut parents = Vec::with_capacity((parent_hi - parent_lo + 1) as usize);
 
-		// Get all 4 children for this parent
-		let mut children = [empty_hash(); ARITY];
-
-		if level == 1 {
-			// Children are leaves
-			let base_leaf_index = parent_index * (ARITY as u64);
+		for parent in parent_lo..=parent_hi {
+			let base = parent * (ARITY as u64);
+			let mut children = [empty_hash(); ARITY];
 			for (i, child) in children.iter_mut().enumerate() {
-				let child_leaf_index = base_leaf_index + (i as u64);
-				*child = if child_leaf_index == leaf_index {
-					current_hash
+				let index = base + i as u64;
+				*child = if index >= lo && index <= hi {
+					dirty[(index - lo) as usize]
+				} else if index > hi {
+					// The tree is append-only: everything to the right of the
+					// last appended leaf is still empty — skip the storage read.
+					empty_hash()
+				} else if level == 1 {
+					// Pre-existing leaves sharing the boundary parent with `start`.
+					get_leaf_hash::<T>(index)
 				} else {
-					get_leaf_hash::<T>(child_leaf_index)
+					get_node_hash::<T>(level - 1, index)
 				};
 			}
-		} else {
-			// Children are internal nodes
-			let base_child_index = parent_index * (ARITY as u64);
-			for (i, child) in children.iter_mut().enumerate() {
-				let child_index = base_child_index + (i as u64);
-				*child = if child_index == current_index {
-					current_hash
-				} else {
-					get_node_hash::<T>(level - 1, child_index)
-				};
+
+			let hash = hash_node(&children);
+			// The root lives in `Root`, not `Nodes`.
+			if level < depth {
+				crate::Nodes::<T>::insert((level, parent), hash);
 			}
+			parents.push(hash);
 		}
 
-		// Compute parent hash
-		current_hash = hash_node(&children);
-
-		// Store the node (except at root level, which is stored separately)
-		if level < depth {
-			crate::Nodes::<T>::insert((level, parent_index), current_hash);
-		}
-
-		current_index = parent_index;
+		dirty = parents;
+		lo = parent_lo;
+		hi = parent_hi;
 	}
 
-	current_hash
+	debug_assert_eq!((lo, hi), (0, 0), "range must converge to the root");
+	dirty[0]
 }
 
-/// Grow the tree by one level.
+/// Prepare the tree to grow beyond `old_depth`.
 ///
-/// The current root becomes one of the children of the new root.
-pub fn grow_tree<T: Config>(old_depth: u8, _new_depth: u8) {
+/// The subtree that used to be the whole tree becomes child 0 of the first new
+/// level, so the current `Root` has to move into `Nodes` at `(old_depth, 0)`.
+/// Everything above it is computed by the next [`update_range`] pass: every node
+/// on the new levels sits on the dirty path of the leaves that triggered the
+/// growth. If the pending range also dirties `(old_depth, 0)` itself (i.e. the
+/// range starts inside the old subtree), the parked value is simply overwritten
+/// by that same pass.
+pub fn grow_tree<T: Config>(old_depth: u8) {
 	if old_depth == 0 {
-		// Tree was empty, just set depth
+		// Tree was empty; there is no old root to park.
 		return;
 	}
-
-	// The old root hash becomes child[0] of the new root
-	let old_root = crate::Root::<T>::get();
-
-	// Store the old root as a node at the old depth level, index 0
-	crate::Nodes::<T>::insert((old_depth, 0), old_root);
-
-	// The new root will be computed when the next leaf triggers update_path
-	// For now, compute it with empty siblings
-	let mut children = [empty_hash(); ARITY];
-	children[0] = old_root;
-	let new_root = hash_node(&children);
-
-	crate::Root::<T>::put(new_root);
+	crate::Nodes::<T>::insert((old_depth, 0), crate::Root::<T>::get());
 }
 
 /// Generate a Merkle proof for a leaf at the given index.

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -162,9 +162,8 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 
 	/// Events deposited by one successfully recorded proof: `ZkTree::LeafInserted`
 	/// plus the wormhole's `NativeTransferred` / `AssetTransferred`. (`TreeGrew` is
-	/// deliberately not modeled: the tree grows at most [`pallet_zk_tree::MAX_TREE_DEPTH`]
-	/// times over the chain's entire life, and the flat depth-ceiling insert pricing
-	/// already carries margin for young trees.)
+	/// not modeled because it cannot appear in the scan at all: it is emitted from
+	/// the zk-tree's `on_finalize`, after every post-dispatch scan has already run.)
 	const EVENTS_PER_RECORDED_PROOF: u64 = 2;
 
 	/// Weight of depositing `events` records from proof recording. Each
@@ -1210,10 +1209,9 @@ mod tests {
 
 	/// Pins the multiplier behind the modeled event-deposit charge: one recorded proof
 	/// deposits exactly `EVENTS_PER_RECORDED_PROOF` events. If recording ever starts
-	/// emitting more, the static reservation must be updated with it. (Capacity-boundary
-	/// inserts additionally emit `TreeGrew`, deliberately unmodeled: it happens at most
-	/// `MAX_TREE_DEPTH` times over the chain's whole life — the warm-up insert below
-	/// steps the fresh test tree past the first boundary.)
+	/// emitting more, the static reservation must be updated with it. (`TreeGrew` is
+	/// emitted from the zk-tree's `on_finalize`, never during recording, so even the
+	/// very first insert on a fresh tree deposits exactly the modeled events.)
 	#[test]
 	fn recording_one_proof_deposits_exactly_the_modeled_events() {
 		new_test_ext().execute_with(|| {
@@ -1235,13 +1233,75 @@ mod tests {
 				u64::from(System::event_count() - events_before)
 			};
 
-			// Warm-up: the very first insert grows the empty tree and emits `TreeGrew`.
-			record_one_transfer();
-
 			assert_eq!(
 				record_one_transfer(),
 				WormholeProofRecorderExtension::<Runtime>::EVENTS_PER_RECORDED_PROOF,
 				"the modeled events-per-proof multiplier must match what recording deposits"
+			);
+		});
+	}
+
+	/// The batched zk-tree settlement assumes every pallet that inserts leaves runs
+	/// its `on_finalize` before `ZkTree`'s. That holds because hooks execute in
+	/// pallet declaration order and `ZkTree` (index 21) is declared after all
+	/// inserters — notably `MiningRewards` (index 6), which records the block
+	/// reward leaf from its own `on_finalize` — but nothing except declaration
+	/// order enforces it. Drive the real `AllPalletsWithSystem` finalize sequence
+	/// and pin the invariant: after a full-block finalize nothing may be left
+	/// pending, and the header root must cover both a mid-block transfer leaf and
+	/// the mining-reward leaf.
+	#[test]
+	fn full_block_finalize_settles_all_leaves_including_mining_reward() {
+		new_test_ext().execute_with(|| {
+			use frame_support::traits::OnFinalize;
+			use frame_system::pallet_prelude::BlockNumberFor;
+
+			let block: BlockNumberFor<Runtime> = 1u32.into();
+			System::set_block_number(block);
+			// Timestamp's `on_finalize` asserts its inherent ran this block.
+			crate::Timestamp::set(crate::RuntimeOrigin::none(), 12_000)
+				.expect("timestamp inherent must apply");
+
+			// A transfer leaf recorded mid-block, as the proof-recorder extension
+			// would do in an extrinsic's post-dispatch. The recipient must be
+			// canonical for the leaf encoding (the wormhole canonicalizes too).
+			let recipient: AccountId =
+				pallet_zk_tree::tree::canonicalize_account_bytes(alice().into()).into();
+			let leaves_before = crate::ZkTree::leaf_count();
+			pallet_zk_tree::Pallet::<Runtime>::insert_leaf(
+				recipient,
+				0,
+				Default::default(),
+				EXISTENTIAL_DEPOSIT,
+			);
+			assert_eq!(crate::ZkTree::unprocessed_leaves(), 1);
+			let root_before = crate::ZkTree::root();
+
+			<crate::AllPalletsWithSystem as OnFinalize<BlockNumberFor<Runtime>>>::on_finalize(
+				block,
+			);
+
+			// MiningRewards' on_finalize (declared before ZkTree's) minted the
+			// block reward and recorded its leaf via the wormhole recorder.
+			assert!(
+				crate::ZkTree::leaf_count() >= leaves_before + 2,
+				"expected the mid-block leaf plus the mining-reward leaf"
+			);
+			assert_eq!(
+				crate::ZkTree::unprocessed_leaves(),
+				0,
+				"a full-block finalize must settle every leaf — if this fails, a \
+				 leaf-inserting pallet's on_finalize now runs after ZkTree's"
+			);
+			assert_ne!(
+				crate::ZkTree::root(),
+				root_before,
+				"the settled root must fold the block's leaves in"
+			);
+			assert_eq!(
+				frame_system::Pallet::<Runtime>::zk_tree_root().0,
+				crate::ZkTree::root(),
+				"the header must carry the settled root"
 			);
 		});
 	}

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -137,12 +137,14 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 	/// Weight charged per recorded transfer proof.
 	///
 	/// Per recorded transfer, `record_transfer` touches one `TransferCount` read and one
-	/// write, plus the ZK-tree leaf insert. The insert price is FLAT at the circuit
-	/// depth ceiling (see [`pallet_zk_tree::INSERT_LEAF_DB_OPS`]), so multiplying this
-	/// single price by a transfer count is sound even for multi-transfer calls that
-	/// cross capacity boundaries. The path update also puts every tree key it reads
-	/// into the PoV ([`pallet_zk_tree::TREE_KEY_POV`] each); omitting that proof-size
-	/// term would let deep-tree blocks exceed the PoV budget validators re-execute
+	/// write, plus the ZK-tree leaf append. Root recomputation is batched once per
+	/// block in the zk-tree's `on_finalize`; this price is the flat *marginal* share
+	/// of that batch (see [`pallet_zk_tree::INSERT_LEAF_DB_OPS`]), so multiplying it
+	/// by a transfer count is sound even for multi-transfer calls that cross capacity
+	/// boundaries — the depth-dependent tail is reserved once per block by the
+	/// zk-tree's `on_initialize`. The batch also puts every tree key it touches into
+	/// the PoV ([`pallet_zk_tree::TREE_KEY_POV`] each); omitting that proof-size term
+	/// would let deep-tree blocks exceed the PoV budget validators re-execute
 	/// against. Recording finally deposits [`Self::EVENTS_PER_RECORDED_PROOF`] events;
 	/// those land after the scan snapshot, so this reservation is the only place their
 	/// System work can be charged.


### PR DESCRIPTION
# Batch ZK-tree root computation once per block

## Summary

Reworks how the ZK tree handles insertions: transfers now only **append** their leaf, and the Merkle root is recomputed **once per block** in the zk-tree pallet's `on_finalize`, folding all of the block's leaves into the tree in a single bottom-up pass.

Previously every transfer ran a full leaf-to-root path update: `depth` Poseidon hashes, `3·depth` sibling reads, and `depth` node writes — repeated per insert even though all inserts in a block share most of their paths. The batched pass hashes each dirty node exactly once, so a block with `n` transfers costs roughly `n/4 + n/16 + … + depth` node hashes instead of `n·depth`.

## Why this is safe

Nothing on-chain needs the root mid-block:

- Wormhole exit proofs verify against **historical block headers** (bound by block hash), never against the live `Root`.
- Callers of `record_transfer` only consume the leaf index, which is still assigned at insert time.
- The only consumer of the fresh root is the header stamp in `on_finalize` — exactly where the computation now lives.

During block execution `Root` is simply the root as of the end of the previous block. A new `UnprocessedLeaves` counter tracks the block's pending range; it defaults to 0, so **no storage migration is needed**.

Hook ordering is safe: `on_finalize` runs in pallet declaration order, and `ZkTree` (index 21) is declared after every leaf inserter — including `MiningRewards` (index 6), which inserts the block reward leaf from its own `on_finalize`.

## Weight repricing

Insert pricing moves from "flat full path at the circuit depth ceiling" to a **marginal + per-block base** split, keeping `price × n` sound for any multi-insert call:

| Constant | Before | After |
|---|---|---|
| `INSERT_LEAF_DB_OPS` (reads, writes) | (52, 21) | (3, 4) |
| `INSERT_LEAF_POSEIDON_EVALS` | 18 | 3 |
| `FINALIZE_BASE_DB_OPS` (new, once per block) | — | (56, 22) |
| `FINALIZE_BASE_POSEIDON_EVALS` (new, once per block) | — | 19 |

The depth-dependent tail (boundary siblings, path above the batch, growth bookkeeping) is reserved unconditionally by the zk-tree pallet's `on_initialize`. Per-transfer PoV drops from ~135 KB (52 tree keys) to ~10 KB, which is the real throughput unlock on top of the earlier Poseidon `ref_time` correction.

Downstream weight formulas (wormhole batch exits, mining rewards, vesting, reversible transfers, the wormhole proof-recorder extension) scale off the shared constants and needed no structural change. Vesting's payout weight now clamps at its benchmarked base, since the marginal append is cheaper than the benchmark-time ops it substitutes.

## Behavioral changes

- `insert_leaf` returns just the leaf index (the root is no longer known at insert time).
- `LeafInserted` event no longer carries `new_root`; the authoritative root for the block is in the header.
- `TreeGrew` is emitted at finalize (once per settlement, with the final depth) instead of per insert.
- `get_merkle_proof` rejects leaves not yet folded into the root; at any block boundary all leaves are folded, so RPC behavior is unchanged.
- Root values are **hash-for-hash identical** to the old per-insert algorithm for any leaf sequence.

## Tests

- New equivalence suite: batched settlement == per-insert settlement == independent in-memory reference tree, across sizes spanning the depth-1/2 capacity boundaries and multi-level growth inside one batch.
- Block-grouping invariance: the same 21-leaf sequence split into two blocks at every possible point produces the same root, with all leaves provable.
- Growth-boundary cases: settlement starting exactly at `4^depth` (relies on parking the old root) and spanning the boundary (overwrites the parked value).
- Existing zk-tree, vesting, mining-rewards, and reversible-transfers suites updated/passing (30/27/51/58).

## Notes for reviewers

- The batch algorithm lives in `tree::update_range`; `grow_tree` now only parks the old root at `(old_depth, 0)` — everything above is recomputed by the same pass.
- Benchmarks (`weights_generated`) were produced against the old per-insert path; regenerating them will lower the vesting/reversible bases further. Until then the clamp keeps them conservative.