### PR TITLE
fix(multisig): reserve one codec depth for execute's boxed call

### DIFF
--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -49,23 +49,18 @@ use frame_support::{traits::Get, BoundedBTreeMap, BoundedVec};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
-/// Maximum decode nesting depth allowed when turning a stored opaque call
-/// (`BoundedCallOf`) back into a `RuntimeCall`.
+/// Maximum decode nesting depth allowed when turning an opaque proposal
+/// (`BoundedCallOf`) into a `RuntimeCall`.
 ///
-/// The outer extrinsic is decoded by FRAME's Executive with
-/// `decode_all_with_depth_limit(MAX_EXTRINSIC_DEPTH, ..)`, but that limit only
-/// applies to the signed envelope; the inner call is carried as opaque bytes and
-/// escapes it. Without a bound here, a signer can store a deeply nested call
-/// (e.g. chained `Utility::batch_all`) that passes pool validation and then
-/// exhausts the runtime stack when `propose`/`execute` decode it during block
-/// construction. We reuse the same ceiling as the outer envelope: Executive
-/// already performs a decode at this depth on every extrinsic, so it is proven
-/// safe, and no value that exceeds it could have entered as a top-level call.
+/// `propose` receives opaque bytes, so Executive cannot depth-limit the inner
+/// call. The accepted call must later fit inside the `Box<RuntimeCall>` carried
+/// by `Multisig::execute`; `Box` consumes one codec depth under Executive's
+/// `MAX_EXTRINSIC_DEPTH` limit. Reserve that level here so every proposal
+/// accepted at the boundary remains encodable as a valid execute extrinsic.
 ///
-/// Depth is bounded here; `propose` then requires the stored bytes to equal
-/// `decoded.encode()`, so trailing garbage cannot be stored. `execute` binds the
-/// submitted call to that canonical payload and does not decode storage again.
-pub const MAX_MULTISIG_CALL_DEPTH: u32 = frame_support::MAX_EXTRINSIC_DEPTH;
+/// Canonical re-encoding below also rejects trailing bytes and non-canonical
+/// encodings before any proposal state or deposit is created.
+pub const MAX_MULTISIG_CALL_DEPTH: u32 = frame_support::MAX_EXTRINSIC_DEPTH - 1;
 
 /// Multisig account data
 #[derive(Encode, Decode, MaxEncodedLen, Clone, TypeInfo, RuntimeDebug, PartialEq, Eq)]

--- a/pallets/multisig/src/tests.rs
+++ b/pallets/multisig/src/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for pallet-multisig
 
 use crate::{mock::*, Error, Event, Multisigs, ProposalStatus, Proposals};
-use codec::{Decode, Encode};
+use codec::{Decode, DecodeLimit, Encode};
 use frame_support::{
 	assert_err_ignore_postinfo, assert_noop, assert_ok,
 	dispatch::GetDispatchInfo,
@@ -1026,6 +1026,79 @@ fn remove_expired_unblocks_undecodable_approved_proposal() {
 
 		// No deposit was reserved (proposal failed before that)
 		assert_eq!(Balances::reserved_balance(bob()), 0);
+	});
+}
+
+fn nested_batch_all_call(depth: usize) -> RuntimeCall {
+	let mut call = RuntimeCall::System(frame_system::Call::remark { remark: Vec::new() });
+	for _ in 0..depth {
+		call = RuntimeCall::Utility(pallet_utility::Call::batch_all { calls: vec![call] });
+	}
+	call
+}
+
+/// `propose` must reserve the one codec-depth level consumed when the accepted
+/// call is later carried inside `Multisig::execute`'s `Box<RuntimeCall>`.
+#[test]
+fn proposal_depth_boundary_remains_executable() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		set_max_inner_call_weight(Weight::from_parts(u64::MAX, u64::MAX));
+
+		let signers = vec![bob(), charlie()];
+		assert_ok!(Multisig::create_multisig(
+			RuntimeOrigin::signed(alice()),
+			signers.clone(),
+			2,
+			0,
+		));
+		let multisig_address = Multisig::derive_multisig_address(&signers, 2, 0);
+
+		let accepted = nested_batch_all_call(crate::MAX_MULTISIG_CALL_DEPTH as usize);
+		let accepted_bytes: crate::BoundedCallOf<Test> = accepted.encode().try_into().unwrap();
+		assert_ok!(Multisig::propose(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			accepted_bytes.clone(),
+			100,
+		));
+
+		let execute = RuntimeCall::Multisig(crate::Call::execute {
+			multisig_address: multisig_address.clone(),
+			proposal_id: 0,
+			call: Box::new(accepted.clone()),
+		});
+		let execute_bytes = execute.encode();
+		assert!(
+			RuntimeCall::decode_all_with_depth_limit(
+				frame_support::MAX_EXTRINSIC_DEPTH,
+				&mut &execute_bytes[..],
+			)
+			.is_ok(),
+			"an accepted proposal must fit inside a depth-limited execute call",
+		);
+
+		assert_ok!(Multisig::approve(
+			RuntimeOrigin::signed(charlie()),
+			multisig_address.clone(),
+			0,
+			accepted_bytes,
+		));
+		assert_ok!(Multisig::execute(
+			RuntimeOrigin::signed(bob()),
+			multisig_address.clone(),
+			0,
+			Box::new(accepted),
+		));
+
+		let rejected = nested_batch_all_call(crate::MAX_MULTISIG_CALL_DEPTH as usize + 1);
+		let rejected_bytes: crate::BoundedCallOf<Test> = rejected.encode().try_into().unwrap();
+		assert_err_ignore_postinfo(
+			Multisig::propose(RuntimeOrigin::signed(bob()), multisig_address, rejected_bytes, 100),
+			Error::<Test>::InvalidCall.into(),
+		);
+
+		reset_max_inner_call_weight();
 	});
 }
 


### PR DESCRIPTION
## Purpose

`Multisig::execute` now carries the inner call (`Box<RuntimeCall>`). `propose` still decoded stored calls at `MAX_EXTRINSIC_DEPTH`. Executive decodes the complete execute extrinsic at that same ceiling, so a proposal accepted at the boundary could not be encoded as a valid `execute`.

This is **not** in public `main` (no inner depth cap) and **not** in chain-private `main` (execute did not carry the call, so the full ceiling was correct). It only appears on the merge of those two. Kept off #675 so that PR stays the merge.

## Change

- `MAX_MULTISIG_CALL_DEPTH = MAX_EXTRINSIC_DEPTH - 1`
- `proposal_depth_boundary_remains_executable`: a call at the new ceiling proposes, encodes as `execute`, and decodes under `MAX_EXTRINSIC_DEPTH`; one level deeper is rejected at propose

## Verification

`SKIP_WASM_BUILD=1 cargo test --locked -p pallet-multisig --lib` — 61 passed