### PR TITLE
Automate release for v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7625,7 +7625,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.9.0-endless-sky"
+version = "0.10.0"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.9.0-endless-sky"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Automated version bump for release v0.10.0.

https://github.com/Quantus-Network/chain/actions/runs/31688969593

Triggered by workflow run: minor

Type: 