### PR TITLE
ci: Miner API version bump to quantus-miner-api-v0.3.0

### DIFF
--- a/.github/workflows/miner-api-publish.yml
+++ b/.github/workflows/miner-api-publish.yml
@@ -9,63 +9,108 @@ on:
     types: [closed]
     branches:
       - main
+  # Recovery path: tag + publish what's already on a ref without a version-bump PR
+  # (e.g. main carries 0.3.0 but create-miner-api-tag never ran after a failed check).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (quantus-miner-api-vX.Y.Z or X.Y.Z)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref containing that version (branch, tag, or SHA)'
+        required: false
+        type: string
+        default: 'main'
+      is_draft:
+        description: 'Draft release (tag only; skip crates.io)?'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   prepare-miner-api-release:
     name: Prepare Miner API Release
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'miner-api-release-proposal')
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'miner-api-release-proposal')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.extract_version.outputs.version }}
-      is_draft: ${{ steps.extract_version.outputs.is_draft }}
-      commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      version: ${{ steps.resolve.outputs.version }}
+      is_draft: ${{ steps.resolve.outputs.is_draft }}
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
     steps:
-      - name: Checkout merge commit
+      - name: Checkout release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.event.pull_request.merge_commit_sha }}
 
-      - name: Extract version from PR title
-        id: extract_version
+      - name: Resolve version and commit
+        id: resolve
         run: |
           set -euo pipefail
-          # Extract version from PR title (format: "ci: Miner API version bump to quantus-miner-api-vX.Y.Z").
-          # Take only the first match so a title with two version strings cannot
-          # write a multi-line value into GITHUB_OUTPUT.
-          VERSION=$(echo "${{ github.event.pull_request.title }}" \
-            | grep -o 'quantus-miner-api-v[0-9]\+\.[0-9]\+\.[0-9]\+' \
-            | head -n1 || true)
-          if [ -z "$VERSION" ]; then
-            echo "Error: Could not extract miner-api version from PR title: ${{ github.event.pull_request.title }}"
-            exit 1
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+            case "$RAW" in
+              quantus-miner-api-v*) VERSION="$RAW" ;;
+              *) VERSION="quantus-miner-api-v$RAW" ;;
+            esac
+            if [[ ! "$VERSION" =~ ^quantus-miner-api-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Error: invalid version '$RAW' (want X.Y.Z or quantus-miner-api-vX.Y.Z)"
+              exit 1
+            fi
+            if [ "${{ github.event.inputs.is_draft }}" = "true" ]; then
+              echo "is_draft=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_draft=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # Take only the first match so a title with two version strings cannot
+            # write a multi-line value into GITHUB_OUTPUT.
+            VERSION=$(echo "${{ github.event.pull_request.title }}" \
+              | grep -o 'quantus-miner-api-v[0-9]\+\.[0-9]\+\.[0-9]\+' \
+              | head -n1 || true)
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract miner-api version from PR title: ${{ github.event.pull_request.title }}"
+              exit 1
+            fi
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
+              echo "is_draft=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_draft=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
-          # The tag/crates.io name comes from the title; cargo publish uses
-          # miner-api/Cargo.toml. Refuse to proceed if they disagree.
           CARGO_VERSION=${VERSION#quantus-miner-api-v}
+
+          # Tag/crates.io name must match what cargo publish will upload.
           if ! grep -q "^version = \"$CARGO_VERSION\"" miner-api/Cargo.toml; then
-            echo "Error: PR title version $VERSION does not match miner-api/Cargo.toml:"
+            echo "Error: release version $VERSION does not match miner-api/Cargo.toml:"
             grep '^version = ' miner-api/Cargo.toml || true
             exit 1
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Check if this is a draft release
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
-            echo "is_draft=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_draft=false" >> $GITHUB_OUTPUT
+          # README ships in the .crate tarball; keep the install snippet honest.
+          if ! grep -q "^quantus-miner-api = \"$CARGO_VERSION\"" miner-api/README.md; then
+            echo "Error: miner-api/README.md install line does not match $CARGO_VERSION:"
+            grep -E '^quantus-miner-api = "' miner-api/README.md || true
+            exit 1
           fi
-          echo "Extracted miner-api version: $VERSION (matches Cargo.toml)"
-          echo "Merge commit: ${{ github.event.pull_request.merge_commit_sha }}"
+
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved miner-api version: $VERSION at $COMMIT_SHA"
 
   format-checks:
     name: 🏁 Format Checks (Miner API)
     needs: prepare-miner-api-release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout merge commit
+      - name: Checkout release commit
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
@@ -86,7 +131,7 @@ jobs:
     needs: [prepare-miner-api-release, format-checks]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout merge commit
+      - name: Checkout release commit
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
@@ -113,7 +158,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout merge commit
+      - name: Checkout release commit
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -142,7 +187,7 @@ jobs:
           fi
 
           git tag -a "$VERSION" -m "Miner API release $VERSION" "$SHA"
-          git push origin "$VERSION"
+          git push origin "refs/tags/$VERSION"
 
   publish-miner-api-to-crates:
     name: 📦 Publish to crates.io
@@ -153,17 +198,33 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Checkout code at tag
+      # Pin by SHA (not the tag name) so a branch named like the tag cannot
+      # shadow refs/tags/ and get published under the org token.
+      - name: Checkout release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-miner-api-release.outputs.version }}
+          ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
 
       - name: Setup Ubuntu
         uses: ./.github/actions/ubuntu
 
       - name: Publish quantus-miner-api to crates.io
         run: |
+          set -euo pipefail
           cd miner-api
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+          set +e
+          cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}" --allow-dirty 2>&1 | tee publish.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          # Idempotent re-run: upload may have succeeded while the job still failed
+          # (runner eviction, dropped response). Tag guard already short-circuits.
+          if grep -Eqi 'already exists|already uploaded' publish.log; then
+            echo "Version already on crates.io; treating as success for idempotent re-run"
+            exit 0
+          fi
+          exit "$status"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/miner-api-publish.yml
+++ b/.github/workflows/miner-api-publish.yml
@@ -11,21 +11,15 @@ on:
       - main
 
 jobs:
-  create-miner-api-tag:
-    name: Create Miner API Tag
+  prepare-miner-api-release:
+    name: Prepare Miner API Release
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'miner-api-release-proposal')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
       is_draft: ${{ steps.extract_version.outputs.is_draft }}
+      commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Extract version from PR title
         id: extract_version
         run: |
@@ -44,23 +38,17 @@ jobs:
             echo "is_draft=false" >> $GITHUB_OUTPUT
           fi
           echo "Extracted miner-api version: $VERSION"
-
-      - name: Create and push miner-api tag
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a "${{ steps.extract_version.outputs.version }}" -m "Miner API release ${{ steps.extract_version.outputs.version }}"
-          git push origin "${{ steps.extract_version.outputs.version }}"
+          echo "Merge commit: ${{ github.event.pull_request.merge_commit_sha }}"
 
   format-checks:
     name: 🏁 Format Checks (Miner API)
-    needs: create-miner-api-tag
+    needs: prepare-miner-api-release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code at tag
+      - name: Checkout merge commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.create-miner-api-tag.outputs.version }}
+          ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
 
       - name: Install required components
         run: rustup component add rustfmt --toolchain nightly
@@ -75,13 +63,13 @@ jobs:
 
   build-and-test-miner-api:
     name: 🛠️ Build & Test Miner API
-    needs: [create-miner-api-tag, format-checks]
+    needs: [prepare-miner-api-release, format-checks]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code at tag
+      - name: Checkout merge commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.create-miner-api-tag.outputs.version }}
+          ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
 
       - name: Setup Ubuntu
         uses: ./.github/actions/ubuntu
@@ -98,10 +86,48 @@ jobs:
       - name: Build docs for miner-api
         run: cargo doc --locked --no-deps --package quantus-miner-api
 
+  create-miner-api-tag:
+    name: Create Miner API Tag
+    needs: [prepare-miner-api-release, build-and-test-miner-api]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ needs.prepare-miner-api-release.outputs.commit_sha }}
+
+      - name: Create and push miner-api tag
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare-miner-api-release.outputs.version }}"
+          SHA="${{ needs.prepare-miner-api-release.outputs.commit_sha }}"
+
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Idempotent: a re-run after a successful tag (e.g. publish flaked) must
+          # not fail just because the tag already exists at the same commit.
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            EXISTING=$(git rev-list -n 1 "$VERSION")
+            if [ "$EXISTING" = "$SHA" ]; then
+              echo "Tag $VERSION already points at $SHA; nothing to do"
+              exit 0
+            fi
+            echo "Error: tag $VERSION already exists at $EXISTING, expected $SHA"
+            exit 1
+          fi
+
+          git tag -a "$VERSION" -m "Miner API release $VERSION" "$SHA"
+          git push origin "$VERSION"
+
   publish-miner-api-to-crates:
     name: 📦 Publish to crates.io
-    needs: [create-miner-api-tag, build-and-test-miner-api]
-    if: needs.create-miner-api-tag.result == 'success' && needs.build-and-test-miner-api.result == 'success' && needs.create-miner-api-tag.outputs.is_draft == 'false'
+    needs: [prepare-miner-api-release, create-miner-api-tag, build-and-test-miner-api]
+    if: needs.prepare-miner-api-release.result == 'success' && needs.create-miner-api-tag.result == 'success' && needs.build-and-test-miner-api.result == 'success' && needs.prepare-miner-api-release.outputs.is_draft == 'false'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -110,7 +136,7 @@ jobs:
       - name: Checkout code at tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.create-miner-api-tag.outputs.version }}
+          ref: ${{ needs.prepare-miner-api-release.outputs.version }}
 
       - name: Setup Ubuntu
         uses: ./.github/actions/ubuntu

--- a/.github/workflows/miner-api-publish.yml
+++ b/.github/workflows/miner-api-publish.yml
@@ -20,15 +20,35 @@ jobs:
       is_draft: ${{ steps.extract_version.outputs.is_draft }}
       commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
     steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
       - name: Extract version from PR title
         id: extract_version
         run: |
-          # Extract version from PR title (format: "ci: Miner API version bump to quantus-miner-api-vX.Y.Z")
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -o 'quantus-miner-api-v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          set -euo pipefail
+          # Extract version from PR title (format: "ci: Miner API version bump to quantus-miner-api-vX.Y.Z").
+          # Take only the first match so a title with two version strings cannot
+          # write a multi-line value into GITHUB_OUTPUT.
+          VERSION=$(echo "${{ github.event.pull_request.title }}" \
+            | grep -o 'quantus-miner-api-v[0-9]\+\.[0-9]\+\.[0-9]\+' \
+            | head -n1 || true)
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract miner-api version from PR title: ${{ github.event.pull_request.title }}"
             exit 1
           fi
+
+          # The tag/crates.io name comes from the title; cargo publish uses
+          # miner-api/Cargo.toml. Refuse to proceed if they disagree.
+          CARGO_VERSION=${VERSION#quantus-miner-api-v}
+          if ! grep -q "^version = \"$CARGO_VERSION\"" miner-api/Cargo.toml; then
+            echo "Error: PR title version $VERSION does not match miner-api/Cargo.toml:"
+            grep '^version = ' miner-api/Cargo.toml || true
+            exit 1
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Check if this is a draft release
@@ -37,7 +57,7 @@ jobs:
           else
             echo "is_draft=false" >> $GITHUB_OUTPUT
           fi
-          echo "Extracted miner-api version: $VERSION"
+          echo "Extracted miner-api version: $VERSION (matches Cargo.toml)"
           echo "Merge commit: ${{ github.event.pull_request.merge_commit_sha }}"
 
   format-checks:

--- a/.github/workflows/miner-api-release-proposal.yml
+++ b/.github/workflows/miner-api-release-proposal.yml
@@ -51,30 +51,59 @@ jobs:
           echo "commit_sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "source_branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Get latest miner-api tag
+      - name: Get latest miner-api tag and manifest version
         id: latest_tag
         run: |
+          set -euo pipefail
           # Get all miner-api version tags and sort them by version
           latest_miner_api_tag=$(git tag -l "quantus-miner-api-v[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)
-          
+
           # If no tags found, use default
           if [ -z "$latest_miner_api_tag" ]; then
             latest_miner_api_tag="quantus-miner-api-v0.0.0"
           fi
-          
-          echo "latest_tag_found=$latest_miner_api_tag" >> $GITHUB_OUTPUT
-          echo "Latest miner-api tag found: $latest_miner_api_tag"
+
+          manifest_version=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' miner-api/Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)"/\1/')
+          if [ -z "$manifest_version" ]; then
+            echo "Error: could not read version from miner-api/Cargo.toml"
+            exit 1
+          fi
+
+          tag_version=${latest_miner_api_tag#quantus-miner-api-v}
+          # Base bumps on max(manifest, tag). Tag-only basing rewrites the
+          # manifest downward when a merge left an untagged higher version
+          # (e.g. tree at 0.3.0, latest tag still 0.2.1 → patch becomes 0.2.2).
+          base_version=$(printf '%s\n%s\n' "$manifest_version" "$tag_version" | sort -V | tail -n 1)
+
+          echo "latest_tag_found=$latest_miner_api_tag" >> "$GITHUB_OUTPUT"
+          echo "manifest_version=$manifest_version" >> "$GITHUB_OUTPUT"
+          echo "base_version=$base_version" >> "$GITHUB_OUTPUT"
+          echo "Latest miner-api tag: $latest_miner_api_tag"
+          echo "Manifest version: $manifest_version"
+          echo "Bump base (max of tag/manifest): $base_version"
+
+          # Untagged merge: tree is ahead of tags. Refusing automatic bumps
+          # forces the recovery path (Miner API - Publish workflow_dispatch)
+          # instead of inventing a higher version that skips the untagged one.
+          if [ "$manifest_version" != "$tag_version" ] && \
+             [ "$(printf '%s\n%s\n' "$manifest_version" "$tag_version" | sort -V | tail -n 1)" = "$manifest_version" ]; then
+            echo "::error::miner-api/Cargo.toml is at $manifest_version but the newest tag is still $latest_miner_api_tag."
+            echo "::error::Publish the untagged version first via workflow_dispatch on 'Miner API - Publish'"
+            echo "::error::(version=$manifest_version, ref=$(git rev-parse --abbrev-ref HEAD)), then re-run this proposal."
+            exit 1
+          fi
 
       - name: Calculate new miner-api version
         id: versioner
         env:
-          LATEST_TAG: ${{ steps.latest_tag.outputs.latest_tag_found }}
+          BASE_VERSION: ${{ steps.latest_tag.outputs.base_version }}
+          MANIFEST_VERSION: ${{ steps.latest_tag.outputs.manifest_version }}
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
           CUSTOM_VERSION: ${{ github.event.inputs.custom_version }}
           IS_DRAFT: ${{ github.event.inputs.is_draft }}
         run: |
-          # Remove 'quantus-miner-api-v' prefix for processing
-          current_version=${LATEST_TAG#quantus-miner-api-v}
+          set -euo pipefail
+          current_version="$BASE_VERSION"
 
           if [[ "$VERSION_TYPE" == "custom" ]]; then
             if [[ -z "$CUSTOM_VERSION" ]]; then
@@ -86,6 +115,14 @@ jobs:
               exit 1
             fi
             new_version="quantus-miner-api-v$CUSTOM_VERSION"
+            # Refuse no-op / downward customs: a custom equal to the manifest
+            # makes every sed a no-op and `git commit` fails under set -ex.
+            if [ "$(printf '%s\n%s\n' "$CUSTOM_VERSION" "$MANIFEST_VERSION" | sort -V | tail -n 1)" != "$CUSTOM_VERSION" ] || \
+               [ "$CUSTOM_VERSION" = "$MANIFEST_VERSION" ]; then
+              echo "Error: custom version $CUSTOM_VERSION must be strictly greater than manifest $MANIFEST_VERSION."
+              echo "If $MANIFEST_VERSION is already on the tree but untagged, use workflow_dispatch on 'Miner API - Publish'."
+              exit 1
+            fi
           else
             # Split version into components
             IFS='.' read -r major minor patch <<< "$current_version"
@@ -113,8 +150,16 @@ jobs:
             new_version="quantus-miner-api-v$major.$minor.$patch"
           fi
 
+          new_cargo_version=${new_version#quantus-miner-api-v}
+          # Belt-and-suspenders: never rewrite the manifest downward.
+          if [ "$(printf '%s\n%s\n' "$new_cargo_version" "$MANIFEST_VERSION" | sort -V | tail -n 1)" != "$new_cargo_version" ] || \
+             [ "$new_cargo_version" = "$MANIFEST_VERSION" ]; then
+            echo "Error: computed version $new_cargo_version is not strictly greater than manifest $MANIFEST_VERSION"
+            exit 1
+          fi
+
           echo "New miner-api version: $new_version"
-          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
 
   update-miner-api-cargo-toml:
     name: 📝 Update Miner API Version Files
@@ -171,8 +216,8 @@ jobs:
             exit 1
           fi
           
-          # Update Cargo.lock
-          cargo update --package quantus-miner-api --precise "$new_cargo_version" || echo "cargo update tried, proceeding."
+          # Update Cargo.lock (must succeed — a stale lock fails --locked after merge)
+          cargo update --package quantus-miner-api --precise "$new_cargo_version"
 
           # Keep the crates.io install snippet in the README in sync (ships in the .crate tarball).
           echo "Updating miner-api/README.md install version to: $new_cargo_version"
@@ -185,8 +230,12 @@ jobs:
           # Commit changes
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          
+
           git add miner-api/Cargo.toml miner-api/README.md Cargo.toml Cargo.lock
+          if git diff --cached --quiet; then
+            echo "Error: version bump staged nothing (already at $new_cargo_version?). Refusing empty commit."
+            exit 1
+          fi
           git commit -m "ci: Miner API version bump to $NEW_VERSION"
           git push origin "$branch_name"
 

--- a/.github/workflows/miner-api-release-proposal.yml
+++ b/.github/workflows/miner-api-release-proposal.yml
@@ -174,11 +174,19 @@ jobs:
           # Update Cargo.lock
           cargo update --package quantus-miner-api --precise "$new_cargo_version" || echo "cargo update tried, proceeding."
 
+          # Keep the crates.io install snippet in the README in sync (ships in the .crate tarball).
+          echo "Updating miner-api/README.md install version to: $new_cargo_version"
+          sed -i -E "s/^quantus-miner-api = \"[0-9]+\.[0-9]+\.[0-9]+\"/quantus-miner-api = \"$new_cargo_version\"/" miner-api/README.md
+          if ! grep -q "^quantus-miner-api = \"$new_cargo_version\"" miner-api/README.md; then
+            echo "Error: Failed to update install version in miner-api/README.md"
+            exit 1
+          fi
+
           # Commit changes
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           
-          git add miner-api/Cargo.toml Cargo.toml Cargo.lock
+          git add miner-api/Cargo.toml miner-api/README.md Cargo.toml Cargo.lock
           git commit -m "ci: Miner API version bump to $NEW_VERSION"
           git push origin "$branch_name"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-miner-api"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ qp-high-security = { path = "./primitives/high-security", default-features = fal
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }
 qpow-math = { path = "./qpow-math", default-features = false }
-quantus-miner-api = { path = "./miner-api", version = "0.2.1", default-features = false }
+quantus-miner-api = { path = "./miner-api", version = "0.3.0", default-features = false }
 quantus-runtime = { path = "./runtime", default-features = false }
 sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
 sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = false }

--- a/MINING.md
+++ b/MINING.md
@@ -632,7 +632,7 @@ closed before the peer is registered as a miner.
 |-------|------|-------------|
 | `job_id` | String | Unique identifier (UUID recommended) |
 | `mining_hash` | String | Header hash (64 hex chars, no 0x prefix) |
-| `distance_threshold` | String | Difficulty (U512 as decimal string) |
+| `difficulty` | String | Difficulty (U512 as decimal string) |
 
 Note: Nonce range is not specified - each miner independently selects a random starting point.
 

--- a/miner-api/Cargo.toml
+++ b/miner-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 license.workspace = true
 name = "quantus-miner-api"
 repository.workspace = true
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 serde = { workspace = true, features = ["alloc", "derive"] }

--- a/miner-api/README.md
+++ b/miner-api/README.md
@@ -15,24 +15,20 @@ By using this crate, both the node and external miner implementations can ensure
 
 Add this crate as a dependency in the `Cargo.toml` of both the node and the external miner implementation.
 
-**Node:**
+**External Miner** (published crate — preferred):
 ```toml
 [dependencies]
-quantus-miner-api = { path = "../miner-api", default-features = false } 
-# ... other dependencies
+quantus-miner-api = "0.3.0"
 ```
 
-**External Miner:**
+**Node / this monorepo** (path dependency):
 ```toml
 [dependencies]
-quantus-miner-api = { path = "../miner-api" }
-# Or if published:
-# quantus-miner-api = "0.1.0"
-# ... other dependencies
+quantus-miner-api = { path = "../miner-api", default-features = false }
 ```
 
 Then, import the types:
 
 ```rust
 use quantus_miner_api::*;
-``` 
+```


### PR DESCRIPTION
## Miner API Release Proposal

This PR proposes releasing **quantus-miner-api** version `0.3.0`.

### Changes
- Updated `miner-api/Cargo.toml` version to `0.3.0`
- Updated `Cargo.toml` workspace dependency version to `0.3.0`
- Updated `Cargo.lock`
