### PR TITLE
feat: staging-mainnet chain spec, fast-upgrade governance track

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -140,7 +140,11 @@ pub struct RunCmd {
 	#[arg(long, conflicts_with_all = &["alice", "bob", "charlie", "dave", "eve", "ferdie", "one"])]
 	pub two: bool,
 
-	/// Enable authoring even when offline.
+	/// Enable authoring even when offline (no connected peers).
+	///
+	/// Required to start mining on a new chain from a single validator,
+	/// for example at mainnet or staging-mainnet genesis. Without this flag,
+	/// mining pauses until at least one peer is connected.
 	#[arg(long)]
 	pub force_authoring: bool,
 

--- a/docs/CHAINSPEC_CREATION.md
+++ b/docs/CHAINSPEC_CREATION.md
@@ -1,0 +1,77 @@
+# Creating a Chain Spec (JSON)
+
+How to produce a committed, raw JSON chain spec for a network profile
+(`heisenberg`, `planck`, `staging_mainnet`). The genesis runtime in the JSON is
+the **published release artifact**, not a local build — anyone can reproduce
+and verify it.
+
+## Naming convention
+
+For a profile `<profile>` (e.g. `staging_mainnet`):
+
+| Name | Meaning |
+| --- | --- |
+| `<profile>_live_spec` | `--chain` id that builds genesis from the preset compiled into the node (used only during generation) |
+| `node/src/chain-specs/<profile-with-dashes>.json` | the committed raw spec |
+| `<profile>` | `--chain` id that loads the committed JSON (what operators use) |
+
+## Prerequisites
+
+- The runtime preset exists in `runtime/src/genesis_config_presets.rs` and is
+  wired up in `node/src/chain_spec.rs` (`<profile>_chain_spec()`) and in
+  `load_spec` (`node/src/command.rs`) under `"<profile>_live_spec"`.
+- Clean git working tree (the script refuses otherwise).
+- `jq`, `curl`, `xxd`, and a Rust toolchain that builds the node.
+
+## Steps
+
+1. **Cut a release tag.** CI publishes the runtime WASM
+   (`quantus-runtime-vNNN.compact.compressed.wasm`) as a release asset on
+   `Quantus-Network/chain`.
+
+2. **Generate the spec from the tag:**
+
+   ```sh
+   ./scripts/genesis_generate_spec.sh <release-tag> <profile>
+   ```
+
+   The script:
+   - creates branch `genesis/<profile>/<release-tag>` at the tag and builds
+     the node there, so genesis state comes from exactly the released code;
+   - runs `build-spec --chain <profile>_live_spec --raw
+     --disable-default-bootnode` into
+     `node/src/chain-specs/<profile-with-dashes>.json` (without
+     `--disable-default-bootnode`, a spec with no bootnodes gets a throwaway
+     `/ip4/127.0.0.1` bootnode injected);
+   - downloads the release's compressed runtime WASM and splices it into the
+     JSON's `:code` key (`.genesis.raw.top."0x3a636f6465"`), so the genesis
+     runtime is byte-identical to the published artifact.
+
+3. **Wire the JSON into the node.** Add a `"<profile>"` arm to `load_spec` in
+   `node/src/command.rs`:
+
+   ```rust
+   "staging_mainnet" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
+       "chain-specs/staging-mainnet.json"
+   ))?) as Box<dyn sc_service::ChainSpec>,
+   ```
+
+4. **Record the genesis hash.** Run `quantus-node --chain <profile> --tmp` and
+   note the genesis hash it prints on startup.
+
+5. **Verify the genesis runtime against the release** (against any running
+   node of the new chain):
+
+   ```sh
+   ./scripts/genesis_verification.sh --release-tag <release-tag> --node-url http://localhost:9944
+   ```
+
+6. **Add bootnodes** once the infrastructure exists: edit the JSON's top-level
+   `bootNodes` array (`/dns/<host>/tcp/30333/p2p/<peer-id>`). This field lives
+   outside genesis, so the genesis hash is unchanged.
+
+7. **Commit** the JSON plus the `load_spec` arm, and cut the node release that
+   embeds them.
+
+For the staging-mainnet launch sequence around this (treasury multisig,
+first server, post-launch), see `docs/STAGING_MAINNET_LAUNCH.md`.

--- a/docs/RUNTIME_SURFACE.md
+++ b/docs/RUNTIME_SURFACE.md
@@ -83,6 +83,7 @@ The runtime derives `RuntimeCall`, `RuntimeEvent`, `RuntimeError`, `RuntimeOrigi
 | 20 | `Wormhole` | `pallet-wormhole` | **Local** (`pallets/wormhole`) | yes |
 | 21 | `ZkTree` | `pallet-zk-tree` | **Local** (`pallets/zk-tree`) | no |
 | 22 | `Vesting` | `pallet-vesting` | **Local** (`pallets/vesting`) | yes |
+| 23 | `Origins` | `pallet_custom_origins` | **Local** (`runtime/src/governance/origins.rs`) | no |
 
 > Indices 4, 10, 12, 16, 17, and 18 are intentionally left vacant after pallet removals so downstream indices stay stable.
 
@@ -154,7 +155,7 @@ All `Config` impls live in `runtime/src/configs/mod.rs` unless noted.
 - **Calls:** `add_member`, `promote_member`, `demote_member`, `remove_member`, `vote`, `cleanup_poll`, `exchange_member`. Removal intentionally leaves the member's votes in ongoing tallies (upstream behavior); `support` clamps at 100% so the shrunken electorate cannot overflow the curve.
 
 ### Index 14 — `TechReferenda` (`pallet-referenda`, `Instance1`)
-- `SubmitOrigin = RootOrMemberForTechReferendaOrigin`, `Tracks = TechCollectiveTracksInfo` (single track, 61% approval / 60% support constant curves), `Tally = pallet_ranked_collective::TallyOf<Runtime>`, `MaxActive = 128` / `MaxActivePerAccount = 8` (global + per-submitter caps on `Ongoing` referenda; storage `ActiveReferendaCount` / `ActiveSubmissionCount`; errors `TooManyActive` / `TooManyActiveBySubmitter`), `MaxProposalSize = 64 KiB`.
+- `SubmitOrigin = RootOrMemberForTechReferendaOrigin`, `Tracks = TechCollectiveTracksInfo` (track 0 for Root proposals, 61% approval / 60% support constant curves; track 1 `fast_upgrade` for `FastUpgrade` proposals, 80%/80% constant curves with 10-minute prepare/confirm/enactment), `Tally = pallet_ranked_collective::TallyOf<Runtime>`, `MaxActive = 128` / `MaxActivePerAccount = 8` (global + per-submitter caps on `Ongoing` referenda; storage `ActiveReferendaCount` / `ActiveSubmissionCount`; errors `TooManyActive` / `TooManyActiveBySubmitter`), `MaxProposalSize = 64 KiB`.
 - **Calls:** same set as `Referenda` (separate instance/storage).
 
 ### Index 15 — `TreasuryPallet` (`pallet-treasury`, local)
@@ -184,6 +185,11 @@ All `Config` impls live in `runtime/src/configs/mod.rs` unless noted.
 - **Proof recording:** the pallet records each pot → beneficiary payout via `TransferProofRecorder` itself (`pay_out` fuses transfer + record and fails with `PayoutProofNotRecorded` if the recorder drops the credit, rolling the transfer back), so scheduler-enacted Root calls — invisible to the event-scanning extension — still create leaves; the extension skips pot-touching transfer events and charges no static weight for vesting calls.
 - **Calls:** `claim`(0) — **permissionless**; pays the largest valid claim from the pot to the schedule's stored beneficiary (never the caller); the only claim path for keyless/high-security beneficiaries. `create_schedule`(1) — admin; validates the schedule and funds the pot from the treasury in the same call. `end_schedule`(2) — admin; unpaid vested part rounded to the nearest quantum → beneficiary if it meets `MinimumPayout`, otherwise the whole remainder → treasury; schedule removed. `retarget_schedule`(3) — admin; changes the beneficiary and pays nothing out. A retarget replaces the *same* grantee's lost/stolen/abandoned wallet, so settling the old address would burn funds or pay a thief; everything vested but unclaimed stays on the schedule and reaches the new wallet at its next claim. (A permissionless claim landing before the retarget still pays the old address, so rotations should happen promptly.)
 - Genesis build validates every schedule (`start ≤ cliff ≤ end`, `start < end`, `total ≥ MinimumPayout`, `total % PayoutQuantum = 0`, beneficiary ≠ pot) and, for a non-empty table, asserts the pot holds exactly `Σ schedule totals + ED`; a misconfigured chain refuses to start. `try_state` validates stored schedules, aligned claims, dust-safe remaining obligations, and—when any schedule exists—`pot balance ≥ Σ(total − claimed) + ED`; an empty schedule table is valid with an unfunded pot.
+
+### Index 23 — `Origins` (`pallet_custom_origins`, local)
+- Storage-less, call-less, event-less origin declaration: its whole body is one `#[pallet::origin] enum Origin { FastUpgrade }`. A pallet is the only way to contribute a variant to `RuntimeOrigin`/`OriginCaller`.
+- `Origin::FastUpgrade` is the proposal origin of tech-referenda track 1 (`fast_upgrade`) and is honored **only** by `system.authorize_upgrade` (`AuthorizeUpgradeOrigin = EitherOfDiverse<EnsureRoot, FastUpgrade>` in the forked frame-system). `set_code` and `authorize_upgrade_without_checks` remain Root-only, so the track can publish an upgrade hash and nothing else.
+- **Calls:** none. See `docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md` for the authorize-then-apply flow.
 
 ---
 
@@ -233,23 +239,25 @@ The high-security whitelist (`HighSecurityConfig::is_whitelisted`, extension 8) 
 
 - `PreimageDeposit` — custom `Consideration` fee model for preimages.
 - `CommunityTracksInfo` — public referenda; single "signed" track (max_deciding 5, 500 UNIT decision deposit, 7-day decision, linear-decreasing approval 70→55% / support 25→5%).
-- `TechCollectiveTracksInfo` — tech-collective referenda; single track (1000 × `FEE_SCALE` UNIT deposit, 61% approval / 60% support constant curves, 1-day decision/confirm/enactment).
+- `TechCollectiveTracksInfo` — tech-collective referenda; track 0 for Root proposals (10 × `FEE_SCALE` UNIT deposit, 61% approval / 60% support constant curves, 1-day decision/confirm/enactment) and track 1 `fast_upgrade` for `FastUpgrade` proposals (10 × `FEE_SCALE` UNIT deposit, 80%/80% constant curves = 8-of-10 at genesis, 10-minute prepare/confirm/enactment — the runtime-upgrade lane, see `docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md`).
 - `MinRankOfClassConverter`, `GlobalMaxMembers` — rank/membership converters.
 - `RootOrMemberForTechReferendaOrigin` — custom origin for TechReferenda submission (Root or ranked-collective member).
+- `governance/origins.rs` (`pallet_custom_origins`, runtime index 23 as `Origins`) — storage-less origin declarations; `Origin::FastUpgrade` is dispatched by approved fast-track referenda and honored only by `system.authorize_upgrade` (`AuthorizeUpgradeOrigin = Root or FastUpgrade` in the forked frame-system).
 - `apply_test_timing` — compiled only under `fast-governance` (collapses all timing windows to 2 blocks for CI).
 
 ---
 
 ## 7. Genesis presets (`genesis_config_presets.rs`)
 
-- **Presets:** `dev` (`DEV_RUNTIME_PRESET`), `heisenberg`, `planck`.
+- **Presets:** `dev` (`DEV_RUNTIME_PRESET`), `heisenberg`, `planck`, `staging_mainnet` (`STAGING_MAINNET_RUNTIME_PRESET`).
 - **Network roles:**
   - `dev` — local development.
   - `heisenberg` — **internal integration testnet**, not mainnet. Tokens have no monetary value; the network may be reset.
   - `planck` — public testnet (live treasury signers + faucet).
-- **Vesting genesis:** every preset endows the vesting pot with `Σ schedule totals + ED` (ED alone when the table is empty, as on `planck`). Because the pot is part of the balances genesis endowment, standard genesis proof generation creates a block-1 Wormhole leaf for it; that leaf is unspendable because the pot is keyless. `dev`/`heisenberg` seed example schedules (one account with two schedules; `dev` also vests the keyless test wormhole address, claimable only via third-party ping). A mainnet preset (4-of-6 treasury multisig, launch-gated allocation table) is planned as a separate PR.
+  - `staging_mainnet` — mainnet dress rehearsal (see `docs/STAGING_MAINNET_LAUNCH.md`).
+- **Vesting genesis:** every preset endows the vesting pot with `Σ schedule totals + ED` (ED alone when the table is empty, as on `planck`). Because the pot is part of the balances genesis endowment, standard genesis proof generation creates a block-1 Wormhole leaf for it; that leaf is unspendable because the pot is keyless. `dev`/`heisenberg` seed example schedules (one account with two schedules; `dev` also vests the keyless test wormhole address, claimable only via third-party ping). `staging_mainnet` builds from `mainnet_config_genesis`, the exact function the eventual mainnet preset will use; its vesting table is a DUMMY scaffold gated by `MAINNET_VESTING_FINALIZED`, and until that flag is flipped with the real allocation table no mainnet preset is exposed (details in `docs/STAGING_MAINNET_LAUNCH.md`).
 - Dilithium well-known accounts: `crystal_alice`, `dilithium_bob`, `crystal_charlie` (public seeds `[0]` / `[1]` / `[2]`). Used by `dev` and **intentionally also by `heisenberg`** so integrators and CI can exercise governance, treasury, and transfer flows without distributing secrets. Those private keys are public by design; do **not** reuse this pattern on a mainnet or any value-bearing chain (Planck already uses distinct live treasury signers).
-- Treasury = 2-of-3 multisig of the three signers for `dev`/`heisenberg` (distinct nonce per preset); no dedicated treasury genesis balance (endowments are a separate list).
+- Treasury = 2-of-3 multisig of the three signers for `dev`/`heisenberg`, 6-of-10 of the mainnet signers for `staging_mainnet` (distinct nonce per preset); no dedicated treasury genesis balance (endowments are a separate list).
 - Tech-collective seeded via the chain-spec-only `tech_collective_seed_members` JSON field (`prepare_genesis_build_input` + `seed_tech_collective`).
 - Endows all genesis balances with wormhole transfer proofs (ZK-spendable). `dev` also endows `TEST_WORMHOLE_SECRET`'s address.
 

--- a/docs/RUNTIME_UPDATE.md
+++ b/docs/RUNTIME_UPDATE.md
@@ -4,8 +4,14 @@ End-to-end runbook for shipping a new runtime to the **Heisenberg** (internal) a
 **Planck** testnets, and smoke-testing them with the chain exercise suite.
 
 Runtime upgrades on this chain are **governance-only** — `pallet-sudo` was removed, so
-there is no `sudo.setCode` shortcut. An upgrade is a Tech-Referenda proposal that, once
-passed, executes `system.set_code` with Root origin. No node restart is required.
+there is no `sudo.setCode` shortcut. An upgrade is a Tech-Referenda proposal on the
+`fast_upgrade` track that, once passed, executes `system.authorize_upgrade(code_hash)`;
+the WASM itself is then delivered via the permissionless `quantus runtime apply`
+(`system.apply_authorized_upgrade`). No node restart is required.
+
+> This flow needs a runtime that has the `fast_upgrade` track and `FastUpgrade`
+> origin. To upgrade an older live runtime that predates them, use the matching
+> older CLI (which submits `system.set_code` on the Root track).
 
 > Polkadot-JS Apps and the standard `@polkadot/api` **cannot** sign for this chain
 > (Dilithium / ML-DSA signatures). Every step below uses the **Quantus CLI**
@@ -48,7 +54,7 @@ export PLANCK_WS="wss://a1-planck.quantus.cat"
 # 2. Get the runtime wasm (from the GitHub release, or the srtool CI artifact)
 export WASM=/path/to/quantus_runtime.compact.compressed.wasm
 
-# 3. Heisenberg: submit -> deposit -> vote (all 3 members) -> wait -> verify
+# 3. Heisenberg: submit -> deposit -> vote (all 3 members) -> wait -> apply -> verify
 # 4. Run the exercise suite:  quantus exercise --skip governance --node-url $HEISENBERG_WS
 # 5. Planck: repeat the governance flow with the planck wallets
 ```
@@ -77,9 +83,9 @@ nodes**, not RPC URLs — but each network also exposes the Substrate RPC over *
 
 ## Tech Collective members
 
-Both testnets have a **3-member** Tech Collective. The Tech track needs **≥ 61 % approval
-and ≥ 60 % support**, so **2 of 3 aye votes** are enough — but vote with all three to be
-safe. Confirm the live membership any time with:
+Both testnets have a **3-member** Tech Collective. The `fast_upgrade` track needs
+**≥ 80 % approval and ≥ 80 % support**, so **all 3 members** must vote aye. Confirm the
+live membership any time with:
 
 ```bash
 quantus tech-collective list-members --node-url <endpoint>
@@ -158,8 +164,8 @@ quantus runtime compare --wasm-file "$WASM" --node-url "$HEISENBERG_WS"
 # b) Confirm the collective membership (who you'll need aye votes from)
 quantus tech-collective list-members --node-url "$HEISENBERG_WS"
 
-# c) Submit the proposal: uploads the wasm as a preimage, then opens the Tech referendum
-#    on the Root track. Add --force to skip the interactive confirm.
+# c) Submit the proposal: notes the authorize_upgrade(code_hash) preimage, then opens
+#    the referendum on the fast_upgrade track. Add --force to skip the interactive confirm.
 quantus runtime update \
   --wasm-file "$WASM" \
   --from "$HEISENBERG_TC" \
@@ -175,20 +181,23 @@ quantus tech-referenda place-decision-deposit \
   --from "$HEISENBERG_TC" \
   --node-url "$HEISENBERG_WS"
 
-# f) Vote aye with all three members (2 of 3 is enough to pass)
+# f) Vote aye with all three members (fast_upgrade needs 80%/80% — all 3 of 3)
 quantus tech-collective vote --referendum-index "$HREF" --vote aye --from crystal_alice   --node-url "$HEISENBERG_WS"
 quantus tech-collective vote --referendum-index "$HREF" --vote aye --from crystal_bob     --node-url "$HEISENBERG_WS"
 quantus tech-collective vote --referendum-index "$HREF" --vote aye --from crystal_charlie --node-url "$HEISENBERG_WS"
 
-# g) Monitor until it passes -> confirms -> enacts
+# g) Monitor until it passes -> confirms -> enacts (authorize_upgrade executes)
 quantus tech-referenda status --index "$HREF" --node-url "$HEISENBERG_WS"
 
-# h) Verify the new runtime is live (compare should now show equal versions)
+# h) Apply the authorized wasm (permissionless — any funded wallet)
+quantus runtime apply --wasm-file "$WASM" --from "$HEISENBERG_TC" --node-url "$HEISENBERG_WS"
+
+# i) Verify the new runtime is live (compare should now show equal versions)
 quantus runtime compare --wasm-file "$WASM" --node-url "$HEISENBERG_WS"
 ```
 
-> ⏱️ **Timing.** On a standard node the Tech track has ~1-day decision, confirm, and
-> enactment periods, so a full upgrade can take a couple of days. If a testnet runs with
+> ⏱️ **Timing.** The `fast_upgrade` track has 10-minute prepare, confirm, and enactment
+> windows (~30 minutes end to end plus voting time). If a testnet runs with
 > `fast-governance`, it enacts in minutes. Check the live periods with
 > `quantus tech-referenda config --node-url "$HEISENBERG_WS"`.
 
@@ -253,7 +262,7 @@ export PREF=<referendum_index_from_list>
 # e) place decision deposit
 quantus tech-referenda place-decision-deposit --index "$PREF" --from planck-tc-1 --node-url "$PLANCK_WS"
 
-# f) vote aye with all three members
+# f) vote aye with all three members (all 3 of 3 required)
 quantus tech-collective vote --referendum-index "$PREF" --vote aye --from planck-tc-1 --node-url "$PLANCK_WS"
 quantus tech-collective vote --referendum-index "$PREF" --vote aye --from planck-tc-2 --node-url "$PLANCK_WS"
 quantus tech-collective vote --referendum-index "$PREF" --vote aye --from s3          --node-url "$PLANCK_WS"
@@ -261,7 +270,10 @@ quantus tech-collective vote --referendum-index "$PREF" --vote aye --from s3    
 # g) monitor to enactment
 quantus tech-referenda status --index "$PREF" --node-url "$PLANCK_WS"
 
-# h) verify new version live
+# h) apply the authorized wasm
+quantus runtime apply --wasm-file "$WASM" --from planck-tc-1 --node-url "$PLANCK_WS"
+
+# i) verify new version live
 quantus runtime compare --wasm-file "$WASM" --node-url "$PLANCK_WS"
 ```
 
@@ -272,7 +284,8 @@ quantus runtime compare --wasm-file "$WASM" --node-url "$PLANCK_WS"
 | Symptom | Cause / fix |
 |---|---|
 | Referendum never leaves "Preparing" | You skipped the **decision deposit** (Step e). Place it, then voting/deciding starts. |
-| Referendum rejected / not enough support | 3-member collective needs ≥ 61 % approval / 60 % support → get a 2nd (and 3rd) aye. |
+| Referendum rejected / not enough support | `fast_upgrade` needs ≥ 80 % approval / 80 % support → all 3 members must vote aye. |
+| Referendum enacted but version unchanged | Enactment only authorizes the hash — run `quantus runtime apply` with the same wasm. |
 | No wasm asset on the GitHub release | The release publish job failed after srtool. Pull the `runtime` workflow artifact (Step 0 fallback) and re-run the release. |
 | Wallet prompts for a password | Add `-p <password>` or `--password-file <file>` to the signing command. |
 
@@ -282,7 +295,8 @@ quantus runtime compare --wasm-file "$WASM" --node-url "$PLANCK_WS"
 |---|---|
 | On-chain runtime version | `quantus runtime compare --wasm-file <wasm> --node-url <ws>` |
 | List collective members | `quantus tech-collective list-members --node-url <ws>` |
-| Submit upgrade (preimage + referendum) | `quantus runtime update --wasm-file <wasm> --from <member> --node-url <ws>` |
+| Submit upgrade (authorize referendum) | `quantus runtime update --wasm-file <wasm> --from <member> --node-url <ws>` |
+| Apply authorized wasm (after enactment) | `quantus runtime apply --wasm-file <wasm> --from <wallet> --node-url <ws>` |
 | List referenda | `quantus tech-referenda list --node-url <ws>` |
 | Referendum detail | `quantus tech-referenda get --index <i> --node-url <ws>` |
 | Place decision deposit | `quantus tech-referenda place-decision-deposit --index <i> --from <wallet> --node-url <ws>` |

--- a/docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md
+++ b/docs/RUNTIME_UPGRADE_VIA_GOVERNANCE.md
@@ -2,10 +2,37 @@
 
 Polkadot JS Apps and the standard `@polkadot/api` **do not support** this chain's signature schemes. All governance actions must be done with the Quantus CLI.
 
+## How upgrades work
+
+Tech-referenda proposals are `Lookup` preimages capped at 64 KiB
+(`MaxReferendaProposalSize`), so a runtime WASM (hundreds of KiB) can never
+itself be a proposal. Upgrades instead go through the hash-then-apply flow,
+modeled on Polkadot's Whitelisted Caller track:
+
+1. `quantus runtime update` notes the 34-byte preimage of
+   `system.authorize_upgrade(code_hash)` and submits it as a referendum on
+   track 1 (`fast_upgrade`) with the custom `Origins::FastUpgrade` proposal
+   origin. That origin is honored **only** by `system.authorize_upgrade` — the
+   track can publish an upgrade hash and nothing else, it cannot dispatch
+   arbitrary Root calls.
+2. The track uses constant 80%/80% approval/support curves — **8-of-10** ayes
+   from the genesis collective (2 nays cannot block) — with 10-minute
+   prepare, confirm, and enactment windows (~30 minutes end to end plus
+   voting time).
+3. After enactment, `quantus runtime apply` submits the permissionless,
+   version-checked `system.apply_authorized_upgrade(wasm)` with the actual
+   runtime bytes. It refuses to run if no authorization exists, the WASM hash
+   does not match the authorized hash, version checking is disabled, or the
+   WASM is already installed — and verifies after inclusion that the new code
+   is live.
+
+Track 0 (Root origin, 61%/60% curves, 1-day windows) remains for other
+governance calls that fit in 64 KiB; it is not used for runtime upgrades.
+
 ## Prerequisites
 
 - A working `quantus` CLI binary (build from https://github.com/Quantus-Network/quantus-cli if needed).
-- At least one Tech Collective member wallet (created and managed inside the CLI). On Planck these are the treasury signers.
+- At least one Tech Collective member wallet (created and managed inside the CLI) to submit, and 8 member wallets to vote.
 - The new runtime WASM file (normally the compressed one from the release: `quantus-runtime-vNNN.compact.compressed.wasm`).
 - Node endpoint (e.g. `wss://rpc.quantus.network`).
 
@@ -21,7 +48,7 @@ Polkadot JS Apps and the standard `@polkadot/api` **do not support** this chain'
    quantus runtime compare --wasm-file /path/to/new-runtime.wasm --node-url <endpoint>
    ```
 
-3. Submit the upgrade proposal (must be run by a Tech Collective member). This notes the preimage and submits the referendum on the Tech track with Root origin. It asks for an interactive `yes/no` confirmation — add `--force` to skip it (e.g. for scripts):
+3. Submit the authorization referendum (must be run by a Tech Collective member). This notes the `authorize_upgrade(code_hash)` preimage and submits the referendum on the `fast_upgrade` track. It asks for an interactive `yes/no` confirmation — add `--force` to skip it (e.g. for scripts):
    ```bash
    quantus runtime update \
      --wasm-file /path/to/new-runtime.wasm \
@@ -42,7 +69,7 @@ Polkadot JS Apps and the standard `@polkadot/api` **do not support** this chain'
      --node-url <endpoint>
    ```
 
-6. Tech Collective members vote:
+6. Tech Collective members vote — 8 of the 10 genesis members must vote aye:
    ```bash
    quantus tech-collective vote \
      --referendum-index <referendum_index> \
@@ -51,18 +78,27 @@ Polkadot JS Apps and the standard `@polkadot/api` **do not support** this chain'
      --node-url <endpoint>
    ```
 
-7. Monitor until it passes and enacts:
+7. Monitor until it passes, confirms, and enacts (`system.authorize_upgrade` executes):
    ```bash
    quantus tech-referenda status --index <referendum_index> --node-url <endpoint>
    ```
 
-When the referendum passes, confirms, and enacts, `system.set_code` executes with Root origin and the new runtime is live immediately. No node restart is required.
+8. Apply the authorized WASM (any funded wallet — the call is permissionless):
+   ```bash
+   quantus runtime apply \
+     --wasm-file /path/to/new-runtime.wasm \
+     --from <any-funded-wallet> \
+     --node-url <endpoint>
+   ```
+
+Once `apply` succeeds the new runtime is live immediately. No node restart is required.
 
 ## Gotchas
 
-- Only Tech Collective members can submit or vote on the Tech track.
+- Only Tech Collective members can submit or vote on tech referenda.
 - The decision deposit must be placed before the referendum can move to the deciding phase.
-- The upgrade block is very heavy (consumes the entire block weight).
+- The `apply` step must pass the **exact** bytes whose hash was authorized — use the same release artifact, not a rebuild.
+- The apply block is very heavy (consumes the entire block weight).
 - Test on a local dev chain first. There is no automatic binary distribution — operators pull new releases on their own schedule.
 
 All commands support `--help` and `--verbose`. Use `--finalized-tx` on important governance transactions if you want to wait for deeper finality on this PoW chain.

--- a/docs/STAGING_MAINNET_LAUNCH.md
+++ b/docs/STAGING_MAINNET_LAUNCH.md
@@ -1,0 +1,64 @@
+# Staging-Mainnet Launch
+
+Mainnet dress rehearsal. Genesis comes from `mainnet_config_genesis`
+(`runtime/src/genesis_config_presets.rs`) — identical to the eventual mainnet's
+except the treasury multisig nonce (staging 1, mainnet 0), so the genesis hash
+differs while everything else stays 1:1.
+
+- Treasury: 6-of-10 multisig of `MAINNET_TREASURY_SIGNERS_SS58`, nonce 1 →
+  `qzpjP5r4NSeWDrbHvboYcychsmCCaJrbRixvghVjnaRzjRb5i`
+- Tech collective: the same ten accounts (referenda curves are runtime constants)
+- Balances: no fixed figure is written down. Each signer's liquid endowment is
+  computed at genesis by `governance_treasury_signer_seed()` from the live
+  runtime constants — treasury multisig bootstrap (multisig fee, proposal fee,
+  refundable proposal deposit, inclusion-fee prepay, ED), the referenda
+  submission and decision bonds, a maximum-size preimage deposit, and a small
+  scaled fee headroom. It is deliberately the minimum that lets any single
+  treasurer act from genesis: bootstrap the multisig and carry one referendum
+  end to end. Because it is derived, changing `FEE_SCALE` or any deposit
+  re-derives the endowment instead of stranding governance, and a genesis test
+  pins every signer balance to the formula. The 20 HD rehearsal accounts
+  (`staging-0`..`staging-19`) each get `STAGING_REHEARSAL_LIQUID` so they can
+  submit transactions. Everything else sits in the vesting pot. Read the
+  exact per-signer and total figures for a given build out of the generated
+  spec's `balances` section rather than restating them here.
+- Vesting: `mainnet_vesting_schedules` is a DUMMY scaffold (team / early-backer /
+  ecosystem entries with stand-in beneficiaries T1, T2, and the treasury, plus
+  20 HD rehearsal accounts with distinct grants summing to 100_000 UNIT,
+  5-minute cliff / 10-day vest from 2026-08-22 00:00 UTC). Replace it with the
+  real allocation table and flip `MAINNET_VESTING_FINALIZED` before the mainnet
+  preset is added — until then only staging-mainnet builds.
+
+## Generate the chain spec
+
+Follow `docs/CHAINSPEC_CREATION.md` with profile `staging_mainnet`: cut a
+release tag, run `./scripts/genesis_generate_spec.sh <tag> staging_mainnet`
+(writes `node/src/chain-specs/staging-mainnet.json` with the released wasm),
+add the `"staging_mainnet"` arm to `load_spec`, record the genesis hash,
+commit, cut the node release.
+
+## First server
+
+```sh
+quantus-node key generate-node-key --file ~/.quantus/node_key.p2p
+quantus-node key quantus --scheme wormhole   # note the printed "Inner Hash"
+quantus-node --chain staging_mainnet --node-key-file ~/.quantus/node_key.p2p \
+  --rewards-inner-hash <0x-inner-hash> --validator --force-authoring \
+  --port 30333 --rpc-port 9944
+```
+
+`--force-authoring` is required on this first miner: it bypasses the two
+authoring gates (no connected peers, and a best block older than
+`--max-tip-age` — which the genesis block always is), so without it the chain
+never starts. Drop the flag once other miners have joined: with it a restarted
+node mines on a stale tip while catching up instead of pausing.
+
+Blocks only start once a miner (`--validator`) runs. Point DNS at the server,
+then add `/dns/<host>/tcp/30333/p2p/<peer-id>` to the JSON's `bootNodes` —
+that field is outside genesis, so the hash is unchanged.
+
+## Post-launch
+
+One signer calls `multisig.createMultisig(signers, 6, 1)`; the derived address
+must equal the genesis treasury account above. Treasury then operates via
+`proposeTransaction` / `approveProposal` at 6-of-10.

--- a/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
+++ b/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
@@ -1,41 +1,40 @@
 # Tech Collective Governance Tuning (Mainnet Parameters)
 
-Scope: the runtime-upgrade track (`TechReferenda` = `pallet_referenda::Pallet<Runtime, Instance1>` + `TechCollective` = `pallet_ranked_collective`). Sources verified against the runtime and crate sources `pallet-referenda-45.0.0` / `pallet-ranked-collective-45.0.0` (cargo registry; not vendored in `pallets/`).
+Scope: the two tech-referenda tracks (`TechReferenda` = `pallet_referenda::Pallet<Runtime, TechReferendaInstance>` + `TechCollective` = `pallet_ranked_collective`). Tracks are defined in `runtime/src/governance/definitions.rs` (`TechCollectiveTracksInfo::create_tech_collective_tracks`) and wired in `runtime/src/configs/mod.rs`. Pallet semantics verified against the crate sources `pallet-referenda-45.0.0` / `pallet-ranked-collective-45.0.0` (cargo registry; not vendored in `pallets/`).
+
+| Track | Proposal origin | May dispatch | Used for |
+|---|---|---|---|
+| 0 `tech_collective_members` | `Root` | any call whose preimage fits `MaxReferendaProposalSize` (64 KiB) | membership and parameter changes, cancel/kill, slow fallback for `authorize_upgrade` |
+| 1 `fast_upgrade` (`FAST_UPGRADE_TRACK_ID`) | `Origins::FastUpgrade` (`pallet_custom_origins`, runtime index 23) | `system.authorize_upgrade(code_hash)` only | **runtime upgrades** |
+
+Runtime upgrades never go through `set_code`: a runtime WASM is hundreds of KiB, far over the 64 KiB proposal cap and over hardware-wallet signing limits. The supported route is to vote on the code *hash* on track 1, then have anyone submit the permissionless, version-checked `system.apply_authorized_upgrade(wasm)` with the exact bytes. `frame_system::Config::AuthorizeUpgradeOrigin` is `EitherOfDiverse<EnsureRoot, FastUpgrade>`, so a track-0 Root referendum can also authorize a hash (about two days slower); `set_code` and `authorize_upgrade_without_checks` stay Root-only. `TracksInfo::track_for` accepts only the `Root` and `FastUpgrade` proposal origins — `Signed(_)` is rejected (#91247/#91270), so neither track can dispatch as an arbitrary account. Operator flow: [`RUNTIME_UPGRADE_VIA_GOVERNANCE.md`](./RUNTIME_UPGRADE_VIA_GOVERNANCE.md).
 
 ## 1. Timing
 
-All periods are in blocks. `runtime/src/lib.rs:84-89`: `TARGET_BLOCK_TIME_MS = 12_000`, so `MINUTES = 5`, `HOURS = 300`, `DAYS = 7200` blocks.
+All periods are in blocks. `runtime/src/lib.rs`: `TARGET_BLOCK_TIME_MS = 12_000`, so `MINUTES = 5`, `HOURS = 300`, `DAYS = 7200` blocks.
 
-Track definition: `runtime/src/governance/definitions.rs:165-192` (`TechCollectiveTracksInfo::create_tech_collective_tracks`):
-
-```rust
-max_deciding: 1,
-decision_deposit: TECH_COLLECTIVE_DECISION_DEPOSIT,
-prepare_period: 2 * HOURS,
-decision_period: DAYS,
-confirm_period: DAYS,
-min_enactment_period: DAYS,
-```
-
-| Parameter | Current (blocks) | Wall clock | Meaning |
+| Parameter | Track 0 | Track 1 `fast_upgrade` | Meaning |
 |---|---|---|---|
-| `prepare_period` | 600 | 2 h | Delay between submission and decision start |
-| `decision_period` | 7200 (`DAYS`) | 24 h | Window in which the referendum must reach passing state |
-| `confirm_period` | 7200 (`DAYS`) | 24 h | Must remain continuously passing this long to be approved |
-| `min_enactment_period` | 7200 (`DAYS`) | 24 h | Min delay between approval and dispatch of the upgrade |
+| `prepare_period` | `2 * HOURS` (600) | `10 * MINUTES` (50) | Delay between submission and decision start |
+| `decision_period` | `DAYS` (7200) | `DAYS` (7200) | Window in which the referendum must reach passing state |
+| `confirm_period` | `DAYS` | `10 * MINUTES` | Must remain continuously passing this long to be approved |
+| `min_enactment_period` | `DAYS` | `10 * MINUTES` | Min delay between approval and dispatch |
+| `max_deciding` | 1 | 1 | Per track: one deciding referendum at a time on each lane |
+| `decision_deposit` | `TECH_COLLECTIVE_DECISION_DEPOSIT` = `scale_fee(10 * UNIT)` | same | Bond required to enter deciding |
 
-To change approval duration, edit these four fields in `definitions.rs:174-177`. Any change is a runtime upgrade: it only takes effect once shipped via this same track (the release workflow bumps `spec_version`, `runtime/src/lib.rs:76`, currently 131).
+Fastest end to end on track 1: 10 min prepare + 10 min confirm + 10 min enactment ≈ **30 minutes** after submission (plus the time to place the decision deposit and collect 8 ayes); the WASM can be applied in the block after `authorize_upgrade` executes. Track 0: 2 h + 24 h + 24 h ≈ 50 h.
 
-Test override: with the `fast-governance` cargo feature, `apply_test_timing` (`definitions.rs:87-95`) forces all four periods to 2 blocks. Production builds never compile it.
+To change a track's timing, edit its `TrackInfo` in `create_tech_collective_tracks`. Any change is itself a runtime upgrade and only takes effect once shipped through the `fast_upgrade` lane (the release workflow bumps `spec_version`, `runtime/src/lib.rs`, currently 147).
 
-Instance1 `Config` (`runtime/src/configs/mod.rs:335-377`) also uses, from `configs/mod.rs:263-264`:
+Test override: with the `fast-governance` cargo feature, `apply_test_timing` forces all four periods of **both** tracks to 2 blocks. Production builds never compile it.
 
-- `UndecidingTimeout = 45 * DAYS` (note: the comment at line 262 says "90 days" — the value is 45). If a referendum never enters deciding within this window (no decision deposit, or no free `max_deciding` slot), it is rejected as `TimedOut` (`pallet-referenda-45.0.0/src/lib.rs:1164-1177`).
+The `TechReferendaInstance` `Config` (`runtime/src/configs/mod.rs`) also sets:
+
+- `ReferendumSubmissionDeposit = scale_fee(10 * UNIT)`: submission bond, sized to stay above the maximum preimage deposit of a 64 KiB proposal so noted bytes remain collateralized after `unnote`.
+- `UndecidingTimeout = 45 * DAYS`: if a referendum never enters deciding within this window (no decision deposit, or no free `max_deciding` slot on its track), it is rejected as `TimedOut` (`pallet-referenda-45.0.0/src/lib.rs:1164-1177`).
 - `AlarmInterval = 1`: granularity of scheduler wake-ups that re-service referenda state. 1 = state transitions (begin/abort confirmation, approve, reject) can happen on any block.
 
-Both constants are shared with the community-track instance (`impl pallet_referenda::Config for Runtime`, `configs/mod.rs:267-309`; tech track is the `Config<TechReferendaInstance>` impl at 335).
-
-## 2. Thresholds for a 5-member collective
+## 2. Thresholds
 
 ### Verified tally semantics
 
@@ -48,44 +47,55 @@ fn approval(&self, _) -> Perbill { Perbill::from_rational(self.ayes, 1.max(self.
 ```
 
 - **approval** = weighted ayes / (ayes + nays) — abstainers excluded.
-- **support** = `bare_ayes` (head-count of aye voters, unweighted) / total members of the class. `get_max_voters` returns `MemberCount[MinRankOfClass]` (lib.rs:266-271); `MinRankOfClassConverter` always returns rank 0 (`definitions.rs:238-243`), so the denominator is the full membership. Nay votes do not add support; abstention counts against support.
-- **vote weight**: `type VoteWeight = Linear` (`configs/mod.rs:326`) = `excess_rank + 1` votes (lib.rs:236-241). `PromoteOrigin = NeverEnsureOrigin` (`configs/mod.rs:320`), so every member stays at rank 0 → exactly 1 vote each, and weighted `ayes == bare_ayes`.
-- **passing is inclusive**: `y >= self.threshold(x)` (`pallet-referenda-45.0.0/src/types.rs:637-639`). Therefore a threshold of exactly 60% would let 3 aye / 2 nay pass (60% ≥ 60%). `min_approval` must be strictly above 3/5.
+- **support** = `bare_ayes` (head-count of aye voters, unweighted) / total members of the class. `get_max_voters` returns `MemberCount[MinRankOfClass]` (lib.rs:266-271); `MinRankOfClassConverter` always returns rank 0 (`definitions.rs`), so the denominator is the full membership. Nay votes do not add support; abstention counts against support.
+- **vote weight**: `type VoteWeight = Linear` = `excess_rank + 1` votes (lib.rs:236-241). `PromoteOrigin = NeverEnsureOrigin`, so every member stays at rank 0 → exactly 1 vote each, and weighted `ayes == bare_ayes`.
+- **passing is inclusive**: `y >= self.threshold(x)` (`pallet-referenda-45.0.0/src/types.rs:637-639`). A threshold of exactly 60% lets 3 aye / 2 nay pass, so track 0's `min_approval` is 61%, strictly above 3/5; track 1's 80% is deliberately inclusive so that 8 ayes / 2 nays passes.
 
-### Current curves (constant; `floor == ceil` makes `LinearDecreasing` flat)
+### Curves (constant; `floor == ceil` makes `LinearDecreasing` flat)
 
-Implemented at `definitions.rs:178-187`:
+Both tracks use flat curves, so the required numbers never decay over the decision period (`fast_track_curves_pin_eight_of_ten` in `runtime/tests/governance/fast_upgrade.rs` pins this for track 1):
 
-```rust
-min_approval: pallet_referenda::Curve::LinearDecreasing {
-    length: Perbill::from_percent(100),
-    floor: Perbill::from_percent(61),   // strictly above 3/5
-    ceil: Perbill::from_percent(61),
-},
-min_support: pallet_referenda::Curve::LinearDecreasing {
-    length: Perbill::from_percent(100),
-    floor: Perbill::from_percent(60),   // 3 of 5 members must actively vote aye
-    ceil: Perbill::from_percent(60),
-},
-```
+| Track | `min_approval` | `min_support` | 10 members (staging-mainnet / mainnet: the treasury signers) | 5 members (`MIN_TECH_COLLECTIVE_MEMBERS`, dev/testnet presets) |
+|---|---|---|---|---|
+| 0 | 61% | 60% | 6 ayes; 4 nays block | 3 ayes; 2 nays block |
+| 1 `fast_upgrade` | 80% | 80% | 8 ayes; 3 nays block | 4 ayes; 2 nays block |
 
-(2/3 ≈ 66.7% for `min_approval` works identically for n=5; 61% is the loosest safe value. `Perbill::from_rational(3,5)` is exactly 600,000,000 < 610,000,000, so the comparison is exact, no rounding hazard.)
+(61% is the loosest value strictly above 3/5: `Perbill::from_rational(3,5)` is exactly 600,000,000 < 610,000,000, so the comparison is exact, no rounding hazard. 2/3 ≈ 66.7% would behave identically for n = 5 and n = 10.)
 
-### Verification, 5 members, all rank 0
+### Verification, 10 members, all rank 0
 
-| Ayes | Nays | Approval = a/(a+n) | ≥61%? | Support = ayes/5 | ≥60%? | Result |
+Track 0 (approval ≥ 61%, support ≥ 60%):
+
+| Ayes | Nays | Approval = a/(a+n) | ≥61%? | Support = ayes/10 | ≥60%? | Result |
 |---|---|---|---|---|---|---|
-| 3 | 0 | 100% | yes | 60% | yes (inclusive) | **PASS** |
-| 3 | 1 | 75% | yes | 60% | yes | **PASS** |
-| 3 | 2 | 60% | **no** | 60% | yes | **FAIL** |
-| 4 | 1 | 80% | yes | 80% | yes | **PASS** |
-| 2 | 0 | 100% | yes | 40% | **no** | **FAIL** |
+| 6 | 0 | 100% | yes | 60% | yes (inclusive) | **PASS** |
+| 6 | 3 | 66.7% | yes | 60% | yes | **PASS** |
+| 6 | 4 | 60% | **no** | 60% | yes | **FAIL** |
+| 7 | 3 | 70% | yes | 70% | yes | **PASS** |
+| 5 | 0 | 100% | yes | 50% | **no** | **FAIL** |
 
-Requirements: (a) 3/5 ayes execute ✓ (rows 1–2); (b) 2 nays block ✓ (row 3); (c) 1 bad member cannot block ✓ (row 2: passes despite 1 nay) nor push through alone (1 aye = 20% support); (d) against 1 honest nay, 3 compromised ayes fail (row 3 generalizes: 3a/2n fails, and 3a/1n passes — so blocking needs 2 honest nays; forcing through 2 honest nays needs 4 ayes, row 4) ✓.
+Track 1 (approval ≥ 80%, support ≥ 80%):
+
+| Ayes | Nays | Approval = a/(a+n) | ≥80%? | Support = ayes/10 | ≥80%? | Result |
+|---|---|---|---|---|---|---|
+| 8 | 0 | 100% | yes | 80% | yes (inclusive) | **PASS** |
+| 8 | 2 | 80% | yes (inclusive) | 80% | yes | **PASS** |
+| 9 | 1 | 90% | yes | 90% | yes | **PASS** |
+| 7 | 0 | 100% | yes | 70% | **no** | **FAIL** |
+| 7 | 3 | 70% | **no** | 70% | **no** | **FAIL** |
+
+Requirements, track 1: (a) 8/10 ayes authorize an upgrade even against both remaining nays ✓ (`eight_of_ten_authorizes_the_upgrade`); (b) 3 nays always block, since support cannot reach 80% ✓ (`seven_of_ten_is_not_enough`); (c) no minority can force one: 7 ayes fail regardless of nays ✓. Track 0: (a) 6/10 ayes execute with up to 3 nays ✓; (b) 4 nays block (6a/4n = 60% < 61%) ✓; (c) 3 compromised members cannot block (7a/3n passes) ✓.
+
+With 5 members the same math gives 3-of-5 on track 0 (3a/1n passes, 3a/2n fails, 2 ayes = 40% support fails) and 4-of-5 on track 1 (4a/1n = 80% passes, 3 ayes = 60% support fails); 2 nays block either track.
 
 ### Confirm/decision periods are security parameters
 
-A referendum must be *continuously* passing for the whole `confirm_period`; any nay that drops it below threshold aborts confirmation (`ConfirmAborted`, `pallet-referenda-45.0.0/src/lib.rs:1235-1240`) and confirmation must restart. Approval only happens at `lib.rs:1190-1208` after the confirm deadline elapses while still passing. So `confirm_period` is the honest members' reaction window: at the current 24 h, even if all ayes land in the first block, approval cannot conclude before a full day has passed — dissenting nays always have that window. Worst case (ayes arrive at the end of the decision window) approval takes up to ~48 h; if the referendum is not passing when `decision_period` ends and is not confirming, it is rejected. `prepare_period` (now 2 h, #91247-era hardening) bounds advance notice before deciding starts.
+A referendum must be *continuously* passing for the whole `confirm_period`; any nay that drops it below threshold aborts confirmation (`ConfirmAborted`, `pallet-referenda-45.0.0/src/lib.rs:1235-1240`) and confirmation must restart. Approval only happens at `lib.rs:1190-1208` after the confirm deadline elapses while still passing. So `confirm_period` is the honest members' reaction window:
+
+- **Track 0: 24 h.** Even if all ayes land in the first block of deciding, approval cannot conclude before a full day has passed; worst case (ayes arrive at the end of the decision window) approval takes up to ~48 h. `prepare_period` (2 h) bounds advance notice before deciding starts.
+- **Track 1: 10 minutes**, after a 10-minute `prepare_period`. From submission, the earliest an upgrade hash can be authorized is ~30 min, and a dissenting member must have voted nay within ~20 min to abort confirmation. This is the trade the fast lane makes: a much shorter window in exchange for a much larger quorum (8 of 10) and a dispatch that can only publish an upgrade hash. Members must expect to react within prepare + confirm, not within a day.
+
+On both tracks, if the referendum is not passing when `decision_period` (1 day) ends and is not confirming, it is rejected.
 
 ## 3. Vote changing
 
@@ -101,37 +111,47 @@ match Voting::<T, I>::get(&poll, &who) {
 Voting::<T, I>::insert(&poll, &who, &vote);
 ```
 
-The first vote on a poll is fee-free (`Pays::No`); changes pay a fee. Voting on `Completed`/missing polls fails with `NotPolling` (lib.rs:646-647). Consequence: an aye cast early can be flipped to nay during confirmation to abort it — this is what makes `confirm_period` an effective defense window.
+The first vote on a poll is fee-free (`Pays::No`); changes pay a fee. Voting on `Completed`/missing polls fails with `NotPolling` (lib.rs:646-647). Consequence: an aye cast early can be flipped to nay during confirmation to abort it — this is what makes `confirm_period` an effective defense window. On track 1 that window is the 10-minute confirm period.
 
 ## 4. Cancellation and incident response
 
-Tech track Instance1 config, `runtime/src/configs/mod.rs:348-351`:
+Tech track `Config` (`runtime/src/configs/mod.rs`):
 
 ```rust
 type CancelOrigin = EnsureRoot<AccountId>;
 type KillOrigin = EnsureRoot<AccountId>;
 ```
 
-(The community instance is identical, `configs/mod.rs:280-283`.)
-
 - `cancel` (`pallet-referenda-45.0.0/src/lib.rs:591-606`): stops an ongoing referendum, **refunds** submission + decision deposits.
-- `kill` (`lib.rs:616-630`): stops it and **slashes** both deposits (`Slash = ()` → burned, `configs/mod.rs:356`).
+- `kill` (`lib.rs:616-630`): stops it and **slashes** both deposits (`Slash = ()` → burned).
 
-Both are Root-only. Root is only reachable via a passed referendum, so cancelling a malicious tech referendum requires winning *another* referendum on the same track before the first one enacts — a chicken-and-egg problem, made worse by `max_deciding: 1` (`definitions.rs:172`): a second referendum cannot even enter deciding until the first leaves it. During an attack the practical defense is votes (2 honest nays), not cancellation. Recommendation: give `CancelOrigin` to a smaller quorum (e.g. `EnsureRoot` OR a 2-of-5 ranked-collective origin via `EitherOf<EnsureRoot<...>, EnsureRankedMember<...>>`-style construct, or a dedicated fast cancel track), keep `kill` Root-only.
+Both are Root-only, and Root is only reachable via a passed track-0 referendum (≥ 2 h prepare + 24 h confirm + 24 h enactment). That is a chicken-and-egg problem on track 0 — `max_deciding: 1` means a cancel referendum cannot even enter deciding while the malicious one holds the slot — and it is simply too slow for track 1: a fast-track referendum authorizes its hash ~30 min after submission, long before any Root cancel could enact. On both tracks the practical defense is votes — 4 honest nays on track 0 and 3 on track 1 with 10 members (2 on either track with 5 members) — cast or flipped before confirmation completes. `Origins::FastUpgrade` itself cannot cancel, kill, or change membership: the only call that honors it is `system.authorize_upgrade` (`fast_track_cannot_dispatch_arbitrary_root_calls`, `direct_authorize_upgrade_origin_checks` in `runtime/tests/governance/fast_upgrade.rs`). Recommendation, more pressing now that a 30-minute lane exists: give `CancelOrigin` to a smaller quorum (e.g. `EnsureRoot` OR a few-member ranked-collective origin via an `EitherOf<EnsureRoot<...>, EnsureRankedMember<...>>`-style construct, or a dedicated fast cancel track), keep `kill` Root-only.
 
-Member removal mid-flight: `remove_member` requires `RemoveOrigin`, which this runtime sets to `EnsureRootRemoveKeepsMemberFloor` (`governance/definitions.rs`, wired in `configs/mod.rs`) — **Root only**, and only while the removal leaves at least `MIN_TECH_COLLECTIVE_MEMBERS` members. That floor is load-bearing: shrinking below it would collapse the tech-referenda curves or (at zero members) deadlock the only governance lane. `AddOrigin` remains `EnsureRootWithSuccess<AccountId, ConstU16<0>>` (#91267). Membership changes therefore require a passed referendum: a single member can no longer unilaterally remove the others or stuff the collective up to `MaxMemberCount = 13`. (Genesis seeding bypasses the origin via `do_add_member_to_rank`, as before.)
+Once `authorize_upgrade` has executed, the remaining safeguards are in the apply step: `apply_authorized_upgrade` accepts only the exact bytes whose hash was authorized and checks the runtime version, and it is permissionless, so it can land in the very next block. `AuthorizedUpgrade` is a single storage slot — a later `authorize_upgrade` (either track) overwrites a pending one, and a successful apply clears it — but an attacker who got a hash authorized will apply immediately, so authorization must be treated as final.
+
+Member removal mid-flight: `remove_member` requires `RemoveOrigin`, which this runtime sets to `EnsureRootRemoveKeepsMemberFloor` (`governance/definitions.rs`) — **Root only**, and only while the removal leaves at least `MIN_TECH_COLLECTIVE_MEMBERS` (5, `genesis_config_presets.rs`) members. That floor is load-bearing: shrinking below it would collapse the tech-referenda curves or (at zero members) deadlock the only governance lane. `AddOrigin` remains `EnsureRootWithSuccess<AccountId, ConstU16<0>>` (#91267). Membership changes therefore require a passed track-0 referendum: a single member can no longer unilaterally remove the others or stuff the collective up to `MaxMemberCount = 13`. (Genesis seeding bypasses the origin via `do_add_member_to_rank`, as before.)
 
 Removal intentionally does not reconcile ongoing tallies — this matches upstream `pallet-ranked-collective` (eager reconciliation would be an unbounded `Voting` scan inside a scheduler-enacted dispatch). A removed member's already-cast votes keep counting until each poll ends, while the support denominator `MemberCount[0]` shrinks immediately; the tally's `support` clamps at 100%, so the distortion is bounded and expires with the poll (at most `decision_period` + `confirm_period`). Completed-poll vote records are swept permissionlessly via `cleanup_poll`.
 
-## 5. Security summary (current 5-member config: approval 61%, support 60%)
+## 5. Security summary (10-member mainnet collective)
 
-Assumes membership management stays Root-only with the member-floor `RemoveOrigin` (see §4).
+Assumes membership management stays Root-only with the member-floor `RemoveOrigin` (see §4) and every member at rank 0 (1 vote each).
 
-| Compromised members | Can block upgrades? | Can force an upgrade? |
+Track 0 — Root proposals (approval 61%, support 60%, 24 h confirm):
+
+| Compromised members | Can block? | Can force a Root call? |
 |---|---|---|
-| 1 | No (3a/1n passes) | No (support 20% < 60%) |
-| 2 | **Yes** — 2 nays hold approval ≤60% < 61% (availability risk only) | No (support 40%) |
-| 3 | Yes | **Only if** fewer than 2 honest nays land within decision + confirm window (3a/0n and 3a/1n pass; 3a/2n fails) |
-| 4 | Yes | **Yes, always** (4a/1n = 80% approval) |
+| 1–3 | No (7a/3n = 70% passes) | No (support ≤ 30% < 60%) |
+| 4–5 | **Yes** — 4 nays hold 6 ayes at 60% < 61% (availability risk only) | No (support ≤ 50%) |
+| 6 | Yes | **Only if** fewer than 4 honest nays land within decision + confirm window (6a/3n passes, 6a/4n fails) |
+| 7+ | Yes | **Yes, always** (7a/3n = 70% approval) |
 
-Design assumption: at least 2 honest members are online and able to vote nay within `decision_period + confirm_period`. That window is 24 h + 24 h: even in the fastest case (all ayes in the first block of deciding), honest members have a full 24 h confirm window to abort.
+Track 1 — upgrade-hash authorization (approval 80%, support 80%, 10 min confirm):
+
+| Compromised members | Can block an upgrade? | Can force an upgrade? |
+|---|---|---|
+| 1–2 | No (8a/2n passes) | No (support ≤ 20%) |
+| 3–7 | **Yes** — support is capped at ≤ 70% (availability risk only; fallback is a track-0 Root `authorize_upgrade`, ~2 days) | No (support ≤ 70% < 80%) |
+| 8+ | Yes | **Yes, always**: 8a/2n = 80%; the hash is authorized ~30 min after submission and the WASM can be applied permissionlessly in the next block |
+
+Design assumptions: track 0 needs 4 honest members able to vote nay within `decision_period + confirm_period` (24 h + 24 h; 2 with a 5-member collective). Track 1 needs **3 honest members able to vote nay within ~20 minutes of submission** (prepare + confirm) and stays available only while 8 members are honest and online; in exchange, fewer than 8 colluding members can never push a hash through, and even 8 can only publish an upgrade hash — never an arbitrary Root call.

--- a/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
+++ b/docs/TECH_COLLECTIVE_GOVERNANCE_TUNING.md
@@ -10,7 +10,7 @@ Track definition: `runtime/src/governance/definitions.rs:165-192` (`TechCollecti
 
 ```rust
 max_deciding: 1,
-decision_deposit: 1000 * UNIT,
+decision_deposit: TECH_COLLECTIVE_DECISION_DEPOSIT,
 prepare_period: 2 * HOURS,
 decision_period: DAYS,
 confirm_period: DAYS,

--- a/docs/TECH_REFERENDA_FEATURES.md
+++ b/docs/TECH_REFERENDA_FEATURES.md
@@ -53,8 +53,8 @@ Referenda's `Tally = pallet_ranked_collective::TallyOf<Runtime>` and
 | Call | Origin | Notes |
 |---|---|---|
 | `submit` | Root or member | Create a referendum |
-| `place_decision_deposit` / `refund_decision_deposit` | signed | 1000 UNIT decision bond |
-| `refund_submission_deposit` | signed | 100 UNIT submission bond |
+| `place_decision_deposit` / `refund_decision_deposit` | signed | 10 × `FEE_SCALE` UNIT decision bond |
+| `refund_submission_deposit` | signed | 10 × `FEE_SCALE` UNIT submission bond |
 | `nudge_referendum` | **Root** (dispatched via governance) | Force the state machine to re-evaluate now (§6) |
 | `cancel` | Root | Stop; refunds deposits |
 | `kill` | Root | Stop; slashes deposits (`Slash = ()` → burned) |
@@ -134,10 +134,11 @@ Decaying curves let a track demand high approval/support early and relax it over
 time (the OpenGov design). The track config lives in `TrackInfo`
 (`pallets/referenda/src/types.rs:189-215`).
 
-The tech track currently uses **constant** curves (`LinearDecreasing` with
-`floor == ceil`, i.e. no decay):
+Both tech tracks use **constant** curves (`LinearDecreasing` with
+`floor == ceil`, i.e. no decay): track 0 at 61% approval / 60% support, and the
+`fast_upgrade` track (id 1) at 80%/80% — 8-of-10 with the genesis collective.
 
-```111:120:runtime/src/governance/definitions.rs
+```runtime/src/governance/definitions.rs
 min_approval: pallet_referenda::Curve::LinearDecreasing {
 	length: from_percent(100), floor: from_percent(61), ceil: from_percent(61),
 },
@@ -196,8 +197,8 @@ instead of waiting for the scheduled alarm.
   opposite direction from quadratic-cost voting. There is no quadratic option.
 - **Token-based voting?** Not in this lane. Tech votes are one-member-one-vote
   (rank-weighted), independent of balances. Tokens appear only as fixed
-  *deposits* (100 UNIT submission, 1000 UNIT decision) that gate participation
-  but never weight a vote. Balance-weighted conviction voting was the separate
+  *deposits* (10 × `FEE_SCALE` UNIT submission, 10 × `FEE_SCALE` UNIT decision)
+  that gate participation but never weight a vote. Balance-weighted conviction voting was the separate
   *community lane* (`pallet-conviction-voting` + community `Referenda`), which
   has been removed, leaving this tech lane as the **sole governance lane**.
 
@@ -209,11 +210,11 @@ instead of waiting for the scheduled alarm.
 |---|---|---|
 | Vote weight | `Unit` / `Linear` / `Geometric` | `Linear` (flat → 1 vote/member; ranks dormant) |
 | Ranks | arbitrary 0..N, per-track min-rank | all rank 0, min-rank 0, changes disabled |
-| Approval curve ("unity") | Linear / Stepped / Reciprocal, time-decaying | constant **61%** |
-| Support curve ("quorum") | same three curve types | constant **60%** (head-count) |
-| `max_deciding` | configurable | 1 |
-| `prepare / decision / confirm / enactment` | per-track | 2 h / 1d / 1d / 1d |
-| Deposits | submission + decision | 100 UNIT + 1000 UNIT |
+| Approval curve ("unity") | Linear / Stepped / Reciprocal, time-decaying | constant **61%** (track 0) / **80%** (track 1) |
+| Support curve ("quorum") | same three curve types | constant **60%** (track 0) / **80%** (track 1, head-count) |
+| `max_deciding` | configurable | 1 per track |
+| `prepare / decision / confirm / enactment` | per-track | track 0: 2 h / 1d / 1d / 1d; track 1: 10 min / 1d / 10 min / 10 min |
+| Deposits | submission + decision | 10 × `FEE_SCALE` UNIT + 10 × `FEE_SCALE` UNIT |
 | Max members | `GlobalMaxMembers` | 13 |
 | Early resolution | confirm-period pass + `nudge_referendum` | enabled |
 | Cancel / kill | `CancelOrigin` / `KillOrigin` | Root only |

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,5 +1,7 @@
 use quantus_runtime::{
-	genesis_config_presets::{HEISENBERG_RUNTIME_PRESET, PLANCK_RUNTIME_PRESET},
+	genesis_config_presets::{
+		HEISENBERG_RUNTIME_PRESET, PLANCK_RUNTIME_PRESET, STAGING_MAINNET_RUNTIME_PRESET,
+	},
 	WASM_BINARY,
 };
 use sc_service::{ChainType, Properties};
@@ -69,6 +71,39 @@ pub fn heisenberg_chain_spec() -> Result<ChainSpec, String> {
 	.with_telemetry_endpoints(telemetry_endpoints)
 	.with_chain_type(ChainType::Live)
 	.with_genesis_config_preset_name(HEISENBERG_RUNTIME_PRESET)
+	.with_properties(properties)
+	.build())
+}
+
+/// Staging-mainnet — dress rehearsal for the mainnet launch.
+///
+/// Genesis is 1:1 with the eventual mainnet's (same 6-of-10 treasury multisig
+/// signers, same tech collective, same endowments); only the treasury multisig
+/// nonce differs, giving staging its own treasury account and genesis hash.
+/// Bootnodes are added once the staging infrastructure exists (the `bootNodes`
+/// field lives outside genesis, so editing it does not change the hash).
+pub fn staging_mainnet_chain_spec() -> Result<ChainSpec, String> {
+	let mut properties = Properties::new();
+	properties.insert("tokenDecimals".into(), json!(12));
+	properties.insert("tokenSymbol".into(), json!("QUAN"));
+	properties.insert("ss58Format".into(), json!(189));
+
+	let telemetry_endpoints = TelemetryEndpoints::new(vec![(
+		"/dns/shard-telemetry.quantus.cat/tcp/443/x-parity-wss/%2Fsubmit%2F".to_string(),
+		0,
+	)])
+	.expect("Telemetry endpoints config is valid; qed");
+
+	Ok(ChainSpec::builder(
+		WASM_BINARY.ok_or_else(|| "Runtime wasm not available".to_string())?,
+		None,
+	)
+	.with_name("Quantus Staging Mainnet")
+	.with_id("staging_mainnet")
+	.with_protocol_id("staging-mainnet")
+	.with_telemetry_endpoints(telemetry_endpoints)
+	.with_chain_type(ChainType::Live)
+	.with_genesis_config_preset_name(STAGING_MAINNET_RUNTIME_PRESET)
 	.with_properties(properties)
 	.build())
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -315,6 +315,11 @@ impl SubstrateCli for Cli {
 			"planck" => Box::new(chain_spec::ChainSpec::from_json_bytes(include_bytes!(
 				"chain-specs/planck.json"
 			))?) as Box<dyn sc_service::ChainSpec>,
+			// "staging_mainnet" resolves to a committed chain-specs/staging-mainnet.json
+			// (generated via scripts/genesis_generate_spec.sh) once the launch signer
+			// addresses are finalized — see docs/STAGING_MAINNET_LAUNCH.md.
+			"staging_mainnet_live_spec" => Box::new(chain_spec::staging_mainnet_chain_spec()?)
+				as Box<dyn sc_service::ChainSpec>,
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
 					as Box<dyn sc_service::ChainSpec>,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -723,6 +723,32 @@ mod tests {
 	};
 
 	#[test]
+	fn force_authoring_flag_is_parsed() {
+		use clap::Parser;
+		use sc_cli::CliConfiguration;
+
+		let with_flag =
+			crate::cli::Cli::try_parse_from(["quantus-node", "--validator", "--force-authoring"])
+				.expect("parse --force-authoring");
+		assert!(with_flag.run.force_authoring);
+		assert!(with_flag.run.force_authoring().expect("force_authoring"));
+
+		let without_flag = crate::cli::Cli::try_parse_from(["quantus-node", "--validator"])
+			.expect("parse --validator");
+		assert!(!without_flag.run.force_authoring);
+		assert!(!without_flag.run.force_authoring().expect("force_authoring"));
+	}
+
+	#[test]
+	fn dev_implies_force_authoring() {
+		use clap::Parser;
+		use sc_cli::CliConfiguration;
+
+		let cli = crate::cli::Cli::try_parse_from(["quantus-node", "--dev"]).expect("parse --dev");
+		assert!(cli.run.force_authoring().expect("force_authoring"));
+	}
+
+	#[test]
 	fn take_trimmed_secret_returns_trimmed_and_rejects_whitespace_only() {
 		let secret = take_trimmed_secret(String::from("  secret-phrase\n")).expect("non-empty");
 		assert_eq!(secret.as_str(), "secret-phrase");

--- a/pallets/frame-system/src/lib.rs
+++ b/pallets/frame-system/src/lib.rs
@@ -368,6 +368,7 @@ pub mod pallet {
 			type BaseCallFilter = frame_support::traits::Everything;
 			type BlockHashCount = TestBlockHashCount<frame_support::traits::ConstU32<10>>;
 			type OnSetCode = ();
+			type AuthorizeUpgradeOrigin = super::EnsureRoot<Self::AccountId>;
 			type SingleBlockMigrations = ();
 			type MultiBlockMigrator = ();
 			type PreInherents = ();
@@ -470,6 +471,9 @@ pub mod pallet {
 
 			/// The set code logic, just the default since we're not a parachain.
 			type OnSetCode = ();
+
+			/// Only Root may authorize a runtime upgrade by default.
+			type AuthorizeUpgradeOrigin = super::EnsureRoot<Self::AccountId>;
 			type SingleBlockMigrations = ();
 			type MultiBlockMigrator = ();
 			type PreInherents = ();
@@ -669,6 +673,11 @@ pub mod pallet {
 		#[pallet::no_default_bounds]
 		type OnSetCode: SetCode<Self>;
 
+		/// The origin permitted to call [`Call::authorize_upgrade`]. `set_code` and
+		/// `authorize_upgrade_without_checks` remain Root-only regardless of this type.
+		#[pallet::no_default_bounds]
+		type AuthorizeUpgradeOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
 		/// The maximum number of consumers allowed on a single account.
 		type MaxConsumers: ConsumerLimits;
 
@@ -861,11 +870,11 @@ pub mod pallet {
 		/// Authorize an upgrade to a given `code_hash` for the runtime. The runtime can be supplied
 		/// later.
 		///
-		/// This call requires Root origin.
+		/// This call requires `Config::AuthorizeUpgradeOrigin` (Root by default).
 		#[pallet::call_index(9)]
 		#[pallet::weight((T::SystemWeightInfo::authorize_upgrade(), DispatchClass::Operational))]
 		pub fn authorize_upgrade(origin: OriginFor<T>, code_hash: T::Hash) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AuthorizeUpgradeOrigin::ensure_origin(origin)?;
 			Self::do_authorize_upgrade(code_hash, true);
 			Ok(())
 		}

--- a/pallets/mining-rewards/src/mock.rs
+++ b/pallets/mining-rewards/src/mock.rs
@@ -43,6 +43,7 @@ impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeTask = ();

--- a/pallets/qpow/src/mock.rs
+++ b/pallets/qpow/src/mock.rs
@@ -21,6 +21,7 @@ parameter_types! {
 impl frame_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type BaseCallFilter = Everything;
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type Block = Block;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -23,6 +23,7 @@ impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeTask = ();

--- a/pallets/vesting/src/mock.rs
+++ b/pallets/vesting/src/mock.rs
@@ -59,6 +59,7 @@ impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeTask = ();

--- a/pallets/wormhole/src/mock.rs
+++ b/pallets/wormhole/src/mock.rs
@@ -38,6 +38,7 @@ parameter_types! {
 impl frame_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type BaseCallFilter = Everything;
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/zk-tree/src/tests.rs
+++ b/pallets/zk-tree/src/tests.rs
@@ -28,6 +28,7 @@ parameter_types! {
 impl frame_system::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type BaseCallFilter = Everything;
+	type AuthorizeUpgradeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -252,11 +252,11 @@ parameter_types! {
 	// deposit while the bytes stay pinned. Cap the blob so that (a) `MaxActive` × size
 	// cannot approach hundreds of MiB of deposit-free state, and (b) the preimage deposit
 	// for a max-sized blob (0.1 UNIT + 0.0001 UNIT/byte ≈ 6.6 UNIT) stays well under the
-	// 100 UNIT submission deposit, so the held bytes remain collateralized even after
+	// 10 UNIT submission deposit, so the held bytes remain collateralized even after
 	// `unnote`. 64 KiB is ample for any tech-collective call.
 	pub const MaxReferendaProposalSize: u32 = 64 * 1024;
 	// Submission deposit for referenda
-	pub const ReferendumSubmissionDeposit: Balance = scale_fee(100 * UNIT);
+	pub const ReferendumSubmissionDeposit: Balance = scale_fee(10 * UNIT);
 	// Undeciding timeout (45 days): a submitted referendum that is NOT in the track queue —
 	// e.g. one that never received a decision deposit — is rejected as TimedOut after this
 	// long. Referenda that ARE queued for deciding are exempt: the timeout check

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -25,11 +25,14 @@
 
 // Substrate and Polkadot dependencies
 use crate::{
-	governance::definitions::{
-		EnsureRootRemoveKeepsMemberFloor, GlobalMaxMembers, MinRankOfClassConverter,
-		PreimageDeposit, RootOrMemberForTechReferendaOrigin, TechCollectiveTracksInfo,
+	governance::{
+		definitions::{
+			EnsureRootRemoveKeepsMemberFloor, GlobalMaxMembers, MinRankOfClassConverter,
+			PreimageDeposit, RootOrMemberForTechReferendaOrigin, TechCollectiveTracksInfo,
+		},
+		origins::FastUpgrade,
 	},
-	MILLI_UNIT,
+	pallet_custom_origins, MILLI_UNIT,
 };
 use frame_support::{
 	derive_impl, parameter_types,
@@ -128,7 +131,13 @@ impl frame_system::Config for Runtime {
 	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 	type SS58Prefix = SS58Prefix;
 	type MaxConsumers = ConstU32<16>;
+	/// `authorize_upgrade` accepts Root (the normal tech-referenda track) or the
+	/// fast-upgrade track's `FastUpgrade` origin. `set_code` and
+	/// `authorize_upgrade_without_checks` remain Root-only.
+	type AuthorizeUpgradeOrigin = EitherOfDiverse<EnsureRoot<AccountId>, FastUpgrade>;
 }
+
+impl pallet_custom_origins::Config for Runtime {}
 
 parameter_types! {
 	pub const MiningUnit: Balance = UNIT;

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -76,9 +76,25 @@ const fn days_ms(days: u64) -> VestingMoment {
 	days * MILLIS_PER_DAY
 }
 
+const fn minutes_ms(minutes: u64) -> VestingMoment {
+	minutes * 60 * 1_000
+}
+
+/// Midnight UTC of a Gregorian date (year >= 1970) as milliseconds since the Unix
+/// epoch, so every vesting epoch below is written as the date it documents and
+/// cannot drift from it. Days-from-civil, per Howard Hinnant's `chrono` algorithm.
+const fn utc_midnight_ms(year: u64, month: u64, day: u64) -> VestingMoment {
+	let y = if month <= 2 { year - 1 } else { year };
+	let era = y / 400;
+	let yoe = y - era * 400;
+	let doy = (153 * ((month + 9) % 12) + 2) / 5 + day - 1;
+	let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+	(era * 146_097 + doe - 719_468) * MILLIS_PER_DAY
+}
+
 /// Genesis vesting starts at this wall-clock time: **2026-08-05 00:00:00 UTC**.
 /// Re-derive this (midnight UTC of the intended start date) before any real launch.
-const GENESIS_VESTING_START_MS: VestingMoment = 1_785_888_000_000;
+const GENESIS_VESTING_START_MS: VestingMoment = utc_midnight_ms(2026, 8, 5);
 /// Testnet example cliff: 90 days after start.
 const GENESIS_VESTING_CLIFF_MS: VestingMoment = GENESIS_VESTING_START_MS + days_ms(90);
 /// Testnet example vesting end: 1 year after start.
@@ -96,6 +112,15 @@ pub const HEISENBERG_RUNTIME_PRESET: &str = "heisenberg";
 
 /// Identifier for the planck runtime preset.
 pub const PLANCK_RUNTIME_PRESET: &str = "planck";
+
+/// Identifier for the staging-mainnet runtime preset.
+///
+/// Staging-mainnet is the mainnet dress rehearsal: its genesis is produced by
+/// [`mainnet_config_genesis`], the same function the eventual mainnet preset
+/// will use, differing only in the treasury multisig nonce
+/// ([`STAGING_MAINNET_TREASURY_MULTISIG_NONCE`]) so the two chains get
+/// distinct treasury accounts and therefore distinct genesis hashes.
+pub const STAGING_MAINNET_RUNTIME_PRESET: &str = "staging_mainnet";
 
 /// SS58 address format used by all Quantus chains.
 fn ss58_version() -> sp_core::crypto::Ss58AddressFormat {
@@ -597,12 +622,222 @@ pub fn planck_config_genesis() -> Value {
 	genesis_template(endowed_accounts, treasury, tech_collective, signer_fee_seed, vec![])
 }
 
+/// The ten mainnet treasury multisig signers, also seeded as the mainnet tech
+/// collective. Staging-mainnet uses the exact same accounts.
+///
+/// Spec building panics while any placeholder remains, and the preset is
+/// skipped in tests until then. Signer order does not matter: multisig address
+/// derivation sorts internally.
+const MAINNET_TREASURY_SIGNERS_SS58: [&str; 10] = [
+	"qznoXy8q1BgD4jka7wGHMgPtEw63Ut8gvLv9b6x1GvavmCgi1",
+	"qzq8U3GsQraM2pofq9zHbrBvByczzCHrYXphPwdPf2cq9Q55r",
+	"qzkCCKgT3r4PekyzFAP6MB9mmmCtPZj1tT56CZiECNq38L24z",
+	"qzkW57Kq9T2b2PJ7Ph5NEAWqRqVR5KBGtECc7ztcf6Fks1ds6",
+	"qzn4x6gecYuuGSEeEHJh7QCr3gcN5kmrSnDW7BNW1zuaiodPR",
+	"qzpMehumJ9qBj2d7Yof1dGbwzeABGbhKu8hFuBLwNmyas6Q4w",
+	"qznDNghWXmnXKnujNAHK9YPVV1peBcusMgAZbbUZkH7uCDyNe",
+	"qzkZQi63WoaYjkjb8VjqswVChjj3Yr4BEpek5V2QuVL61FXCa",
+	"qzkuV7zpYtXVU5YzkoQuNMHCDPXiryZKiKE6KrRbwccuoGdPF",
+	"qzob8fLUV7xUE8EjXpGsy3JHtxYdCUXhgYh9GhPCTpys1LttF",
+];
+
+/// Approvals required on the mainnet (and staging-mainnet) treasury multisig.
+const MAINNET_TREASURY_MULTISIG_THRESHOLD: u32 = 6;
+
+/// Multisig nonce for the staging-mainnet treasury. The eventual mainnet
+/// treasury uses the same signers and threshold with nonce 0; the different
+/// nonce yields a different derived treasury account and therefore a different
+/// genesis hash — the only intended state difference between the two chains.
+const STAGING_MAINNET_TREASURY_MULTISIG_NONCE: u64 = 1;
+
+/// Placeholder TGE timestamp for the mainnet vesting table: **2026-12-01 00:00:00 UTC**.
+/// DUMMY — re-derive as midnight UTC of the real launch date.
+const MAINNET_VESTING_START_MS: VestingMoment = utc_midnight_ms(2026, 12, 1);
+
+/// Flip to `true` only when [`mainnet_vesting_schedules`] holds the final mainnet
+/// allocation table. While `false`, [`mainnet_config_genesis`] refuses to build
+/// any preset except staging-mainnet (the dress rehearsal may ship dummies).
+const MAINNET_VESTING_FINALIZED: bool = false;
+
+/// HD indexes 0..=19 of the staging rehearsal wallet
+/// (`m/44'/189189'/{i}'/0'/0'`, ML-DSA-87). Dummy grants so those keys can
+/// exercise claim on staging-mainnet; replace each amount with the real
+/// allocation before flipping [`MAINNET_VESTING_FINALIZED`].
+const STAGING_REHEARSAL_VESTING: [(&str, u128); 20] = [
+	("qznAAg1Mxu9cmFyxdqi9yTFHm8ycaHfgWbL71z3QHraFAqJCP", 400 * UNIT), // staging-0
+	("qznwThCk3UNZNQNGtz93D3KQi9aQRfnZbsA7AmbhzLTP1cUWK", 1_000 * UNIT), // staging-1
+	("qznTih513uSHqqWHXSQxDbPrnCvMZ4nVYvPqGiABEwnk6Ponf", 2_500 * UNIT), // staging-2
+	("qzq22NnFZGLYp7hfbrSirczEK4pnQVnCdz3awVVQHNttb8QjA", 800 * UNIT), // staging-3
+	("qzmdgmNDo9KvteNsmUsdiUfEnHD7UF1pyCkjBYszDwksHZG26", 15_000 * UNIT), // staging-4
+	("qzk4KpxLG5nxuQ8FDaGtkpykmWr1aNSyGcLJt6u5XJzirhCMF", 600 * UNIT), // staging-5
+	("qznFo5RNzZpnSqVPupfdf7hJ1gQcCszKSg23VQFoafK2ELUJE", 5_000 * UNIT), // staging-6
+	("qzk5TFfu1Ho9mCFxxDWTYvYhaRqbvSihTcCz93Xx4bY4SpTjH", 12_000 * UNIT), // staging-7
+	("qzkVJZyvPi2s2kv1S8W1zxFySKVRNEnAiQ8HaGCRWdxpb6PPD", 3_000 * UNIT), // staging-8
+	("qzmU6CAqZKx5Fu5S4Hq45UeR8xLFZRfqpqDg1QwUb7gvaZn14", 10_000 * UNIT), // staging-9
+	("qzjddxfxWzvR1DoFVqEaXzPkER6cwC7EgFSMi24oKUCpduRsr", 2_000 * UNIT), // staging-10
+	("qzkgvQv22Q3sZWC4sxk7rzAF76kwchnhCdEZrhAZ1r2TbNnHY", 7_000 * UNIT), // staging-11
+	("qzjd5MS1GSCpXLYp8DjZASifnkgtUpx5WwhmEzW3ppHdDe3uq", 3_500 * UNIT), // staging-12
+	("qzjWJCQtKsXL6kwTdBH21sPqp6RrXy9zNChjh4zLTcjvZi4YA", 9_000 * UNIT), // staging-13
+	("qzkjDVS4pZrRM2nxdVVbPDiVJwaBepWULHJa8SGHEEQHiQf7y", 1_500 * UNIT), // staging-14
+	("qzoAfKAW3x7JyfTDVjYD6uocxuM73DpBgZzRQEMm4RvjiChE3", 8_000 * UNIT), // staging-15
+	("qzoMF7cRmEPuwGp1MeNP6npaaHfgyGaoWpKPSqMBj7qDq1Pkb", 5_500 * UNIT), // staging-16
+	("qzp9KrTrEJAu2kYGnRFiStg5h3hXXpoL6eVnnZYJaskuYhzkD", 6_000 * UNIT), // staging-17
+	("qzpz6P9kHM6USaaZzSiRCLgZQtdBmrKzpU54utjhg2QAmm1Zz", 3_200 * UNIT), // staging-18
+	("qznhDdGC8aRrHLHBGt99eHaLkGYwnRZxqNJ8yi4VTPqz9wfDo", 4_000 * UNIT), // staging-19
+];
+
+/// Staging rehearsal vest clock: **2026-08-22 00:00:00 UTC**, 5-minute cliff,
+/// fully vested after 10 days. Independent of the dummy mainnet TGE so these
+/// keys can be exercised on the dress-rehearsal chain.
+const STAGING_REHEARSAL_VESTING_START_MS: VestingMoment = utc_midnight_ms(2026, 8, 22);
+const STAGING_REHEARSAL_VESTING_CLIFF_MS: VestingMoment =
+	STAGING_REHEARSAL_VESTING_START_MS + minutes_ms(5);
+const STAGING_REHEARSAL_VESTING_END_MS: VestingMoment =
+	STAGING_REHEARSAL_VESTING_START_MS + days_ms(10);
+
+/// Liquid genesis endowment so rehearsal accounts can pay fees.
+const STAGING_REHEARSAL_LIQUID: u128 = UNIT;
+
+fn staging_rehearsal_accounts() -> Vec<AccountId> {
+	let accounts: Vec<AccountId> =
+		STAGING_REHEARSAL_VESTING.iter().map(|(s, _)| account_from_ss58(s)).collect();
+	let mut deduped = accounts.clone();
+	deduped.sort();
+	deduped.dedup();
+	assert_eq!(
+		deduped.len(),
+		accounts.len(),
+		"staging rehearsal vesting accounts must be distinct"
+	);
+	accounts
+}
+
+fn staging_rehearsal_liquid_seed() -> Vec<(AccountId, u128)> {
+	staging_rehearsal_accounts()
+		.into_iter()
+		.map(|who| (who, STAGING_REHEARSAL_LIQUID))
+		.collect()
+}
+
+fn staging_rehearsal_vesting_schedules() -> Vec<VestingScheduleTuple> {
+	STAGING_REHEARSAL_VESTING
+		.iter()
+		.map(|(ss58, total)| {
+			(
+				account_from_ss58(ss58),
+				STAGING_REHEARSAL_VESTING_START_MS,
+				STAGING_REHEARSAL_VESTING_CLIFF_MS,
+				STAGING_REHEARSAL_VESTING_END_MS,
+				*total,
+			)
+		})
+		.collect()
+}
+
+/// Mainnet vesting allocation table, shared with staging-mainnet.
+///
+/// DUMMY scaffold: the category shape (cliff / duration) approximates the launch
+/// plan, but the beneficiaries are stand-ins (treasury signers T1/T2 and the
+/// treasury itself) plus the staging rehearsal HD accounts, and the amounts are
+/// placeholders. Replace every entry with the real allocation and flip
+/// [`MAINNET_VESTING_FINALIZED`] before adding the mainnet preset.
+fn mainnet_vesting_schedules(treasury_account: &AccountId) -> Vec<VestingScheduleTuple> {
+	let signers = mainnet_treasury_signers();
+	let start = MAINNET_VESTING_START_MS;
+	let mut schedules = vec![
+		// DUMMY team allocation — 12-month cliff, 4-year linear vest.
+		(
+			signers[0].clone(),
+			start,
+			start + days_ms(365),
+			start + days_ms(4 * 365),
+			1_500_000 * UNIT,
+		),
+		// DUMMY early-backer allocation — 6-month cliff, 2-year linear vest.
+		(
+			signers[1].clone(),
+			start,
+			start + days_ms(180),
+			start + days_ms(2 * 365),
+			1_000_000 * UNIT,
+		),
+		// DUMMY ecosystem reserve — no cliff, 4-year linear vest into the treasury.
+		(treasury_account.clone(), start, start, start + days_ms(4 * 365), 500_000 * UNIT),
+	];
+	schedules.extend(staging_rehearsal_vesting_schedules());
+	schedules
+}
+
+/// True once every entry of [`MAINNET_TREASURY_SIGNERS_SS58`] has been
+/// replaced with a real address.
+fn mainnet_signers_finalized() -> bool {
+	MAINNET_TREASURY_SIGNERS_SS58
+		.iter()
+		.all(|s| !s.starts_with("REPLACE_WITH_SIGNER"))
+}
+
+fn mainnet_treasury_signers() -> Vec<AccountId> {
+	assert!(
+		mainnet_signers_finalized(),
+		"mainnet treasury signers are placeholders — fill MAINNET_TREASURY_SIGNERS_SS58 \
+		 with the real launch addresses before building this chain spec"
+	);
+	let signers: Vec<AccountId> =
+		MAINNET_TREASURY_SIGNERS_SS58.iter().map(|s| account_from_ss58(s)).collect();
+	let mut deduped = signers.clone();
+	deduped.sort();
+	deduped.dedup();
+	assert_eq!(deduped.len(), signers.len(), "mainnet treasury signers must be distinct");
+	signers
+}
+
+/// Genesis shared 1:1 between mainnet and staging-mainnet: the 6-of-10
+/// treasury multisig, a tech collective of the same ten accounts, and the
+/// [`mainnet_vesting_schedules`] allocation table. Final mainnet allocations
+/// belong in here so staging inherits them unchanged; only `treasury_nonce`
+/// may differ between the two presets.
+fn mainnet_config_genesis(preset: &str, treasury_nonce: u64) -> Value {
+	assert!(
+		MAINNET_VESTING_FINALIZED || preset == STAGING_MAINNET_RUNTIME_PRESET,
+		"mainnet vesting table still holds dummy entries — finalize mainnet_vesting_schedules() \
+		 and flip MAINNET_VESTING_FINALIZED before building this chain spec"
+	);
+	let treasury_signers = mainnet_treasury_signers();
+	let tech_collective = treasury_signers.clone();
+	let treasury_account = Multisig::<crate::Runtime>::derive_multisig_address(
+		&treasury_signers,
+		MAINNET_TREASURY_MULTISIG_THRESHOLD,
+		treasury_nonce,
+	);
+	let signer_seed = governance_treasury_signer_seed(treasury_signers.len() as u32);
+	let mut extra_balances: Vec<_> =
+		treasury_signers.iter().cloned().map(|a| (a, signer_seed)).collect();
+	extra_balances.extend(staging_rehearsal_liquid_seed());
+	let rehearsal_accounts = staging_rehearsal_accounts();
+	log_genesis_accounts(
+		preset,
+		&rehearsal_accounts,
+		&treasury_account,
+		&treasury_signers,
+		&tech_collective,
+	);
+	let vesting_schedules = mainnet_vesting_schedules(&treasury_account);
+	log_vesting_schedules(preset, &vesting_schedules);
+	let treasury = TreasuryGenesis { account: treasury_account };
+	genesis_template(vec![], treasury, tech_collective, extra_balances, vesting_schedules)
+}
+
+pub fn staging_mainnet_config_genesis() -> Value {
+	mainnet_config_genesis(STAGING_MAINNET_RUNTIME_PRESET, STAGING_MAINNET_TREASURY_MULTISIG_NONCE)
+}
+
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => development_config_genesis(),
 		HEISENBERG_RUNTIME_PRESET => heisenberg_config_genesis(),
 		PLANCK_RUNTIME_PRESET => planck_config_genesis(),
+		STAGING_MAINNET_RUNTIME_PRESET => staging_mainnet_config_genesis(),
 		_ => return None,
 	};
 	Some(
@@ -624,6 +859,7 @@ pub fn preset_names() -> Vec<PresetId> {
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(HEISENBERG_RUNTIME_PRESET),
 		PresetId::from(PLANCK_RUNTIME_PRESET),
+		PresetId::from(STAGING_MAINNET_RUNTIME_PRESET),
 	]
 }
 
@@ -651,6 +887,26 @@ mod tests {
 		] {
 			assert!(seed.len() >= MIN_TECH_COLLECTIVE_MEMBERS);
 		}
+		// Staging-mainnet's collective is the signer table itself.
+		assert!(MAINNET_TREASURY_SIGNERS_SS58.len() >= MIN_TECH_COLLECTIVE_MEMBERS);
+	}
+
+	/// While the signer table still holds placeholders, staging-mainnet spec building
+	/// must fail loudly; once the real launch addresses land, the preset must build and
+	/// seed all ten signers as the tech collective.
+	#[test]
+	fn staging_mainnet_gates_on_real_signers() {
+		if mainnet_signers_finalized() {
+			let raw =
+				get_preset(&PresetId::from(STAGING_MAINNET_RUNTIME_PRESET)).expect("preset exists");
+			let (_, members) = prepare_genesis_build_input(raw).expect("well-formed");
+			assert_eq!(
+				members.expect("tech collective must be seeded").len(),
+				MAINNET_TREASURY_SIGNERS_SS58.len()
+			);
+		} else {
+			assert!(std::panic::catch_unwind(mainnet_treasury_signers).is_err());
+		}
 	}
 
 	/// 2020-01-01 and 2100-01-01 UTC, sanity bounds for genesis vesting dates.
@@ -664,13 +920,43 @@ mod tests {
 	}
 
 	#[test]
+	fn minutes_ms_is_exact() {
+		assert_eq!(minutes_ms(5), 300_000);
+	}
+
+	#[test]
+	fn utc_midnight_ms_matches_known_epochs() {
+		assert_eq!(utc_midnight_ms(1970, 1, 1), 0);
+		assert_eq!(utc_midnight_ms(2000, 3, 1), 951_868_800_000);
+		assert_eq!(utc_midnight_ms(2024, 2, 29), 1_709_164_800_000);
+		// Each documented vesting epoch, pinned to its independently derived value.
+		assert_eq!(GENESIS_VESTING_START_MS, 1_785_888_000_000); // 2026-08-05 UTC
+		assert_eq!(STAGING_REHEARSAL_VESTING_START_MS, 1_787_356_800_000); // 2026-08-22 UTC
+		assert_eq!(MAINNET_VESTING_START_MS, 1_796_083_200_000); // 2026-12-01 UTC
+	}
+
+	#[test]
 	fn genesis_vesting_times_are_sane() {
-		assert_eq!(GENESIS_VESTING_START_MS % MILLIS_PER_DAY, 0, "start must be midnight UTC");
-		assert!(GENESIS_VESTING_START_MS > YEAR_2020_MS);
-		assert!(GENESIS_VESTING_START_MS < YEAR_2100_MS);
+		for start in
+			[GENESIS_VESTING_START_MS, MAINNET_VESTING_START_MS, STAGING_REHEARSAL_VESTING_START_MS]
+		{
+			assert_eq!(start % MILLIS_PER_DAY, 0, "start must be midnight UTC");
+			assert!(start > YEAR_2020_MS);
+			assert!(start < YEAR_2100_MS);
+		}
 		assert!(GENESIS_VESTING_START_MS <= GENESIS_VESTING_CLIFF_MS);
 		assert!(GENESIS_VESTING_CLIFF_MS <= GENESIS_VESTING_END_MS);
 		assert!(GENESIS_VESTING_START_MS < GENESIS_VESTING_END_MS);
+		assert_eq!(
+			STAGING_REHEARSAL_VESTING_CLIFF_MS,
+			STAGING_REHEARSAL_VESTING_START_MS + minutes_ms(5)
+		);
+		assert_eq!(
+			STAGING_REHEARSAL_VESTING_END_MS,
+			STAGING_REHEARSAL_VESTING_START_MS + days_ms(10)
+		);
+		assert!(STAGING_REHEARSAL_VESTING_START_MS <= STAGING_REHEARSAL_VESTING_CLIFF_MS);
+		assert!(STAGING_REHEARSAL_VESTING_CLIFF_MS < STAGING_REHEARSAL_VESTING_END_MS);
 	}
 
 	/// Every shipped preset must build genesis storage, including the vesting pallet's
@@ -679,6 +965,13 @@ mod tests {
 	#[test]
 	fn all_presets_build_genesis_storage() {
 		for id in preset_names() {
+			// Staging-mainnet intentionally panics on its placeholder signer table
+			// until the real launch addresses are filled in.
+			if AsRef::<str>::as_ref(&id) == STAGING_MAINNET_RUNTIME_PRESET &&
+				!mainnet_signers_finalized()
+			{
+				continue;
+			}
 			let bytes = get_preset(&id).expect("listed preset must resolve");
 			let (config_bytes, _members) = prepare_genesis_build_input(bytes)
 				.unwrap_or_else(|e| panic!("preset {:?}: invalid genesis JSON: {e}", id));
@@ -721,13 +1014,16 @@ mod tests {
 	/// validity (`start <= cliff < end`).
 	#[test]
 	fn preset_vesting_schedules_enforce_the_published_cliff() {
-		let expected: &[(&str, usize)] = &[
+		let mut expected: Vec<(&str, usize)> = vec![
 			(sp_genesis_builder::DEV_RUNTIME_PRESET, 4),
 			(HEISENBERG_RUNTIME_PRESET, 3),
 			(PLANCK_RUNTIME_PRESET, 0),
 		];
+		if mainnet_signers_finalized() {
+			expected.push((STAGING_MAINNET_RUNTIME_PRESET, 3 + STAGING_REHEARSAL_VESTING.len()));
+		}
 		let mut total = 0usize;
-		for &(name, expected_count) in expected {
+		for &(name, expected_count) in &expected {
 			let id = PresetId::from(name);
 			let raw = get_preset(&id).expect("listed preset must resolve");
 			let (json, _) = prepare_genesis_build_input(raw).expect("well-formed");
@@ -753,6 +1049,67 @@ mod tests {
 			}
 			total += config.vesting.schedules.len();
 		}
-		assert_eq!(total, 7, "dev (4) + heisenberg (3) + planck (0) must sum to 7");
+		let expected_total: usize = expected.iter().map(|(_, count)| count).sum();
+		assert_eq!(
+			total, expected_total,
+			"per-preset vesting schedule counts must sum to the pinned total"
+		);
+	}
+
+	#[test]
+	fn staging_mainnet_includes_rehearsal_vesting_accounts() {
+		assert!(
+			mainnet_signers_finalized(),
+			"staging-mainnet preset is gated on real treasury signers"
+		);
+		let raw =
+			get_preset(&PresetId::from(STAGING_MAINNET_RUNTIME_PRESET)).expect("preset exists");
+		let (json, _) = prepare_genesis_build_input(raw).expect("well-formed");
+		let config: RuntimeGenesisConfig = serde_json::from_slice(&json).expect("deserializes");
+		let mut totals = Vec::with_capacity(STAGING_REHEARSAL_VESTING.len());
+		for (ss58, total) in STAGING_REHEARSAL_VESTING {
+			let who = account_from_ss58(ss58);
+			let hit = config.vesting.schedules.iter().find(|(b, _, _, _, _)| *b == who);
+			let (_, got_start, got_cliff, got_end, got_total) =
+				hit.unwrap_or_else(|| panic!("missing rehearsal schedule for {ss58}"));
+			assert_eq!(*got_start, STAGING_REHEARSAL_VESTING_START_MS, "{ss58}");
+			assert_eq!(*got_cliff, STAGING_REHEARSAL_VESTING_CLIFF_MS, "{ss58}");
+			assert_eq!(*got_end, STAGING_REHEARSAL_VESTING_END_MS, "{ss58}");
+			assert_eq!(*got_total, total, "{ss58}");
+			totals.push(*got_total);
+			let liquid = config
+				.balances
+				.balances
+				.iter()
+				.find(|(b, _)| *b == who)
+				.map(|(_, amount)| *amount)
+				.unwrap_or_else(|| panic!("missing liquid endowment for {ss58}"));
+			assert_eq!(liquid, STAGING_REHEARSAL_LIQUID, "{ss58}");
+		}
+		let mut distinct = totals.clone();
+		distinct.sort();
+		distinct.dedup();
+		assert_eq!(distinct.len(), totals.len(), "rehearsal vesting amounts must be distinct");
+		assert_eq!(totals.iter().sum::<u128>(), 100_000 * UNIT);
+	}
+
+	#[test]
+	fn staging_mainnet_funds_each_signer_for_governance() {
+		let raw =
+			get_preset(&PresetId::from(STAGING_MAINNET_RUNTIME_PRESET)).expect("preset exists");
+		let (json, _) = prepare_genesis_build_input(raw).expect("well-formed");
+		let config: RuntimeGenesisConfig = serde_json::from_slice(&json).expect("deserializes");
+		let signers = mainnet_treasury_signers();
+		let expected = governance_treasury_signer_seed(signers.len() as u32);
+		for signer in signers {
+			let balance = config
+				.balances
+				.balances
+				.iter()
+				.find(|(account, _)| account == &signer)
+				.map(|(_, amount)| *amount)
+				.expect("mainnet signer must have a genesis balance");
+			assert_eq!(balance, expected);
+		}
 	}
 }

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -561,6 +561,21 @@ pub fn treasury_signer_seed(signers_count: u32) -> crate::Balance {
 		crate::scale_fee(100 * crate::MILLI_UNIT)
 }
 
+pub fn governance_treasury_signer_seed(signers_count: u32) -> crate::Balance {
+	use crate::{
+		configs::{MaxReferendaProposalSize, ReferendumSubmissionDeposit},
+		governance::definitions::{preimage_amount, TECH_COLLECTIVE_DECISION_DEPOSIT},
+	};
+	use frame_support::traits::Footprint;
+	let max_preimage_deposit =
+		preimage_amount(Footprint { count: 1, size: u64::from(MaxReferendaProposalSize::get()) });
+	treasury_signer_seed(signers_count)
+		.saturating_add(ReferendumSubmissionDeposit::get())
+		.saturating_add(TECH_COLLECTIVE_DECISION_DEPOSIT)
+		.saturating_add(max_preimage_deposit)
+		.saturating_add(crate::scale_fee(UNIT))
+}
+
 pub fn planck_config_genesis() -> Value {
 	let treasury_signers = planck_treasury_signers();
 	let tech_collective = planck_tech_collective_seed();

--- a/runtime/src/governance/definitions.rs
+++ b/runtime/src/governance/definitions.rs
@@ -95,7 +95,7 @@ pub struct TechCollectiveTracksInfo;
 
 /// Track for [`CustomOrigin::FastUpgrade`] proposals.
 pub const FAST_UPGRADE_TRACK_ID: u16 = 1;
-pub const TECH_COLLECTIVE_DECISION_DEPOSIT: Balance = scale_fee(1000 * UNIT);
+pub const TECH_COLLECTIVE_DECISION_DEPOSIT: Balance = scale_fee(10 * UNIT);
 
 impl TechCollectiveTracksInfo {
 	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 2] {

--- a/runtime/src/governance/definitions.rs
+++ b/runtime/src/governance/definitions.rs
@@ -1,5 +1,6 @@
 use crate::{
-	scale_fee, AccountId, Balance, Balances, BlockNumber, Runtime, RuntimeOrigin, DAYS, HOURS, UNIT,
+	governance::origins::Origin as CustomOrigin, scale_fee, AccountId, Balance, Balances,
+	BlockNumber, OriginCaller, Runtime, RuntimeOrigin, DAYS, HOURS, MINUTES, UNIT,
 };
 use alloc::borrow::Cow;
 use codec::{Decode, Encode, MaxEncodedLen};
@@ -92,8 +93,12 @@ fn apply_test_timing(
 // tech-collective lane below is the sole governance lane (runtime upgrades + other Root calls).
 pub struct TechCollectiveTracksInfo;
 
+/// Track for [`CustomOrigin::FastUpgrade`] proposals.
+pub const FAST_UPGRADE_TRACK_ID: u16 = 1;
+pub const TECH_COLLECTIVE_DECISION_DEPOSIT: Balance = scale_fee(1000 * UNIT);
+
 impl TechCollectiveTracksInfo {
-	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] {
+	fn create_tech_collective_tracks() -> [pallet_referenda::Track<u16, Balance, BlockNumber>; 2] {
 		// With 5 members: >=3 ayes required (support 60%), and 2 nays always block
 		// (3 ayes / 2 nays = 60% approval < 61%). Constant curves: thresholds don't
 		// decay over the decision period. The 24h confirm period guarantees nays can
@@ -107,7 +112,7 @@ impl TechCollectiveTracksInfo {
 		let info = pallet_referenda::TrackInfo {
 			name: str_array("tech_collective_members"),
 			max_deciding: 1,
-			decision_deposit: scale_fee(1000 * UNIT),
+			decision_deposit: TECH_COLLECTIVE_DECISION_DEPOSIT,
 			// Advance-notice window before deciding starts. Raised from 4 min to give the
 			// collective (and observers) visibility of a pending Root proposal before voting can
 			// conclude.
@@ -128,7 +133,42 @@ impl TechCollectiveTracksInfo {
 		};
 		#[cfg(feature = "fast-governance")]
 		let info = apply_test_timing(info);
-		[pallet_referenda::Track { id: 0, info }]
+
+		// Emergency runtime-upgrade lane, modeled on Polkadot's Whitelisted Caller
+		// track (10-minute confirm + 10-minute enactment vs a full day each on the
+		// normal lane). Proposals dispatch with `CustomOrigin::FastUpgrade`, which is
+		// honored only by `system.authorize_upgrade` — never arbitrary Root — so the
+		// short windows cannot be leveraged for anything but publishing an upgrade
+		// hash (the wasm itself is applied permissionlessly and version-checked).
+		// The 80%/80% constant curves require 8-of-10 ayes from the genesis
+		// collective (support counts all members, so 8 ayes are needed regardless of
+		// nays; approval at exactly 8 ayes / 2 nays is 80% and still passes).
+		let fast_upgrade = pallet_referenda::TrackInfo {
+			name: str_array("fast_upgrade"),
+			max_deciding: 1,
+			decision_deposit: TECH_COLLECTIVE_DECISION_DEPOSIT,
+			prepare_period: 10 * MINUTES,
+			decision_period: DAYS,
+			confirm_period: 10 * MINUTES,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(80),
+				ceil: Perbill::from_percent(80),
+			},
+			min_support: pallet_referenda::Curve::LinearDecreasing {
+				length: Perbill::from_percent(100),
+				floor: Perbill::from_percent(80),
+				ceil: Perbill::from_percent(80),
+			},
+		};
+		#[cfg(feature = "fast-governance")]
+		let fast_upgrade = apply_test_timing(fast_upgrade);
+
+		[
+			pallet_referenda::Track { id: 0, info },
+			pallet_referenda::Track { id: FAST_UPGRADE_TRACK_ID, info: fast_upgrade },
+		]
 	}
 }
 
@@ -140,21 +180,24 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TechCollectiveTracks
 	) -> impl Iterator<Item = Cow<'static, pallet_referenda::Track<Self::Id, Balance, BlockNumber>>>
 	{
 		lazy_static! {
-			static ref TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 1] =
+			static ref TRACKS: [pallet_referenda::Track<u16, Balance, BlockNumber>; 2] =
 				TechCollectiveTracksInfo::create_tech_collective_tracks();
 		}
 		TRACKS.iter().map(Cow::Borrowed)
 	}
 
 	fn track_for(id: &Self::RuntimeOrigin) -> Result<Self::Id, ()> {
-		// #91247/#91270: only a `Root` proposal origin is accepted. A referendum's
-		// `proposal_origin` is stored and dispatched verbatim on approval, so accepting
-		// `Signed(_)` here would let a passed referendum execute calls as an arbitrary account
-		// (impersonation) and route Root- level dispatch through this single low-threshold track.
-		// The tech lane exists solely to authorize Root governance (e.g. runtime upgrades);
-		// members submit via `SubmitOrigin`.
-		match id.as_system_ref() {
-			Some(frame_system::RawOrigin::Root) => Ok(0),
+		// #91247/#91270: only the `Root` and `FastUpgrade` proposal origins are accepted. A
+		// referendum's `proposal_origin` is stored and dispatched verbatim on approval, so
+		// accepting `Signed(_)` here would let a passed referendum execute calls as an
+		// arbitrary account (impersonation) and route Root-level dispatch through a
+		// low-threshold track. The tech lane exists solely to authorize Root governance
+		// (e.g. runtime upgrades); members submit via `SubmitOrigin`.
+		if let Some(frame_system::RawOrigin::Root) = id.as_system_ref() {
+			return Ok(0);
+		}
+		match id {
+			OriginCaller::Origins(CustomOrigin::FastUpgrade) => Ok(FAST_UPGRADE_TRACK_ID),
 			_ => Err(()),
 		}
 	}

--- a/runtime/src/governance/mod.rs
+++ b/runtime/src/governance/mod.rs
@@ -1,1 +1,2 @@
 pub mod definitions;
+pub mod origins;

--- a/runtime/src/governance/origins.rs
+++ b/runtime/src/governance/origins.rs
@@ -1,0 +1,46 @@
+//! Custom governance origins, dispatched by passed tech referenda on
+//! dedicated tracks (see `definitions::TechCollectiveTracksInfo`).
+
+// The `#[frame_support::pallet]` macro generates `expect()` calls (PalletInfo lookups).
+#![allow(clippy::expect_used)]
+
+pub use pallet_custom_origins::*;
+
+#[frame_support::pallet]
+pub mod pallet_custom_origins {
+	use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[derive(
+		PartialEq, Eq, Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
+	)]
+	#[pallet::origin]
+	pub enum Origin {
+		/// Dispatched by an approved referendum on the fast-upgrade track; may only
+		/// authorize a runtime upgrade (`system.authorize_upgrade`), never arbitrary
+		/// Root calls.
+		FastUpgrade,
+	}
+
+	/// `EnsureOrigin` accepting only [`Origin::FastUpgrade`].
+	pub struct FastUpgrade;
+
+	impl<O: Into<Result<Origin, O>> + From<Origin>> EnsureOrigin<O> for FastUpgrade {
+		type Success = ();
+
+		fn try_origin(o: O) -> Result<Self::Success, O> {
+			o.into().map(|Origin::FastUpgrade| ())
+		}
+
+		#[cfg(feature = "runtime-benchmarks")]
+		fn try_successful_origin() -> Result<O, ()> {
+			Ok(O::from(Origin::FastUpgrade))
+		}
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,6 +35,8 @@ pub mod genesis_config_presets;
 pub mod governance;
 pub mod transaction_extensions;
 
+pub use governance::origins::pallet_custom_origins;
+
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -308,4 +310,9 @@ mod runtime {
 
 	#[runtime::pallet_index(22)]
 	pub type Vesting = pallet_vesting;
+
+	// Custom governance origins (no calls, no storage): dispatch origins for the
+	// non-Root tech-referenda tracks, e.g. `FastUpgrade`.
+	#[runtime::pallet_index(23)]
+	pub type Origins = pallet_custom_origins;
 }

--- a/runtime/src/transaction_extensions.rs
+++ b/runtime/src/transaction_extensions.rs
@@ -533,6 +533,22 @@ impl<T: pallet_wormhole::Config + Send + Sync> WormholeProofRecorderExtension<T>
 		}
 	}
 
+	/// One worst-case walk of an `execute` inner call: decode/match up to
+	/// `MaxCallSize` bytes. Charged twice (`weight()` and `validate()`). The
+	/// inner call is already in the extrinsic, so this is compute only.
+	fn execute_call_walk_weight() -> Weight {
+		let max_call = u64::from(<Runtime as pallet_multisig::Config>::MaxCallSize::get());
+		Weight::from_parts(
+			Self::EVENT_SCAN_DECODE_REF_TIME_PS
+				.saturating_add(Self::EVENT_SCAN_DECODE_BYTE_REF_TIME_PS.saturating_mul(max_call)),
+			0,
+		)
+	}
+
+	fn is_multisig_execute(call: &RuntimeCall) -> bool {
+		matches!(call, RuntimeCall::Multisig(pallet_multisig::Call::execute { .. }))
+	}
+
 	/// Scan events and record transfer proofs for any transfers that occurred
 	/// since the given event count (to avoid re-processing previous events
 	/// within the same block).
@@ -656,10 +672,17 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 
 	fn weight(&self, call: &RuntimeCall) -> Weight {
 		let n = Self::count_transfers(call);
-		if n > 0 {
-			Self::per_transfer_weight().saturating_mul(n)
+		let proofs =
+			if n > 0 { Self::per_transfer_weight().saturating_mul(n) } else { Weight::zero() };
+		if Self::is_multisig_execute(call) {
+			// Always reserve two worst-case inner-call walks: `weight()` itself
+			// walks to size the proof reservation, and `validate()` walks to
+			// carry the count into `prepare`. A MaxCallSize no-transfer execute
+			// must not be free — the pallet can reject a non-signer after one
+			// `Multisigs` read, and that error path must not refund this work.
+			proofs.saturating_add(Self::execute_call_walk_weight().saturating_mul(2))
 		} else {
-			Weight::zero()
+			proofs
 		}
 	}
 
@@ -703,7 +726,9 @@ impl<T: pallet_wormhole::Config + Send + Sync + alloc::fmt::Debug> TransactionEx
 		// recorded, so the static per-transfer reservation is unspent. Returning it
 		// refunds both the fee (this extension precedes `ChargeTransactionPayment`
 		// in `TxExtension`, so payment sees the corrected weight) and block
-		// capacity (via the trailing `WeightReclaim`).
+		// capacity (via the trailing `WeightReclaim`). The execute inner-call-walk
+		// reservation is not returned: that work already ran in `weight()` /
+		// `validate()`, including on the non-signer reject path.
 		if result.is_err() {
 			return Ok(Self::per_transfer_weight().saturating_mul(charged_transfers));
 		}
@@ -1615,10 +1640,12 @@ mod tests {
 		assert_eq!(WormholeProofRecorderExtension::<Runtime>::count_transfers(&wrapped), 3);
 	}
 
-	/// A remark inner call records no proofs; a failed non-signer execute refunds
-	/// the (zero) transfer reservation.
+	/// A 10 KiB no-transfer inner call plus a non-signer execute used to
+	/// reserve zero extension weight, then refund that zero after the pallet
+	/// rejected on the `Multisigs` read. The two inner-call walks must stay
+	/// charged.
 	#[test]
-	fn multisig_execute_failed_non_signer_refunds_transfer_reservation() {
+	fn multisig_execute_failed_non_signer_keeps_call_walk_weight() {
 		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 
@@ -1637,6 +1664,8 @@ mod tests {
 				0,
 				"a remark inner call records no proofs"
 			);
+			let walk = WormholeProofRecorderExtension::<Runtime>::execute_call_walk_weight()
+				.saturating_mul(2);
 			let (info, post_info) = run_lifecycle_with_result(
 				&charlie(),
 				execute,
@@ -1654,11 +1683,11 @@ mod tests {
 					);
 				},
 			);
-			assert_eq!(info.extension_weight, Weight::zero());
+			assert_eq!(info.extension_weight, walk);
 			assert_eq!(
 				post_info.actual_weight,
 				Some(info.total_weight()),
-				"zero transfer reservation stays zero after a failed execute"
+				"failed execute must not refund the inner-call-walk reservation"
 			);
 		});
 	}
@@ -1697,10 +1726,14 @@ mod tests {
 			});
 
 			assert_eq!(Wormhole::transfer_count(&charlie()), 1);
+			let walk = WormholeProofRecorderExtension::<Runtime>::execute_call_walk_weight()
+				.saturating_mul(2);
 			assert_eq!(
 				info.extension_weight,
-				WormholeProofRecorderExtension::<Runtime>::per_transfer_weight(),
-				"execute reserves one transfer"
+				walk.saturating_add(
+					WormholeProofRecorderExtension::<Runtime>::per_transfer_weight()
+				),
+				"execute reserves the inner-call walks plus the one transfer"
 			);
 			assert_eq!(
 				post_info.actual_weight,

--- a/runtime/tests/governance/fast_upgrade.rs
+++ b/runtime/tests/governance/fast_upgrade.rs
@@ -1,0 +1,252 @@
+//! Fast-upgrade track (track 1): an emergency runtime-upgrade lane modeled on
+//! Polkadot's Whitelisted Caller track. Proposals dispatch with the custom
+//! `FastUpgrade` origin, which only `system.authorize_upgrade` honors, and the
+//! 80%/80% constant curves require 8-of-10 ayes from the genesis collective.
+
+#[cfg(test)]
+mod tests {
+	use crate::common::TestCommons;
+	use codec::Encode;
+	use frame_support::{assert_ok, traits::Currency};
+	use pallet_referenda::TracksInfo;
+	use quantus_runtime::{
+		configs::TechReferendaInstance,
+		genesis_config_presets::governance_treasury_signer_seed,
+		governance::definitions::{TechCollectiveTracksInfo, FAST_UPGRADE_TRACK_ID},
+		pallet_custom_origins, Balances, OriginCaller, Preimage, Runtime, RuntimeCall,
+		RuntimeOrigin, System, TechCollective, TechReferenda,
+	};
+	use sp_runtime::{traits::Hash, MultiAddress, Perbill};
+
+	fn fast_upgrade_origin() -> OriginCaller {
+		OriginCaller::Origins(pallet_custom_origins::Origin::FastUpgrade)
+	}
+
+	fn upgrade_hash(seed: &[u8]) -> <Runtime as frame_system::Config>::Hash {
+		<Runtime as frame_system::Config>::Hashing::hash(seed)
+	}
+
+	/// Seed a 10-member collective (accounts 1..=10, mirroring the mainnet genesis
+	/// collective size) and fund the proposer for the preimage + submission +
+	/// decision deposits. Returns the proposer.
+	fn seed_ten_member_collective() -> sp_core::crypto::AccountId32 {
+		for i in 1..=10u8 {
+			assert_ok!(TechCollective::add_member(
+				RuntimeOrigin::root(),
+				MultiAddress::from(TestCommons::account_id(i))
+			));
+		}
+		let proposer = TestCommons::account_id(1);
+		Balances::make_free_balance_be(&proposer, governance_treasury_signer_seed(10));
+		proposer
+	}
+
+	/// Submit a referendum with the `FastUpgrade` proposal origin, place the
+	/// decision deposit, and return its index.
+	fn submit_fast_track_referendum(
+		proposer: &sp_core::crypto::AccountId32,
+		call: RuntimeCall,
+	) -> u32 {
+		let encoded = call.encode();
+		let preimage_hash = <Runtime as frame_system::Config>::Hashing::hash(&encoded);
+		assert_ok!(Preimage::note_preimage(
+			RuntimeOrigin::signed(proposer.clone()),
+			encoded.clone()
+		));
+		assert_ok!(TechReferenda::submit(
+			RuntimeOrigin::signed(proposer.clone()),
+			Box::new(fast_upgrade_origin()),
+			frame_support::traits::Bounded::Lookup {
+				hash: preimage_hash,
+				len: encoded.len() as u32,
+			},
+			frame_support::traits::schedule::DispatchTime::After(0u32)
+		));
+		let index = pallet_referenda::ReferendumCount::<Runtime, TechReferendaInstance>::get() - 1;
+		assert_ok!(TechReferenda::place_decision_deposit(
+			RuntimeOrigin::signed(proposer.clone()),
+			index
+		));
+		index
+	}
+
+	fn vote(member: u8, index: u32, aye: bool) {
+		assert_ok!(TechCollective::vote(
+			RuntimeOrigin::signed(TestCommons::account_id(member)),
+			index,
+			aye
+		));
+	}
+
+	fn run_out_the_track(track_id: u16) {
+		let info = <TechCollectiveTracksInfo as TracksInfo<_, _>>::info(track_id)
+			.expect("track must exist");
+		let target = System::block_number() +
+			TestCommons::calculate_governance_blocks(
+				info.prepare_period,
+				info.decision_period,
+				info.confirm_period,
+				info.min_enactment_period,
+			);
+		TestCommons::run_to_block(target);
+	}
+
+	fn approved(index: u32) -> bool {
+		matches!(
+			pallet_referenda::ReferendumInfoFor::<Runtime, TechReferendaInstance>::get(index),
+			Some(pallet_referenda::ReferendumInfo::Approved(..))
+		)
+	}
+
+	fn rejected(index: u32) -> bool {
+		matches!(
+			pallet_referenda::ReferendumInfoFor::<Runtime, TechReferendaInstance>::get(index),
+			Some(pallet_referenda::ReferendumInfo::Rejected(..))
+		)
+	}
+
+	fn authorized_upgrade() -> Option<frame_system::CodeUpgradeAuthorization<Runtime>> {
+		frame_system::Pallet::<Runtime>::authorized_upgrade()
+	}
+
+	/// Only the `FastUpgrade` custom origin routes to the fast track; Root keeps
+	/// the normal track and signed origins map to no track at all.
+	#[test]
+	fn fast_track_is_reachable_only_via_the_custom_origin() {
+		assert_eq!(
+			TechCollectiveTracksInfo::track_for(&OriginCaller::system(
+				frame_system::RawOrigin::Root
+			)),
+			Ok(0)
+		);
+		assert_eq!(
+			TechCollectiveTracksInfo::track_for(&fast_upgrade_origin()),
+			Ok(FAST_UPGRADE_TRACK_ID)
+		);
+		assert!(TechCollectiveTracksInfo::track_for(&OriginCaller::system(
+			frame_system::RawOrigin::Signed(TestCommons::account_id(1))
+		))
+		.is_err());
+	}
+
+	/// The curves are constant 80%/80%: with the 10-member genesis collective that
+	/// is exactly 8-of-10 ayes, at any point of the decision period.
+	#[test]
+	fn fast_track_curves_pin_eight_of_ten() {
+		let info = <TechCollectiveTracksInfo as TracksInfo<_, _>>::info(FAST_UPGRADE_TRACK_ID)
+			.expect("fast track must exist");
+		for x in [Perbill::zero(), Perbill::from_percent(50), Perbill::one()] {
+			assert_eq!(info.min_approval.threshold(x), Perbill::from_percent(80));
+			assert_eq!(info.min_support.threshold(x), Perbill::from_percent(80));
+		}
+	}
+
+	/// Happy path: 8 ayes / 2 nays authorizes the upgrade hash (support 8/10 = 80%
+	/// and approval 8/(8+2) = 80% both pass on the constant curves).
+	#[test]
+	fn eight_of_ten_authorizes_the_upgrade() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let proposer = seed_ten_member_collective();
+			let code_hash = upgrade_hash(b"fake runtime wasm");
+			let index = submit_fast_track_referendum(
+				&proposer,
+				RuntimeCall::System(frame_system::Call::authorize_upgrade { code_hash }),
+			);
+
+			for member in 1..=8u8 {
+				vote(member, index, true);
+			}
+			vote(9, index, false);
+			vote(10, index, false);
+
+			run_out_the_track(FAST_UPGRADE_TRACK_ID);
+
+			assert!(approved(index), "8-of-10 with 2 nays must approve on the fast track");
+			let authorized = authorized_upgrade()
+				.expect("approved fast-track referendum must authorize the upgrade");
+			assert_eq!(*authorized.code_hash(), code_hash);
+		});
+	}
+
+	/// 7 ayes / 3 nays fails both 80% thresholds: the referendum is rejected and
+	/// nothing is authorized.
+	#[test]
+	fn seven_of_ten_is_not_enough() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let proposer = seed_ten_member_collective();
+			let index = submit_fast_track_referendum(
+				&proposer,
+				RuntimeCall::System(frame_system::Call::authorize_upgrade {
+					code_hash: upgrade_hash(b"insufficient support"),
+				}),
+			);
+
+			for member in 1..=7u8 {
+				vote(member, index, true);
+			}
+			for member in 8..=10u8 {
+				vote(member, index, false);
+			}
+
+			run_out_the_track(FAST_UPGRADE_TRACK_ID);
+
+			assert!(rejected(index), "7-of-10 must not pass the fast track");
+			assert!(
+				authorized_upgrade().is_none(),
+				"a rejected referendum must not authorize anything"
+			);
+		});
+	}
+
+	/// The scoping property: the fast lane cannot do arbitrary Root business. A
+	/// Root-gated call (here `TechCollective::add_member`) proposed on the fast
+	/// track passes the vote but fails at dispatch with `BadOrigin`, because it is
+	/// dispatched with the `FastUpgrade` origin — not Root.
+	#[test]
+	fn fast_track_cannot_dispatch_arbitrary_root_calls() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let proposer = seed_ten_member_collective();
+			let candidate = TestCommons::account_id(42);
+			let index = submit_fast_track_referendum(
+				&proposer,
+				RuntimeCall::TechCollective(pallet_ranked_collective::Call::add_member {
+					who: MultiAddress::from(candidate.clone()),
+				}),
+			);
+
+			for member in 1..=10u8 {
+				vote(member, index, true);
+			}
+
+			run_out_the_track(FAST_UPGRADE_TRACK_ID);
+
+			assert!(approved(index), "the vote itself passes");
+			assert!(
+				!pallet_ranked_collective::Members::<Runtime>::contains_key(&candidate),
+				"a Root-gated call must not execute under the FastUpgrade origin"
+			);
+		});
+	}
+
+	/// Direct calls: Root still authorizes upgrades, plain signed accounts never do.
+	#[test]
+	fn direct_authorize_upgrade_origin_checks() {
+		TestCommons::new_fast_governance_test_ext().execute_with(|| {
+			let hash = upgrade_hash(b"root direct");
+			assert!(frame_system::Pallet::<Runtime>::authorize_upgrade(
+				RuntimeOrigin::signed(TestCommons::account_id(1)),
+				hash
+			)
+			.is_err());
+			assert!(authorized_upgrade().is_none());
+			assert_ok!(frame_system::Pallet::<Runtime>::authorize_upgrade(
+				RuntimeOrigin::root(),
+				hash
+			));
+			assert_eq!(
+				*authorized_upgrade().expect("root authorization must persist").code_hash(),
+				hash
+			);
+		});
+	}
+}

--- a/runtime/tests/governance/mod.rs
+++ b/runtime/tests/governance/mod.rs
@@ -1,3 +1,4 @@
+pub mod fast_upgrade;
 pub mod tech_collective;
 pub mod treasury;
 pub mod vesting;

--- a/runtime/tests/governance/tech_collective.rs
+++ b/runtime/tests/governance/tech_collective.rs
@@ -26,7 +26,6 @@ mod tests {
 		use quantus_runtime::configs::{
 			MaxActiveReferenda, MaxActiveReferendaPerAccount, MaxMemberCount,
 		};
-		use sp_core::Get;
 		let worst_case =
 			u64::from(MaxMemberCount::get()) * u64::from(MaxActiveReferendaPerAccount::get());
 		assert!(worst_case < u64::from(MaxActiveReferenda::get()));

--- a/scripts/genesis_generate_spec.sh
+++ b/scripts/genesis_generate_spec.sh
@@ -12,10 +12,12 @@ if [ -z "$1" ] || [ -z "$2" ]; then
   echo "Usage: $0 <release_tag> <profile>"
   echo "Example: $0 v0.1.1-nibbler-snack heisenberg"
   echo "Example: $0 v0.1.1-nibbler-snack planck"
+  echo "Example: $0 v0.1.1-nibbler-snack staging_mainnet"
   echo ""
   echo "Available profiles:"
   echo "  - heisenberg: Heisenberg testnet"
   echo "  - planck: Planck network"
+  echo "  - staging_mainnet: Mainnet dress rehearsal (see docs/STAGING_MAINNET_LAUNCH.md)"
   echo ""
   echo "Naming convention:"
   echo "  profile -> profile_live_spec (for execution)"
@@ -83,7 +85,10 @@ if [ ! -f "$QUANTUS_NODE_BIN" ]; then
 fi
 
 echo "🔧 Generating initial chain spec from '$CHAIN_ID'..."
-$QUANTUS_NODE_BIN build-spec --chain "$PROFILE_SPEC" --raw > "$OUTPUT_FILE"
+# --disable-default-bootnode: without it, a spec with no declared bootnodes gets a
+# throwaway /ip4/127.0.0.1 bootnode injected (matters for staging_mainnet, whose
+# bootnodes are added post-launch).
+$QUANTUS_NODE_BIN build-spec --chain "$PROFILE_SPEC" --raw --disable-default-bootnode > "$OUTPUT_FILE"
 
 if [ ! -s "$OUTPUT_FILE" ]; then
   echo "❌ Failed to generate chain spec. The output file is empty."


### PR DESCRIPTION
Ports the staging-mainnet work from `chain-private` PR #18 onto the public repo. This is the last piece of the chain-private move.

Stack: #675 (the merge) → #676 → #677 → this PR. It targets `n13/execute-walk-weight`, so review it after #677.

## What this does

**1. Fast-upgrade governance track.** A runtime WASM is hundreds of KiB, so it can never be a tech-referenda proposal: `MaxReferendaProposalSize` caps a `Lookup` preimage at 64 KiB. Upgrades have to go `authorize_upgrade(hash)` first, then the permissionless `apply_authorized_upgrade(wasm)`. Root can already do that, but only on the 1-day track, which is too slow for an emergency.

So there is now a second track:

- `pallet_custom_origins` at runtime index 23 contributes a single `Origin::FastUpgrade` to `RuntimeOrigin`. It has no calls, no storage, no events and no config items; its whole body is one `#[pallet::origin] enum`. A pallet is the only way to add a `RuntimeOrigin` variant, and a distinct non-Root origin is required because `TracksInfo::track_for` maps proposal origin to track, so two tracks cannot both be Root. Reusing `Signed(_)` is the impersonation hole `track_for` already rejects (#91247/#91270).
- Track 1 (`fast_upgrade`): 80%/80% constant curves, which is 8-of-10 with a ten-member collective, and 10-minute prepare, confirm and enactment windows. Track 0 keeps 61%/60% and its 1-day windows for everything else.
- `frame-system` gains `Config::AuthorizeUpgradeOrigin`, defaulting to Root. The runtime sets it to `Root or FastUpgrade`. `set_code` and `authorize_upgrade_without_checks` stay Root-only, so the short windows can publish an upgrade hash and nothing else.

`quantus-cli` already ships this flow (`tech_referenda` FastUpgrade submission, `system.apply_authorized_upgrade`), generated against a runtime that has the `Origins` pallet. The public runtime does not have it yet, so the CLI's upgrade path does not currently work against public builds.

**2. Cheaper governance.** Tech decision deposit 1000 → 10 UNIT, referendum submission deposit 100 → 10 UNIT, both scaled by `FEE_SCALE`. At the old numbers each launch signer would need over 1100 QUAN of liquid balance at genesis just to carry one referendum end to end. The maximum preimage deposit for a 64 KiB proposal is about 6.65 UNIT at the current scale, still under the 10 UNIT submission bond, so noted bytes stay collateralized after `unnote`.

**3. `staging_mainnet` genesis preset.** The mainnet dress rehearsal. Genesis is built by `mainnet_config_genesis`, the same function the eventual mainnet preset will call. The only difference is the treasury multisig nonce, 1 for staging and 0 for mainnet, which gives the two chains distinct treasury accounts and therefore distinct genesis hashes. Everything else is 1:1, so whatever is rehearsed is what launches.

- Treasury: 6-of-10 multisig of `MAINNET_TREASURY_SIGNERS_SS58`, which is also seeded as the tech collective.
- Signer endowments are derived, not written down. `governance_treasury_signer_seed` sums the treasury multisig bootstrap, the referenda submission and decision bonds, a maximum-size preimage deposit, and a small scaled fee headroom. It is deliberately the minimum that lets one treasurer bootstrap the multisig and carry one referendum end to end. Changing `FEE_SCALE` or any deposit re-derives it instead of stranding governance, and a genesis test pins every signer balance to the formula. Read the actual figures out of the generated spec's `balances` section.
- `mainnet_vesting_schedules` is a DUMMY scaffold behind `MAINNET_VESTING_FINALIZED = false`. While that flag is false only staging-mainnet builds; a mainnet preset panics. It carries stand-in team, backer and ecosystem entries plus 20 HD rehearsal accounts (`staging-0`..`staging-19`) so those keys can exercise claim.
- `utc_midnight_ms` replaces hand-computed epoch constants, so every vesting date is written as the date it documents. Tests pin all three.

**4. Docs and `--force-authoring`.** New runbooks `docs/STAGING_MAINNET_LAUNCH.md` and `docs/CHAINSPEC_CREATION.md`. The upgrade docs are rewritten for the authorize-then-apply flow. `--force-authoring` gets clearer help text: it is required to start mining on a new chain from a single validator, because at genesis there are no peers and the best block is always older than `--max-tip-age`. `--dev` already implies it.

## Runtime compatibility

The new origin variant appends at index 23, after `Vesting` at 22, so existing encoded `proposal_origin` values in referenda storage stay valid. No migration. No call indices move, so the call ABI is unchanged.

Runtime metadata does change, so hardware-wallet metadata needs regenerating for whatever release carries this.

No `spec_version` bump: `runtime/src/lib.rs` says not to increment it in feature PRs. No `transaction_version` bump either, since the signed extrinsic encoding is unchanged.

`pallet-referenda` stores each referendum's deposit amount, so the bond reduction does not affect refunds of already-placed deposits on live chains. Only new submissions see the new numbers.

## Differences from chain-private #18

- Dropped one rustfmt-only hunk in `node/src/command.rs` that rewrote `None =>` into `None => { … }`. It conflicted with the miner-flag block that landed publicly, carries no behaviour, and `cargo +nightly fmt --all -- --check` passes without it.
- Added pallet 23 to `docs/RUNTIME_SURFACE.md`. That file enumerates every pallet index in a table and gives each one a section; #18 added the pallet to the runtime but to neither list.

Everything else is the same change, split into four commits for review.

## Remaining before launch

1. Merge, cut a release tag, run `./scripts/genesis_generate_spec.sh <tag> staging_mainnet`.
2. Commit the JSON and the `"staging_mainnet"` `include_bytes!` arm in `load_spec`.
3. Boot the first server and add its bootnode. See `docs/STAGING_MAINNET_LAUNCH.md`.
