### PR TITLE
fix: grandfather RuntimeEnvironmentUpdated in the QPoW digest window

### DIFF
--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -775,9 +775,7 @@ mod tests {
 
 	#[test]
 	fn verifier_rejects_undersized_digest() {
-		let digest = Digest {
-			logs: vec![DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64])],
-		};
+		let digest = Digest { logs: vec![DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64])] };
 		assert!(digest.encode().len() < DIGEST_LOGS_SIZE);
 
 		let params = BlockImportParams::<TestBlock>::new(

--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -14,7 +14,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use codec::Encode;
-use qp_header::DIGEST_LOGS_SIZE;
+use qp_header::{check_digest_commitment_window, DIGEST_LOGS_SIZE};
 
 use crate::worker::UntilImportedOrTransaction;
 pub use crate::worker::{MiningBuild, MiningHandle, MiningMetadata, RebuildTrigger};
@@ -70,8 +70,8 @@ pub enum Error<B: BlockT> {
 	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
 	#[error("Multiple pre-runtime digests")]
 	MultiplePreRuntimeDigests,
-	#[error("Header has an encoded digest of {0} bytes, exceeding the {1}-byte commitment window")]
-	DigestTooLong(usize, usize),
+	#[error("Header has an encoded digest of {0} bytes; expected {1}-byte commitment window")]
+	DigestWindowMismatch(usize, usize),
 	#[error(transparent)]
 	Client(sp_blockchain::Error),
 	#[error(transparent)]
@@ -229,19 +229,21 @@ where
 		&self,
 		mut block_import_params: BlockImportParams<B>,
 	) -> Result<ImportResult, Self::Error> {
-		// Reject any header whose canonical (post-seal) digest encodes to more
-		// than the fixed window committed by `Header::hash()`. Past that window
-		// the digest bytes are not covered by the block hash, so silently
-		// truncating (as `hash()` does defensively) would let two distinct
-		// sealed headers collide on the same block hash. Fail closed before
-		// *any* `hash()` call on this header — hashing an oversized digest
-		// trips a debug assertion in `qp-header` — and, for the same reason,
-		// without embedding a hash of the malformed header in the error. The
-		// pre-seal digest is a prefix of the post-seal one, so this bound also
-		// covers the pre-seal `header.hash()` calls below.
-		let encoded_digest_len = block_import_params.post_header().digest().encode().len();
-		if encoded_digest_len > DIGEST_LOGS_SIZE {
-			return Err(Error::<B>::DigestTooLong(encoded_digest_len, DIGEST_LOGS_SIZE).into());
+		// The canonical post-seal digest must encode to exactly the window
+		// committed by `Header::hash()`, except for the one-byte
+		// `RuntimeEnvironmentUpdated` leftover on historical runtime-upgrade
+		// blocks (see `check_digest_commitment_window`). Short encodings are
+		// zero-padded and long encodings are truncated, so either mismatch
+		// would let two distinct sealed headers collide. Fail closed before
+		// *any* `hash()` call on this header, and without embedding a hash of
+		// the malformed header in the error. The pre-seal digest is a prefix
+		// of the post-seal one, so this bound also covers the pre-seal
+		// `header.hash()` calls below.
+		let post_header = block_import_params.post_header();
+		if let Err(encoded_digest_len) = check_digest_commitment_window(post_header.digest()) {
+			return Err(
+				Error::<B>::DigestWindowMismatch(encoded_digest_len, DIGEST_LOGS_SIZE).into()
+			);
 		}
 
 		let parent_hash = *block_import_params.header.parent_hash();
@@ -407,15 +409,14 @@ where
 	B: BlockT<Hash = H256>,
 {
 	// This is the first point in the import pipeline that hashes a
-	// network-supplied header, and hashing a digest longer than the committed
-	// window trips a debug assertion in `qp-header` (the hash would silently
-	// truncate it). Reject the oversized digest before any `hash()` call; the
-	// authoritative check lives in `import_block`, this one only keeps the
-	// hashing below panic-free in debug builds.
-	let encoded_digest_len = block.header.digest().encode().len();
-	if encoded_digest_len > DIGEST_LOGS_SIZE {
+	// network-supplied header. `Header::hash()` pads short encodings and
+	// truncates long ones, so reject anything that is not a permitted
+	// commitment-window length before any `hash()` call. The authoritative
+	// check lives in `import_block`; this one only keeps the hashing below
+	// panic-free in debug builds.
+	if let Err(encoded_digest_len) = check_digest_commitment_window(block.header.digest()) {
 		return Err(format!(
-			"Header has an encoded digest of {encoded_digest_len} bytes, exceeding the {DIGEST_LOGS_SIZE}-byte commitment window"
+			"Header has an encoded digest of {encoded_digest_len} bytes; expected {DIGEST_LOGS_SIZE}-byte commitment window"
 		));
 	}
 
@@ -766,7 +767,29 @@ mod tests {
 		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
 
 		let err = result.err().expect("oversized digest must be rejected");
-		assert!(err.contains("exceeding the"), "expected the digest-length rejection, got: {err}");
+		assert!(
+			err.contains("commitment window"),
+			"expected the digest-length rejection, got: {err}"
+		);
+	}
+
+	#[test]
+	fn verifier_rejects_undersized_digest() {
+		let digest = Digest {
+			logs: vec![DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64])],
+		};
+		assert!(digest.encode().len() < DIGEST_LOGS_SIZE);
+
+		let params = BlockImportParams::<TestBlock>::new(
+			BlockOrigin::NetworkBroadcast,
+			sealed_header(digest),
+		);
+		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
+		let err = result.err().expect("undersized digest must be rejected");
+		assert!(
+			err.contains("commitment window"),
+			"expected the digest-length rejection, got: {err}"
+		);
 	}
 
 	/// The canonical digest fits the window exactly and must pass the length
@@ -791,6 +814,38 @@ mod tests {
 		assert!(
 			!result.header.digest().logs.iter().any(|l| matches!(l, DigestItem::Seal(..))),
 			"seal must be removed from the pre-seal header"
+		);
+	}
+
+	/// Runtime-upgrade blocks produced by 0.8.x WASM insert
+	/// `RuntimeEnvironmentUpdated` between the pre-runtime item and the seal
+	/// (111 bytes). 0.9.0 must still import those already-canonical headers.
+	#[test]
+	fn verifier_accepts_runtime_environment_updated_upgrade_digest() {
+		let mut digest = canonical_digest();
+		digest.logs.insert(1, DigestItem::RuntimeEnvironmentUpdated);
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE + 1);
+
+		let params = BlockImportParams::<TestBlock>::new(
+			BlockOrigin::NetworkBroadcast,
+			sealed_header(digest),
+		);
+		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params))
+			.expect("historical upgrade digest must be grandfathered");
+
+		assert_eq!(
+			result.post_digests.last(),
+			Some(&DigestItem::Seal(POW_ENGINE_ID, vec![2u8; 64])),
+			"seal must be moved into post_digests"
+		);
+		assert!(
+			result
+				.header
+				.digest()
+				.logs
+				.iter()
+				.any(|l| matches!(l, DigestItem::RuntimeEnvironmentUpdated)),
+			"RuntimeEnvironmentUpdated must remain on the pre-seal header"
 		);
 	}
 }

--- a/primitives/header/src/lib.rs
+++ b/primitives/header/src/lib.rs
@@ -20,7 +20,7 @@ use qp_poseidon_core::{
 use scale_info::TypeInfo;
 use sp_core::{H256, U256};
 use sp_runtime::{
-	generic::Digest,
+	generic::{Digest, DigestItem},
 	traits::{AtLeast32BitUnsigned, BlockNumber, Hash as HashT, MaybeDisplay, Member},
 	RuntimeDebug,
 };
@@ -39,18 +39,46 @@ use serde::{Deserialize, Serialize};
 /// preimage plus one 64-byte PoW seal (the canonical post-seal digest), so a
 /// well-formed header uses the whole window with no slack.
 ///
-/// Headers whose encoded digest exceeds this bound must be **rejected** before
-/// import rather than silently truncated; see the digest length check in
-/// `sc-consensus-qpow`. Truncation would let two distinct headers share a block
-/// hash on the bytes past this window.
+/// A well-formed sealed digest must encode to **exactly** this size. Import
+/// rejects any other length rather than padding or truncating; see
+/// [`check_digest_commitment_window`]. `Header::hash()` pads short encodings
+/// with zeros and drops bytes past this window, so either mismatch would let
+/// two distinct headers share a block hash.
 ///
 /// Because the window has no slack, the runtime must never deposit digest items
 /// of its own: even a 1-byte item (e.g. upstream frame-system's
 /// `RuntimeEnvironmentUpdated` on `set_code`) pushes the sealed digest to 111
-/// bytes and makes the block unimportable network-wide. The vendored
-/// frame-system's deposits were removed for exactly this reason — see the
-/// warning on `frame_system::Pallet::deposit_log`.
+/// bytes. The vendored frame-system's deposits were removed for exactly this
+/// reason — see the warning on `frame_system::Pallet::deposit_log`. One
+/// historical exception is grandfathered at import: see
+/// [`check_digest_commitment_window`].
 pub const DIGEST_LOGS_SIZE: usize = 110;
+
+/// Returns `Ok(())` if `digest` may be imported, or `Err(encoded_len)` if its
+/// SCALE length is not a permitted commitment-window size.
+///
+/// The only accepted lengths are [`DIGEST_LOGS_SIZE`] (canonical
+/// `[PreRuntime, Seal]`) and `DIGEST_LOGS_SIZE + 1` with exactly one
+/// `RuntimeEnvironmentUpdated` item. The latter is the leftover from 0.8.x
+/// `set_code` deposits: those upgrade blocks are already canonical, and 0.8.x
+/// imported them by truncating the Poseidon preimage. Anything shorter is
+/// padded with zeros by [`Header::hash`] and anything else longer is truncated,
+/// so both must be rejected.
+pub fn check_digest_commitment_window(digest: &Digest) -> Result<(), usize> {
+	let encoded_len = digest.encode().len();
+	if encoded_len == DIGEST_LOGS_SIZE {
+		return Ok(());
+	}
+	let reu_count = digest
+		.logs
+		.iter()
+		.filter(|item| matches!(item, DigestItem::RuntimeEnvironmentUpdated))
+		.count();
+	if reu_count == 1 && encoded_len == DIGEST_LOGS_SIZE + 1 {
+		return Ok(());
+	}
+	Err(encoded_len)
+}
 
 /// Extension trait for headers that support ZK tree root.
 ///
@@ -260,10 +288,12 @@ where
 		));
 
 		// digest – SCALE encode then pad to the fixed DIGEST_LOGS_SIZE window to
-		// match circuit expectation. Bytes past the window are NOT committed by
-		// this hash: an encoded digest longer than the window would let two
-		// distinct headers collide, which is why the import path rejects such
-		// headers outright (see the digest length checks in `sc-consensus-qpow`).
+		// match circuit expectation. Bytes past the window are NOT committed, and
+		// short encodings are zero-padded, so either mismatch would let two
+		// distinct headers collide. Import therefore demands an exact window
+		// length (other than the grandfathered `RuntimeEnvironmentUpdated`
+		// leftover on historical upgrade blocks) via
+		// [`check_digest_commitment_window`].
 		// No assertion here, not even a debug one: generic network code hashes
 		// completely unverified headers long before any consensus check runs
 		// (e.g. block-announce validation in `sc-network-sync` hashes the
@@ -525,5 +555,45 @@ mod tests {
 		// Sanity: a within-window digest change does alter the hash.
 		let hash_canonical = header_with_digest(canonical_pow_digest()).hash();
 		assert_ne!(hash_a, hash_canonical);
+	}
+
+	/// Historical runtime-upgrade blocks deposited `RuntimeEnvironmentUpdated`
+	/// between the pre-runtime item and the seal, encoding to 111 bytes. Those
+	/// headers are already canonical and must pass the import window check.
+	#[test]
+	fn runtime_environment_updated_upgrade_digest_is_grandfathered() {
+		let mut digest = canonical_pow_digest();
+		digest.logs.insert(1, DigestItem::RuntimeEnvironmentUpdated);
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE + 1);
+		assert_eq!(check_digest_commitment_window(&digest), Ok(()));
+	}
+
+	#[test]
+	fn arbitrary_overflow_is_still_rejected() {
+		let mut digest = canonical_pow_digest();
+		digest.logs.insert(1, DigestItem::Other(vec![0u8; 64]));
+		assert!(digest.encode().len() > DIGEST_LOGS_SIZE);
+		assert_eq!(check_digest_commitment_window(&digest), Err(digest.encode().len()));
+	}
+
+	#[test]
+	fn two_runtime_environment_updated_items_are_rejected() {
+		let mut digest = canonical_pow_digest();
+		digest.logs.insert(1, DigestItem::RuntimeEnvironmentUpdated);
+		digest.logs.insert(1, DigestItem::RuntimeEnvironmentUpdated);
+		assert!(digest.encode().len() > DIGEST_LOGS_SIZE + 1);
+		assert_eq!(check_digest_commitment_window(&digest), Err(digest.encode().len()));
+	}
+
+	#[test]
+	fn canonical_digest_passes_window_check() {
+		assert_eq!(check_digest_commitment_window(&canonical_pow_digest()), Ok(()));
+	}
+
+	#[test]
+	fn undersized_digest_is_rejected() {
+		let digest = Digest::default();
+		assert!(digest.encode().len() < DIGEST_LOGS_SIZE);
+		assert_eq!(check_digest_commitment_window(&digest), Err(digest.encode().len()));
 	}
 }


### PR DESCRIPTION
0.9.0 rejected 111-byte upgrade headers that 0.8.x already finalized, so upgraded nodes could not import the chain or replay from genesis.