### PR TITLE
Automate release for v0.11.0-rocket-fuel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7560,7 +7560,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.10.0"
+version = "0.11.0-rocket-fuel"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-runtime"
-version = "0.9.0-endless-sky"
+version = "0.11.0-rocket-fuel"
 dependencies = [
  "env_logger",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.10.0"
+version = "0.11.0-rocket-fuel"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "quantus-runtime"
 publish = false
 repository.workspace = true
-version = "0.9.0-endless-sky"
+version = "0.11.0-rocket-fuel"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("quantus-runtime"),
 	impl_name: alloc::borrow::Cow::Borrowed("quantus-runtime"),
 	authoring_version: 1,
-	spec_version: 147,
+	spec_version: 148,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
Automated version bump for release v0.11.0-rocket-fuel.

https://github.com/Quantus-Network/chain/actions/runs/33462307544

Triggered by workflow run: minor

Type: 