### PR TITLE
Automate release for v0.11.0-rocket-fuel

### DIFF
--- a/docs/release-notes/v0.11.0-rocket-fuel.md
+++ b/docs/release-notes/v0.11.0-rocket-fuel.md
@@ -1,0 +1,15 @@
+# v0.11.0-rocket-fuel
+
+Runtime upgrade — `spec_version` **148**.
+
+This re-publishes the `v0.11.0-rocket-fuel` release. The original release run
+([33463125437](https://github.com/Quantus-Network/chain/actions/runs/33463125437))
+created the tag but produced no GitHub release: the `x86_64-apple-darwin` leg
+failed in **Setup macOS** on the `macos-15-intel` runner (`openssl@3: no bottle
+available`) before cargo ran, and `fail-fast` cancelled the other platforms and
+skipped the publish job.
+
+Fixed in #688 by dropping Intel macOS from the release and hotfix build
+matrices, so the remaining matrix (Linux x86_64/aarch64, Apple Silicon,
+Windows) and the runtime wasm publish normally. Intel Mac users are pointed at
+a local build by `scripts/install-quantus-node.sh`.


### PR DESCRIPTION
## Purpose

Re-fire the **Release Tag & Publish** workflow for `v0.11.0-rocket-fuel`, which previously created a tag but no release (Intel macOS `openssl@3` bottle failure, now fixed in #688).

Merging this PR (it carries the `release-proposal` label and the version in its title) runs `create-tag` → re-creates the `v0.11.0-rocket-fuel` tag at current `main` (which no longer builds Intel macOS) → builds Linux x86_64/aarch64, Apple Silicon, Windows → srtool runtime wasm → publishes the GitHub release with binaries + wasm.

## Why the tag was deleted first

The stale tag pointed at `b038b406` (pre-fix, Intel Mac still in the matrix); reusing it would fail the same way. It has been deleted so `create-tag` recreates it at the fixed commit. `spec_version` stays **148** — this does not go through the Release Proposal workflow, so nothing re-increments it.

## Contents

Just release notes (`docs/release-notes/v0.11.0-rocket-fuel.md`) — the diff needed to open the PR; no code or version changes.