### PR TITLE
ci: drop Intel macOS from release builds

### DIFF
--- a/.github/workflows/quantus-hotfix-release.yml
+++ b/.github/workflows/quantus-hotfix-release.yml
@@ -69,8 +69,6 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-15-intel
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     steps:

--- a/.github/workflows/quantus-release.yml
+++ b/.github/workflows/quantus-release.yml
@@ -76,8 +76,6 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-15-intel
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     steps:

--- a/scripts/install-quantus-node.sh
+++ b/scripts/install-quantus-node.sh
@@ -45,7 +45,8 @@ case "$(uname -m)" in
         if [ "$OS" = "linux" ]; then
             TARGET_ARCH_NAME="x86_64-unknown-linux-gnu"
         elif [ "$OS" = "macos" ]; then
-            TARGET_ARCH_NAME="x86_64-apple-darwin"
+            echo "Intel macOS (x86_64) is not a release target. Use an Apple Silicon Mac or Linux, or compile the node locally: cargo build --release --locked --package quantus-node"
+            exit 1
         fi
         ;;
     arm64|aarch64)


### PR DESCRIPTION
v0.11.0-rocket-fuel died in **Setup macOS** on `macos-15-intel` (`openssl@3: no bottle available`) before cargo ran, which cancelled the other platforms. Intel Mac is no longer worth carrying as a release target.

- Remove `x86_64-apple-darwin` / `macos-15-intel` from the Release Tag & Publish and hotfix build matrices.
- `install-quantus-node.sh` tells Intel Mac users to use Apple Silicon, Linux, or compile locally, instead of downloading an asset that will not exist.

No other workflow changes. After merge, rocket-fuel is re-fired the same way v0.8.0 was: delete the tag, re-merge the release-proposal PR.