### PR TITLE
fix: don't feed external miners stale jobs during initial sync

### DIFF
--- a/node/src/miner_server.rs
+++ b/node/src/miner_server.rs
@@ -174,6 +174,16 @@ impl MinerServer {
 		}
 	}
 
+	/// Clear the stored job so miners connecting while mining is paused (major
+	/// sync, no peers) don't receive stale work on connect. Already-connected
+	/// miners keep grinding their last job — the protocol has no cancel
+	/// message — until the next broadcast supersedes it.
+	pub async fn clear_current_job(&self) {
+		if self.current_job.write().await.take().is_some() {
+			log::debug!("Cleared pending miner job while mining is paused");
+		}
+	}
+
 	/// Wait for a mining result with a timeout.
 	pub async fn recv_result_timeout(&self, timeout: Duration) -> Option<MiningResult> {
 		let mut rx = self.result_rx.lock().await;
@@ -929,6 +939,48 @@ mod tests {
 			rx.recv().await.unwrap();
 		}
 		assert_eq!(drops, 0, "counter must be reset by the last successful forward");
+	}
+
+	fn test_server() -> MinerServer {
+		let (result_tx, result_rx) = mpsc::channel::<MiningResult>(64);
+		MinerServer {
+			miners: Arc::new(RwLock::new(HashMap::new())),
+			result_rx: tokio::sync::Mutex::new(result_rx),
+			result_tx,
+			current_job: Arc::new(RwLock::new(None)),
+			next_miner_id: AtomicU64::new(1),
+			auth_token: "token".to_string(),
+			unauth_slots: Arc::new(Semaphore::new(MAX_UNAUTHENTICATED_CONNECTIONS)),
+		}
+	}
+
+	fn dummy_job(job_id: &str) -> MiningRequest {
+		MiningRequest {
+			job_id: job_id.to_string(),
+			mining_hash: "00".repeat(32),
+			difficulty: "1".to_string(),
+		}
+	}
+
+	/// A job broadcast before a sync/offline pause must not be handed to miners
+	/// that connect during the pause: with no cancel message in the protocol
+	/// they would grind the stale job for the entire sync.
+	#[tokio::test]
+	async fn clearing_the_current_job_stops_serving_it_to_new_miners() {
+		let server = test_server();
+		server.broadcast_job(dummy_job("1")).await;
+		assert!(server.get_current_job().await.is_some());
+
+		server.clear_current_job().await;
+		assert!(
+			server.get_current_job().await.is_none(),
+			"miners connecting during a pause must not receive the pre-pause job"
+		);
+
+		// Idempotent, and the next broadcast serves fresh work again.
+		server.clear_current_job().await;
+		server.broadcast_job(dummy_job("2")).await;
+		assert_eq!(server.get_current_job().await.unwrap().job_id, "2");
 	}
 
 	fn temp_token_path(name: &str) -> PathBuf {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -346,19 +346,21 @@ async fn mining_loop(
 	let mut mining_start_time = std::time::Instant::now();
 	let mut job_counter: u64 = 0;
 
-	// Track when we first detected offline status for grace period
-	let mut offline_since: Option<std::time::Instant> = None;
-	const OFFLINE_GRACE_PERIOD: Duration = Duration::from_secs(30);
-
 	loop {
 		if cancellation_token.is_cancelled() {
 			log::info!("⛏️ QPoW Mining task shutting down gracefully");
 			break;
 		}
 
-		// Don't mine if we're still syncing
+		// Don't mine if we're still syncing. Also drop the stored job so miners
+		// connecting during the sync don't receive stale work on connect —
+		// the protocol has no cancel message, so they would grind it until the
+		// post-sync broadcast supersedes it.
 		if sync_service.is_major_syncing() {
 			log::debug!(target: "pow", "Mining paused: node is still syncing with network");
+			if let Some(ref server) = miner_server {
+				server.clear_current_job().await;
+			}
 			tokio::select! {
 				_ = tokio::time::sleep(Duration::from_secs(5)) => {}
 				_ = cancellation_token.cancelled() => continue
@@ -366,36 +368,18 @@ async fn mining_loop(
 			continue;
 		}
 
-		// Don't mine if we have no peers (unless --dev or --force-authoring)
-		// Use a grace period to handle brief network hiccups
+		// Don't mine if we have no peers (unless --dev or --force-authoring).
+		// This must pause immediately, without a grace period: at startup
+		// `is_major_syncing()` is still false before the first peers connect,
+		// so any grace window hands external miners a job built on a stale
+		// local best block, which they then grind for the entire sync.
 		if !allow_mining_without_peers && sync_service.is_offline() {
-			let now = std::time::Instant::now();
-			match offline_since {
-				None => {
-					// First time detecting offline, start grace period
-					offline_since = Some(now);
-					log::debug!(target: "pow", "No peers detected, starting {}s grace period before pausing mining", OFFLINE_GRACE_PERIOD.as_secs());
-				},
-				Some(since) if now.duration_since(since) >= OFFLINE_GRACE_PERIOD => {
-					// Grace period exceeded, pause mining
-					log::warn!(target: "pow", "Mining paused: no connected peers for {}s (node is offline)", OFFLINE_GRACE_PERIOD.as_secs());
-					tokio::select! {
-						_ = tokio::time::sleep(Duration::from_secs(5)) => {}
-						_ = cancellation_token.cancelled() => continue
-					}
-					continue;
-				},
-				Some(_) => {
-					// Still within grace period, continue mining but log
-					log::debug!(target: "pow", "No peers but still within grace period, continuing mining");
-				},
+			log::info!(target: "pow", "Mining paused: waiting for peers");
+			tokio::select! {
+				_ = tokio::time::sleep(Duration::from_secs(5)) => {}
+				_ = cancellation_token.cancelled() => continue
 			}
-		} else {
-			// We have peers (or are in dev mode), reset offline tracking
-			if offline_since.is_some() {
-				log::info!(target: "pow", "Peers reconnected, resuming normal mining");
-			}
-			offline_since = None;
+			continue;
 		}
 
 		// Wait for mining metadata to be available. We are past the sync check,


### PR DESCRIPTION
## Human overview

Fixes bug where miner runs at 100% capacity the entire time a node is syncing (on a stale / invalid job that's never canceled)



## Error mode

A GUI/CLI miner shows a full, real hashrate while its node is still deep in major sync (e.g. block 51k of 878k). It is not a test mode — the miner is genuinely hashing, but on a job that can never produce a block:

1. **Startup window.** The mining loop gates on `is_major_syncing()`, but at startup that is still `false` before the first peers connect, and the no-peers check had a 30-second grace period that let mining proceed. The loop therefore broadcast job 1 — built on whatever stale local best block the node had — one second after spawn (`⛏️ Broadcasting job 1` right after `⛏️ QPoW Mining task spawned`).
2. **No cancel.** The miner protocol has only `Ready` / `NewJob` / `JobResult`. When sync engages the node just stops sending new jobs, so miners grind the last job indefinitely at full hashrate.
3. **Stale job served on connect.** `MinerServer` stores the last broadcast job and hands it to every newly connecting miner; it was never cleared, so a miner connecting mid-sync immediately received the pre-sync job.

Every seal found this way is discarded (`Received stale result from miner … ignoring`, plus the seal re-verification under the build lock), so the only damage is hours of wasted work — but it makes syncing nodes look like they are mining.

## Fix (minimal)

- **Pause immediately when offline** instead of after a 30s grace period. The grace period is exactly what opened the startup window, and with external mining a pause is nearly free: connected miners keep their current job through a brief peer blip anyway, and a fresh job is broadcast on resume. This removes the `offline_since` / `OFFLINE_GRACE_PERIOD` machinery (net −16 lines).
- **Clear the stored job when pausing for major sync** (`MinerServer::clear_current_job`), so miners connecting during a sync receive no work until the first post-sync broadcast.

Already-connected miners that hold a job when a sync begins still grind it until superseded — stopping them would need a cancel message in the wire protocol (ALPN bump), out of scope here.

## Testing

- New unit test `clearing_the_current_job_stops_serving_it_to_new_miners`.
- `cargo test -p quantus-node` miner_server suite passes; `cargo +nightly fmt --check` clean.