### PR TITLE
Bump qp-rusty-crystals dilithium/hdwallet to 4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7380,18 +7380,18 @@ checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2facf5349ce149731e6d21dc338f847c78e4a3a65e92e086e2cee244e7cf0457"
+checksum = "789877c169226a35d2ea686bbd9d506becc693f7bb0ee91acc03f74491e80c0f"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40119eb0c9a085722330c15ce17b71ca3aaecf5fa5a44891a47c1c9ec2c3109c"
+checksum = "51ec6c3db4055c217a503c45d0c101cf3c10d4fc1e562f0588aa55dda4f60a4d"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,8 +274,8 @@ sp-consensus-qpow = { path = "./primitives/consensus/qpow", default-features = f
 qp-plonky2 = { version = "1.5.5", default-features = false }
 qp-plonky2-verifier = { version = "1.5.5", default-features = false }
 qp-poseidon-core = { version = "3.1.0", default-features = false }
-qp-rusty-crystals-dilithium = { version = "4.1.0", default-features = false, features = ["ml-dsa-65", "ml-dsa-87"] }
-qp-rusty-crystals-hdwallet = { version = "4.1.0", features = ["ml-dsa-65"] }
+qp-rusty-crystals-dilithium = { version = "4.1.1", default-features = false, features = ["ml-dsa-65", "ml-dsa-87"] }
+qp-rusty-crystals-hdwallet = { version = "4.1.1", features = ["ml-dsa-65"] }
 qp-wormhole-aggregator = { version = "=4.3.0", default-features = false }
 qp-wormhole-circuit = { version = "=4.3.0", default-features = false }
 qp-wormhole-circuit-builder = { version = "=4.3.0", default-features = false }


### PR DESCRIPTION
Bumps `qp-rusty-crystals-dilithium` and `qp-rusty-crystals-hdwallet` from 4.1.0 to 4.1.1 (`Cargo.toml` + lockfile; no other crates touched).

dilithium 4.1.1 fixes a signature-forgery vulnerability: the malicious-key guard only rejected an all-zero `t1`, but any key whose coefficients keep `HighBits(c·2^D·t1)` at zero accepted forged signatures (`z = 0`, empty hint) for every message with no secret key. 4.1.1 rejects the whole degenerate family; honest keys are unaffected. hdwallet 4.1.1 is the companion release raising its dilithium floor to `^4.1.1`.

Cooldown-bypass-reason: dilithium 4.1.1 fixes a signature-forgery vulnerability (degenerate t1 public keys accepted forged signatures); first-party crates published by our own CI today, waiting 30 days would leave the vulnerable 4.1.0 pinned.

Note for the cooldown gate: apply the `dependency-cooldown-bypass` label (the label needs to be created in this repo first) — the check re-runs on labeling and reads the reason line above.
