### PR TITLE
fix: treat the QPoW digest as a fixed preimage+seal

### DIFF
--- a/client/consensus/qpow/src/lib.rs
+++ b/client/consensus/qpow/src/lib.rs
@@ -13,8 +13,7 @@ use sp_consensus_qpow::{QPoWApi, Seal as RawSeal};
 use sp_runtime::traits::Block as BlockT;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
-use codec::Encode;
-use qp_header::{check_digest_commitment_window, DIGEST_LOGS_SIZE};
+use qp_header::{check_digest_commitment_window, QpowDigest, DIGEST_LOGS_SIZE};
 
 use crate::worker::UntilImportedOrTransaction;
 pub use crate::worker::{MiningBuild, MiningHandle, MiningMetadata, RebuildTrigger};
@@ -70,7 +69,9 @@ pub enum Error<B: BlockT> {
 	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
 	#[error("Multiple pre-runtime digests")]
 	MultiplePreRuntimeDigests,
-	#[error("Header has an encoded digest of {0} bytes; expected {1}-byte commitment window")]
+	#[error(
+		"Header digest is not the fixed QPoW log (32-byte preimage + 64-byte seal); encoded length {0}, expected {1}"
+	)]
 	DigestWindowMismatch(usize, usize),
 	#[error(transparent)]
 	Client(sp_blockchain::Error),
@@ -229,16 +230,8 @@ where
 		&self,
 		mut block_import_params: BlockImportParams<B>,
 	) -> Result<ImportResult, Self::Error> {
-		// The canonical post-seal digest must encode to exactly the window
-		// committed by `Header::hash()`, except for the one-byte
-		// `RuntimeEnvironmentUpdated` leftover on historical runtime-upgrade
-		// blocks (see `check_digest_commitment_window`). Short encodings are
-		// zero-padded and long encodings are truncated, so either mismatch
-		// would let two distinct sealed headers collide. Fail closed before
-		// *any* `hash()` call on this header, and without embedding a hash of
-		// the malformed header in the error. The pre-seal digest is a prefix
-		// of the post-seal one, so this bound also covers the pre-seal
-		// `header.hash()` calls below.
+		// Sealed digest must be QpowDigest (or the grandfathered 0.8.x REU
+		// leftover). Fail closed before any `hash()` call.
 		let post_header = block_import_params.post_header();
 		if let Err(encoded_digest_len) = check_digest_commitment_window(post_header.digest()) {
 			return Err(
@@ -408,15 +401,9 @@ async fn extract_pow_seal<B>(
 where
 	B: BlockT<Hash = H256>,
 {
-	// This is the first point in the import pipeline that hashes a
-	// network-supplied header. `Header::hash()` pads short encodings and
-	// truncates long ones, so reject anything that is not a permitted
-	// commitment-window length before any `hash()` call. The authoritative
-	// check lives in `import_block`; this one only keeps the hashing below
-	// panic-free in debug builds.
 	if let Err(encoded_digest_len) = check_digest_commitment_window(block.header.digest()) {
 		return Err(format!(
-			"Header has an encoded digest of {encoded_digest_len} bytes; expected {DIGEST_LOGS_SIZE}-byte commitment window"
+			"Header digest is not the fixed QPoW log (32-byte preimage + 64-byte seal); encoded length {encoded_digest_len}, expected {DIGEST_LOGS_SIZE}"
 		));
 	}
 
@@ -678,6 +665,14 @@ where
 		},
 	};
 
+	if QpowDigest::check_pre_seal(proposal.block.header().digest()).is_err() {
+		warn!(
+			target: LOG_TARGET,
+			"Discarding proposal whose digest is not a single 32-byte QPoW preimage"
+		);
+		return None;
+	}
+
 	// Check if best_hash changed during building
 	if client.info().best_hash != best_hash {
 		info!(target: LOG_TARGET, "Best hash changed during block building, discarding proposal");
@@ -720,6 +715,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::Encode;
 	use sp_consensus::BlockOrigin;
 	use sp_runtime::{traits::BlakeTwo256, OpaqueExtrinsic};
 
@@ -767,10 +763,7 @@ mod tests {
 		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
 
 		let err = result.err().expect("oversized digest must be rejected");
-		assert!(
-			err.contains("commitment window"),
-			"expected the digest-length rejection, got: {err}"
-		);
+		assert!(err.contains("fixed QPoW log"), "expected the digest-shape rejection, got: {err}");
 	}
 
 	#[test]
@@ -784,10 +777,7 @@ mod tests {
 		);
 		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
 		let err = result.err().expect("undersized digest must be rejected");
-		assert!(
-			err.contains("commitment window"),
-			"expected the digest-length rejection, got: {err}"
-		);
+		assert!(err.contains("fixed QPoW log"), "expected the digest-shape rejection, got: {err}");
 	}
 
 	/// The canonical digest fits the window exactly and must pass the length
@@ -813,6 +803,20 @@ mod tests {
 			!result.header.digest().logs.iter().any(|l| matches!(l, DigestItem::Seal(..))),
 			"seal must be removed from the pre-seal header"
 		);
+	}
+
+	#[test]
+	fn verifier_rejects_window_sized_wrong_shape() {
+		let digest = Digest { logs: vec![DigestItem::Other(vec![0u8; 106])] };
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE);
+
+		let params = BlockImportParams::<TestBlock>::new(
+			BlockOrigin::NetworkBroadcast,
+			sealed_header(digest),
+		);
+		let result = futures::executor::block_on(extract_pow_seal::<TestBlock>(params));
+		let err = result.err().expect("wrong-shape digest must be rejected");
+		assert!(err.contains("fixed QPoW log"), "expected the digest-shape rejection, got: {err}");
 	}
 
 	/// Runtime-upgrade blocks produced by 0.8.x WASM insert

--- a/pallets/frame-system/src/lib.rs
+++ b/pallets/frame-system/src/lib.rs
@@ -2117,17 +2117,12 @@ impl<T: Config> Pallet<T> {
 	///
 	/// # WARNING: the QPoW digest window has no spare capacity
 	///
-	/// `qp_header::Header::hash()` commits the digest through a fixed
-	/// `DIGEST_LOGS_SIZE` window that the client-injected pre-runtime item plus the
-	/// PoW seal fill **exactly**, and block import rejects any sealed header whose
-	/// encoded digest exceeds it (truncating would let distinct headers share a
-	/// hash). A digest item deposited from runtime code therefore does not fail the
-	/// call — it makes the finished block **unimportable by the entire network**,
-	/// silently, after mining. This is why the fork's `set_code` /
-	/// `set_heap_pages` paths do not deposit `RuntimeEnvironmentUpdated` the way
-	/// upstream does. Do not deposit digest items from runtime logic unless the
-	/// header format and the wormhole circuit's digest field are resized in the
-	/// same release.
+	/// Import accepts only [`qp_header::QpowDigest`]: one 32-byte pre-runtime
+	/// preimage and one 64-byte seal. A runtime-deposited item does not fail
+	/// this call — it makes the finished block unimportable after mining.
+	/// `set_code` / `set_heap_pages` therefore do not deposit
+	/// `RuntimeEnvironmentUpdated`. Do not deposit digest items from runtime
+	/// logic.
 	pub fn deposit_log(item: generic::DigestItem) {
 		<Digest<T>>::append(item);
 	}

--- a/primitives/header/src/digest.rs
+++ b/primitives/header/src/digest.rs
@@ -1,0 +1,101 @@
+use codec::Encode;
+use sp_runtime::generic::{Digest, DigestItem};
+
+use crate::DIGEST_LOGS_SIZE;
+
+pub const POW_PREIMAGE_LEN: usize = 32;
+pub const POW_SEAL_LEN: usize = 64;
+
+/// The only sealed digest QPoW accepts: one 32-byte rewards preimage and one
+/// 64-byte seal. Encodes on the wire as a Substrate [`Digest`] so existing
+/// headers keep decoding.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct QpowDigest {
+	pub engine_id: [u8; 4],
+	pub preimage: [u8; POW_PREIMAGE_LEN],
+	pub seal: [u8; POW_SEAL_LEN],
+	/// 0.8.x `set_code` leftover. Current WASM never sets this.
+	pub historical_runtime_environment_updated: bool,
+}
+
+impl QpowDigest {
+	pub fn new(
+		engine_id: [u8; 4],
+		preimage: [u8; POW_PREIMAGE_LEN],
+		seal: [u8; POW_SEAL_LEN],
+	) -> Self {
+		Self { engine_id, preimage, seal, historical_runtime_environment_updated: false }
+	}
+
+	pub fn to_digest(&self) -> Digest {
+		let mut logs = alloc::vec![DigestItem::PreRuntime(self.engine_id, self.preimage.to_vec())];
+		if self.historical_runtime_environment_updated {
+			logs.push(DigestItem::RuntimeEnvironmentUpdated);
+		}
+		logs.push(DigestItem::Seal(self.engine_id, self.seal.to_vec()));
+		Digest { logs }
+	}
+
+	/// Sealed header only. Returns `Err(encoded_len)` if the digest is not
+	/// exactly `[PreRuntime(32), Seal(64)]`, or that pair plus one grandfathered
+	/// `RuntimeEnvironmentUpdated`.
+	pub fn try_from_sealed(digest: &Digest) -> Result<Self, usize> {
+		let encoded_len = digest.encode().len();
+		let parsed = match digest.logs.as_slice() {
+			[DigestItem::PreRuntime(id, pre), DigestItem::Seal(sid, seal)] =>
+				parse_pair(*id, pre, *sid, seal, false),
+			[DigestItem::PreRuntime(id, pre), DigestItem::RuntimeEnvironmentUpdated, DigestItem::Seal(sid, seal)] =>
+				parse_pair(*id, pre, *sid, seal, true),
+			_ => None,
+		};
+		let parsed = parsed.ok_or(encoded_len)?;
+		let expected = if parsed.historical_runtime_environment_updated {
+			DIGEST_LOGS_SIZE + 1
+		} else {
+			DIGEST_LOGS_SIZE
+		};
+		if encoded_len != expected {
+			return Err(encoded_len);
+		}
+		Ok(parsed)
+	}
+
+	/// In-progress header after inherents, before the seal is appended.
+	pub fn check_pre_seal(digest: &Digest) -> Result<([u8; 4], [u8; POW_PREIMAGE_LEN]), usize> {
+		match digest.logs.as_slice() {
+			[DigestItem::PreRuntime(id, pre)] if pre.len() == POW_PREIMAGE_LEN => {
+				let mut preimage = [0u8; POW_PREIMAGE_LEN];
+				preimage.copy_from_slice(pre);
+				Ok((*id, preimage))
+			},
+			_ => Err(digest.encode().len()),
+		}
+	}
+}
+
+fn parse_pair(
+	id: [u8; 4],
+	pre: &[u8],
+	sid: [u8; 4],
+	seal: &[u8],
+	historical_reu: bool,
+) -> Option<QpowDigest> {
+	if id != sid || pre.len() != POW_PREIMAGE_LEN || seal.len() != POW_SEAL_LEN {
+		return None;
+	}
+	let mut preimage = [0u8; POW_PREIMAGE_LEN];
+	preimage.copy_from_slice(pre);
+	let mut seal_arr = [0u8; POW_SEAL_LEN];
+	seal_arr.copy_from_slice(seal);
+	Some(QpowDigest {
+		engine_id: id,
+		preimage,
+		seal: seal_arr,
+		historical_runtime_environment_updated: historical_reu,
+	})
+}
+
+/// Import gate. Thin wrapper over [`QpowDigest::try_from_sealed`].
+pub fn check_digest_commitment_window(digest: &Digest) -> Result<(), usize> {
+	QpowDigest::try_from_sealed(digest).map(|_| ())
+}

--- a/primitives/header/src/lib.rs
+++ b/primitives/header/src/lib.rs
@@ -20,7 +20,7 @@ use qp_poseidon_core::{
 use scale_info::TypeInfo;
 use sp_core::{H256, U256};
 use sp_runtime::{
-	generic::{Digest, DigestItem},
+	generic::Digest,
 	traits::{AtLeast32BitUnsigned, BlockNumber, Hash as HashT, MaybeDisplay, Member},
 	RuntimeDebug,
 };
@@ -31,6 +31,9 @@ use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+mod digest;
+pub use digest::{check_digest_commitment_window, QpowDigest, POW_PREIMAGE_LEN, POW_SEAL_LEN};
+
 /// Size of the fixed digest window (in bytes) committed by [`Header::hash`].
 ///
 /// The SCALE-encoded digest is folded into the Poseidon preimage through a
@@ -39,46 +42,17 @@ use serde::{Deserialize, Serialize};
 /// preimage plus one 64-byte PoW seal (the canonical post-seal digest), so a
 /// well-formed header uses the whole window with no slack.
 ///
-/// A well-formed sealed digest must encode to **exactly** this size. Import
-/// rejects any other length rather than padding or truncating; see
-/// [`check_digest_commitment_window`]. `Header::hash()` pads short encodings
-/// with zeros and drops bytes past this window, so either mismatch would let
-/// two distinct headers share a block hash.
+/// A well-formed sealed digest is [`QpowDigest`]: one 32-byte pre-runtime
+/// preimage and one 64-byte seal, which SCALE-encode to **exactly** this size.
+/// Import rejects any other shape; see [`check_digest_commitment_window`].
+/// `Header::hash()` pads short encodings with zeros and drops bytes past this
+/// window, so a mismatch would let two distinct headers share a block hash.
 ///
-/// Because the window has no slack, the runtime must never deposit digest items
-/// of its own: even a 1-byte item (e.g. upstream frame-system's
-/// `RuntimeEnvironmentUpdated` on `set_code`) pushes the sealed digest to 111
-/// bytes. The vendored frame-system's deposits were removed for exactly this
-/// reason — see the warning on `frame_system::Pallet::deposit_log`. One
-/// historical exception is grandfathered at import: see
-/// [`check_digest_commitment_window`].
+/// The on-wire [`Header::digest`] field stays a Substrate [`Digest`] list so
+/// existing blocks decode. The only accepted *value* is [`QpowDigest`].
+/// Runtime code must not deposit extra items — see `deposit_log`. One
+/// historical 0.8.x `RuntimeEnvironmentUpdated` leftover is grandfathered.
 pub const DIGEST_LOGS_SIZE: usize = 110;
-
-/// Returns `Ok(())` if `digest` may be imported, or `Err(encoded_len)` if its
-/// SCALE length is not a permitted commitment-window size.
-///
-/// The only accepted lengths are [`DIGEST_LOGS_SIZE`] (canonical
-/// `[PreRuntime, Seal]`) and `DIGEST_LOGS_SIZE + 1` with exactly one
-/// `RuntimeEnvironmentUpdated` item. The latter is the leftover from 0.8.x
-/// `set_code` deposits: those upgrade blocks are already canonical, and 0.8.x
-/// imported them by truncating the Poseidon preimage. Anything shorter is
-/// padded with zeros by [`Header::hash`] and anything else longer is truncated,
-/// so both must be rejected.
-pub fn check_digest_commitment_window(digest: &Digest) -> Result<(), usize> {
-	let encoded_len = digest.encode().len();
-	if encoded_len == DIGEST_LOGS_SIZE {
-		return Ok(());
-	}
-	let reu_count = digest
-		.logs
-		.iter()
-		.filter(|item| matches!(item, DigestItem::RuntimeEnvironmentUpdated))
-		.count();
-	if reu_count == 1 && encoded_len == DIGEST_LOGS_SIZE + 1 {
-		return Ok(());
-	}
-	Err(encoded_len)
-}
 
 /// Extension trait for headers that support ZK tree root.
 ///
@@ -290,10 +264,8 @@ where
 		// digest – SCALE encode then pad to the fixed DIGEST_LOGS_SIZE window to
 		// match circuit expectation. Bytes past the window are NOT committed, and
 		// short encodings are zero-padded, so either mismatch would let two
-		// distinct headers collide. Import therefore demands an exact window
-		// length (other than the grandfathered `RuntimeEnvironmentUpdated`
-		// leftover on historical upgrade blocks) via
-		// [`check_digest_commitment_window`].
+		// distinct headers collide. Import therefore requires [`QpowDigest`]
+		// (grandfathering the 0.8.x `RuntimeEnvironmentUpdated` leftover).
 		// No assertion here, not even a debug one: generic network code hashes
 		// completely unverified headers long before any consensus check runs
 		// (e.g. block-announce validation in `sc-network-sync` hashes the
@@ -595,5 +567,30 @@ mod tests {
 		let digest = Digest::default();
 		assert!(digest.encode().len() < DIGEST_LOGS_SIZE);
 		assert_eq!(check_digest_commitment_window(&digest), Err(digest.encode().len()));
+	}
+
+	#[test]
+	fn window_sized_but_wrong_shape_is_rejected() {
+		let digest = Digest { logs: vec![DigestItem::Other(vec![0u8; 106])] };
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE);
+		assert!(check_digest_commitment_window(&digest).is_err());
+	}
+
+	#[test]
+	fn qpow_digest_round_trips_through_substrate_digest() {
+		let fixed = QpowDigest::new([b'p', b'o', b'w', b'_'], [7u8; 32], [9u8; 64]);
+		let digest = fixed.to_digest();
+		assert_eq!(digest.encode().len(), DIGEST_LOGS_SIZE);
+		assert_eq!(QpowDigest::try_from_sealed(&digest).expect("canonical"), fixed);
+	}
+
+	#[test]
+	fn pre_seal_digest_is_only_the_preimage() {
+		let digest =
+			Digest { logs: vec![DigestItem::PreRuntime([b'p', b'o', b'w', b'_'], vec![3u8; 32])] };
+		let (id, pre) = QpowDigest::check_pre_seal(&digest).expect("pre-seal");
+		assert_eq!(id, [b'p', b'o', b'w', b'_']);
+		assert_eq!(pre, [3u8; 32]);
+		assert!(QpowDigest::check_pre_seal(&canonical_pow_digest()).is_err());
 	}
 }


### PR DESCRIPTION
## What

The sealed QPoW digest is now a **fixed value** (`QpowDigest`: 32-byte rewards preimage + 64-byte seal), not “whatever list encodes to 110 bytes.”

`Header.digest` remains a Substrate `Digest` on the wire. Changing that type would break decode of every existing block. `sp_runtime::traits::Header` also requires `&Digest` / `&mut Digest`.

## Compatibility

- Same SCALE header encoding. `poseidon_header_hash_is_stable` still passes.
- Canonical `[PreRuntime(32), Seal(64)]` still imports.
- Grandfathered 0.8.x `[PreRuntime, RuntimeEnvironmentUpdated, Seal]` (111 bytes) still imports (#665).
- New: a 110-byte digest that is **not** that shape is rejected (previously accepted).
- After `propose`, a header that is not a single 32-byte preimage is discarded so we do not mine a brick.

## Why

A byte budget plus “please don’t call `deposit_log`” is brittle. Checking **shape** at import and at authoring is the hardening that does not fork the live chain.

A later protocol change can replace the list on the header entirely (or commit `Poseidon(digest)`). That is a circuit + consensus fork and is not this PR.

## Test plan

- [x] `cargo test -p qp-header -p sc-consensus-qpow`
- [ ] Fresh-node sync of Heisenberg (preflight) before any release that includes this