### PR TITLE
feat: add dependency cooldown

### DIFF
--- a/.github/workflows/dependency-cooldown-audit.yml
+++ b/.github/workflows/dependency-cooldown-audit.yml
@@ -1,0 +1,13 @@
+name: Dependency cooldown audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    uses: Quantus-Network/shared-workflows/.github/workflows/dependency-cooldown-audit.yml@v1

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -1,0 +1,14 @@
+name: Dependency cooldown
+
+on:
+  pull_request:
+    # labeled/unlabeled/edited are required so the gate re-runs when an
+    # emergency bypass label or reason is added.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-cooldown:
+    uses: Quantus-Network/shared-workflows/.github/workflows/dependency-cooldown.yml@v1


### PR DESCRIPTION
Basically adding the dependency cooldown workflow. Enforcing in repo rules will be done later because doesn't have permission.