### PR TITLE
Automate release for v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7560,7 +7560,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-node"
-version = "0.11.0-rocket-fuel"
+version = "0.11.1"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-node"
 publish = false
 repository.workspace = true
-version = "0.11.0-rocket-fuel"
+version = "0.11.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Automated version bump for release v0.11.1.

https://github.com/Quantus-Network/chain/actions/runs/33475188490

Triggered by workflow run: patch

Type: 